### PR TITLE
chore: add agent config files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,9 @@ local.properties
 
 # macOS specific files
 .DS_Store
+
+# AI Agent configuration files (environment-specific)
+# Copy from docs/agent-templates/ for AI-assisted development
+AGENTS.md
+CLAUDE.md
+GEMINI.md

--- a/docs/agent-templates/AGENTS.md
+++ b/docs/agent-templates/AGENTS.md
@@ -1,0 +1,35 @@
+# Local Agent Rules (Repo Scope)
+
+These rules apply to all agent work in this folder.
+
+## Required Process
+1. Choose exactly one ticket before editing code.
+2. Create/use a dedicated branch: `codex/<ticket-id>-<slug>`.
+3. Follow the workflow in `.local/LLM_DELIVERY_PLAYBOOK.md`.
+4. Implement only in-ticket scope (no unrelated refactors).
+5. Run verification appropriate to the ticket risk tier.
+6. Perform self-review before commit.
+7. Commit with ticket prefix: `<ticket-id>: <summary>`.
+8. Open/update PR with compliant title and fully updated description.
+9. Update the local sprint board notes after work.
+
+## Hard Stops
+- If ticket ID, acceptance criteria, or dependencies are unclear: stop and clarify.
+- If unexpected repo changes appear: stop and report before continuing.
+- If verification cannot be run: document exactly what was skipped and why.
+
+## Quality Gates
+- No new `runBlocking` in UI-thread callbacks.
+- No new top-level `GlobalScope` usage.
+- No multi-ticket commit unless explicitly planned.
+- PR title must include ticket ID and concise scope.
+- PR description must include scope, verification, risk, and rollback notes.
+
+## Priority Enforcement
+- `P0` fork-compliance tickets are blocking for any external fork distribution.
+- `P0`/`T3` tickets must include rollback notes.
+
+## Source of Truth
+- Playbook: `.local/LLM_DELIVERY_PLAYBOOK.md`
+- Sprint board: `.local/remediation-sprint-board.md`
+- Agent Guidelines: `CLAUDE.md`, `GEMINI.md`

--- a/docs/agent-templates/GEMINI.md
+++ b/docs/agent-templates/GEMINI.md
@@ -1,0 +1,155 @@
+# Gemini Code Guidelines (Repo Scope)
+
+These guidelines apply to all Gemini CLI work in this repository.
+
+## Required Process
+
+1. **Prime first:** Always load context by reading `.local/remediation-sprint-board.md` and `.local/LLM_DELIVERY_PLAYBOOK.md` before ANY work.
+2. **Choose exactly one ticket** before editing code.
+3. **Create/use dedicated branch:** `<agent-prefix>/<ticket-id>-<slug>` (default: `gemini/<ticket-id>-<slug>`).
+4. **Follow workflow:** `.local/LLM_DELIVERY_PLAYBOOK.md`.
+5. **Implement only in-ticket scope** (no unrelated refactors).
+6. **Run verification** appropriate to the ticket risk tier.
+7. **Perform self-review** before commit.
+8. **Commit with ticket prefix:** `<ticket-id>: <summary>`.
+9. **Open/update PR** with compliant title and fully updated description.
+10. **Update sprint board** notes after work.
+
+## Hard Stops
+
+- If ticket ID, acceptance criteria, or dependencies are unclear: **stop and clarify**.
+- If unexpected repo changes appear: **stop and report** before continuing.
+- If verification cannot be run: **document exactly** what was skipped and why.
+- If user requests skipping governance steps: **explain requirements** and follow them anyway.
+
+## Quality Gates
+
+### Code Quality
+- No new `runBlocking` in UI-thread callbacks.
+- No new top-level `GlobalScope` usage.
+- No multi-ticket commit unless explicitly planned.
+- Preserve existing error handling and safety checks.
+
+### Documentation Requirements
+- PR title must include ticket ID and concise scope: `[R##] imperative summary`.
+- PR description must include:
+  - Scope (done) and Non-goals (not done).
+  - Verification commands and outcomes.
+  - Risk assessment.
+  - Rollback plan (required for P0/T3).
+
+### Workflow Compliance
+- Sprint board updates mandatory after ticket completion.
+- Branch naming format enforced: `gemini/<ticket-id>-<slug>`.
+- One ticket per branch.
+
+## Priority Enforcement
+
+**P0 Fork Compliance Tickets (BLOCKING):**
+These MUST be completed before any external fork distribution:
+- R34: Update app display name and launcher icon to "rayniyomi".
+- R35: Change base `applicationId` from `xyz.jmir.tachiyomi.mi`.
+- R36: Change or disable app update checker endpoints.
+- R37: Set up fork-owned Firebase config (or explicitly disable).
+- R38: Set fork-owned ACRA endpoint (or explicitly disable).
+
+## Risk Tiers & Verification
+
+### T1 (Low Risk)
+- **Criteria:** Localized change, no data migration, no concurrency changes.
+- **Verification:** Targeted tests + lint/type checks (`./gradlew test`).
+
+### T2 (Medium Risk)
+- **Criteria:** Multi-file behavior change or API boundary change.
+- **Verification:** Targeted tests + affected module tests + manual sanity path.
+
+### T3 (High Risk)
+- **Criteria:** Concurrency/threading, storage/migration, startup/critical flows.
+- **Verification:** Targeted tests + broader suite + explicit regression checks + rollback validation.
+
+## High-Conflict Files (Single Owner)
+
+Only one agent/person should work on these files at a time:
+- `app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerViewModel.kt`
+- `app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt`
+- `app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt`
+- `app/src/main/java/eu/kanade/tachiyomi/ui/entries/anime/AnimeScreenModel.kt`
+- `app/src/main/java/eu/kanade/tachiyomi/ui/entries/manga/MangaScreenModel.kt`
+
+## Git Workflow
+
+### Branch Naming Convention
+**Format:** `gemini/<ticket-id>-<short-slug>`
+
+**Examples:**
+```
+gemini/r33-rename-program
+gemini/r35-applicationid-update
+```
+
+### Commit Format
+```
+<ticket-id>: <imperative summary>
+
+[Optional body with context]
+
+Co-Authored-By: Gemini CLI <gemini-cli@google.com>
+```
+
+### Pull Request Format
+```
+[R##] Imperative summary of change
+
+## Scope
+- What was done
+- What was changed
+
+## Verification
+```bash
+./gradlew test
+./gradlew lint
+```
+
+## Risk Assessment
+Risk tier: T2 (medium)
+
+## Rollback Plan
+To rollback: git revert <commit-hash>
+
+🤖 Generated with Gemini CLI
+```
+
+## Tool Preferences
+
+### Build & Test
+- **Build tool:** Gradle with Kotlin DSL.
+- **Run tests:** `./gradlew test`.
+- **Run lint:** `./gradlew lint`.
+- **Build APK:** `./gradlew assembleDebug`.
+
+### Code Quality
+- **Format:** Follow existing Kotlin style (EditorConfig configured).
+
+## Source of Truth
+- This file (`GEMINI.md`) - Gemini CLI-specific guidelines.
+- `AGENTS.md` - General agent rules.
+- `CLAUDE.md` - Reference for fellow agent Claude.
+- `.local/LLM_DELIVERY_PLAYBOOK.md` - Detailed workflow process.
+- `.local/remediation-sprint-board.md` - Current tickets and priorities.
+
+## Special Notes for Gemini CLI
+
+### Context Management (Priming)
+- Gemini CLI does not have a native `/aniyomi-prime` command. 
+- **Manual Priming:** At the start of every session, you MUST:
+  1. Read `.local/remediation-sprint-board.md` to identify the current ticket and project status.
+  2. Read `.local/LLM_DELIVERY_PLAYBOOK.md` to ensure workflow compliance.
+  3. Save a memory summary of the priming to persist across turns if necessary.
+
+### Tool Usage
+- Use `run_shell_command` with `cat` to read `.local` files if they are ignored by standard `read_file` filters.
+- Use `save_memory` to retain critical sprint context between tasks.
+
+---
+
+**Remember:** Maintain the standard of the "rayniyomi" fork. Follow all governance and safety protocols.


### PR DESCRIPTION
## Scope
- Add AGENTS.md, CLAUDE.md, GEMINI.md to .gitignore
- Move canonical versions to docs/agent-templates/
- Keeps repo root clean while preserving agent guidelines

## Non-goals
- No functional code changes
- No deletion of agent guidelines (just relocated)

## Verification
```bash
# Verify .gitignore updated
grep "AGENTS.md" .gitignore

# Verify templates exist
ls docs/agent-templates/
```
**Results:** Agent files now ignored in root, templates preserved

## Risk Assessment
Risk tier: T1 (low)
Areas affected: Repository structure only
Impact: Cleaner repo root, preserved agent guidelines

## Rollback Plan
To rollback: Revert commit and restore agent files to root
Impact: Agent files return to root directory

🤖 Generated with Claude Code