### PR TITLE
feat: change base applicationId to xyz.rayniyomi (R35)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,7 +17,7 @@ android {
     namespace = "eu.kanade.tachiyomi"
 
     defaultConfig {
-        applicationId = "xyz.jmir.tachiyomi.mi"
+        applicationId = "xyz.rayniyomi"
 
         versionCode = 131
         versionName = "0.18.1.2"


### PR DESCRIPTION
## Scope
- Changed base applicationId from "xyz.jmir.tachiyomi.mi" to "xyz.rayniyomi"
- Provider authorities auto-update via ${applicationId} placeholder:
  - ${applicationId}.provider
  - ${applicationId}.shizuku
- Build variants will use:
  - debug: xyz.rayniyomi.dev
  - preview: xyz.rayniyomi.debug
  - benchmark: xyz.rayniyomi.benchmark

Closes #44

## Non-goals
- No package name changes (eu.kanade.tachiyomi remains)
- No deep link scheme changes (tachiyomi://, aniyomi:// remain for compatibility)
- No class renames

## Verification
```bash
# Verify applicationId change
grep "applicationId" app/build.gradle.kts
# Expected: applicationId = "xyz.rayniyomi"

# Verify provider authorities use placeholder
grep "android:authorities" app/src/main/AndroidManifest.xml
# Expected: ${applicationId}.provider and ${applicationId}.shizuku
```

## Risk Assessment
Risk tier: T3 (HIGH)
Areas affected: Application identity, provider authorities, existing installations
Impact: **BREAKING CHANGE** - Existing app installations will NOT update; users must reinstall or data will be lost

## Rollback Plan
To rollback: git revert <commit-hash> and update back to xyz.jmir.tachiyomi.mi
Impact: Reverts to old applicationId; existing Rayniyomi installs will be orphaned

⚠️ **IMPORTANT**: This is a breaking change. Users with existing installations will need to:
1. Backup their library/data
2. Uninstall the old app
3. Install the new version
4. Restore from backup

🤖 Generated with Claude Code