### PR TITLE
docs: require TDD evidence in PR governance

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,6 +23,12 @@
 - Not tested:
   - ...
 
+## TDD Evidence
+- Failing test added/updated first:
+- Implementation change that made it pass:
+- Refactor step (if any):
+- If not applicable, explain why:
+
 ## Risk
 - Regression risks and mitigations.
 

--- a/.github/workflows/pr_governance.yml
+++ b/.github/workflows/pr_governance.yml
@@ -113,6 +113,22 @@ jobs:
               }
             }
 
+            const hasTddSection = /^##\s+TDD Evidence/m.test(body);
+            if (!hasTddSection) {
+              errors.push("PR description must include a `## TDD Evidence` section.");
+            } else {
+              const tddMatch = body.match(/##\s+TDD Evidence\s*[\r\n]+([\s\S]*?)(?=\n##\s+|$)/i);
+              const tddBody = tddMatch ? tddMatch[1].trim() : "";
+              if (!tddBody || /^[-*\s`:.]*$/i.test(tddBody)) {
+                errors.push("`## TDD Evidence` section is empty.");
+              }
+              const hasMeaningfulTddText =
+                /(failing test|red|green|refactor|not applicable|docs-only|workflow-only|metadata-only)/i.test(tddBody);
+              if (!hasMeaningfulTddText) {
+                errors.push("`## TDD Evidence` must include concrete TDD steps or a clear non-applicable reason.");
+              }
+            }
+
             if (errors.length > 0) {
               core.setFailed(errors.map((e) => `- ${e}`).join("\n"));
             } else {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,8 @@ You do not need to ask for permission nor an assignment.
 - Use ticket-based PR titles: `[R123] short imperative summary`
 - Fill out all required sections in the PR template.
 - Include verification evidence and risk/rollback notes.
+- Use TDD for behavior changes: write/adjust a failing test first, implement, then refactor.
+- Include a `TDD Evidence` section in PR descriptions (or state why TDD is not applicable).
 - For `P0` or `T3` changes, include `breaking-change` and `rollback-tested` labels.
 - For user-facing changes, include a concrete Release Notes section.
 
@@ -28,6 +30,7 @@ See governance docs:
 - [`docs/governance/release-notes-policy.md`](docs/governance/release-notes-policy.md)
 - [`docs/governance/rollback-drills.md`](docs/governance/rollback-drills.md)
 - [`docs/governance/slo-policy.md`](docs/governance/slo-policy.md)
+- [`docs/governance/tdd-policy.md`](docs/governance/tdd-policy.md)
 - ADRs: [`docs/adr/`](docs/adr/)
 
 ## Prerequisites

--- a/docs/governance/tdd-policy.md
+++ b/docs/governance/tdd-policy.md
@@ -1,0 +1,24 @@
+# TDD Policy
+
+## Objective
+Use test-driven development to reduce regressions and improve change confidence.
+
+## Default Rule
+- For behavior changes, follow Red -> Green -> Refactor.
+
+## Required PR Evidence
+- PR descriptions must include a `TDD Evidence` section covering:
+  - Which failing test was added/updated first.
+  - Which implementation change made it pass.
+  - Any follow-up refactor done while tests stayed green.
+
+## Allowed Exceptions
+- Docs-only changes.
+- Pure CI/workflow metadata changes.
+- Non-behavior refactors with no runtime effect.
+
+For exceptions, state explicit reason in `TDD Evidence` (for example: `Not applicable (docs-only change)`).
+
+## Review Guidance
+- Reviewers should verify tests actually fail without the implementation change.
+- Reviewers should reject PRs that claim TDD but provide no concrete test evidence.


### PR DESCRIPTION
## Summary
Add explicit TDD governance requirements and enforce `TDD Evidence` in PR descriptions.

## Changes
- Add new governance doc: `docs/governance/tdd-policy.md`
- Update PR template with `## TDD Evidence`
- Update PR governance workflow to require non-empty, meaningful `TDD Evidence`

## Scope
- Governance/docs/workflow validation only.
- No runtime app behavior changes.

## Testing
- Verified workflow script contains `TDD Evidence` checks.
- Verified PR template includes `## TDD Evidence` section.

## Notes
- Agent-workflow local-only preferences were respected: no tracked changes to `docs/governance/agent-workflow.md` in this PR.
