### PR TITLE
ci(r49): enforce issue-closing references in PR descriptions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 - ID: R____
 - Priority: P0 | P1 | P2
 - Risk Tier: T1 | T2 | T3
-- GitHub Issue: Closes #____ (link to related issue)
+- GitHub Issue: Closes #____ (required; use `Closes`, `Fixes`, or `Resolves`)
 
 ## Objective
 - What problem does this PR solve?

--- a/.github/workflows/pr_governance.yml
+++ b/.github/workflows/pr_governance.yml
@@ -44,6 +44,14 @@ jobs:
               errors.push("PR description is too short. Add a brief summary and testing notes.");
             }
 
+            const closesIssuePattern =
+              /\b(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+((?:[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)?#\d+|https?:\/\/github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/issues\/\d+)\b/i;
+            if (!closesIssuePattern.test(normalizedBody)) {
+              errors.push(
+                "PR description must include an issue auto-close reference (for example: `Closes #123`).",
+              );
+            }
+
             if (errors.length > 0) {
               core.setFailed(errors.map((e) => `- ${e}`).join("\n"));
             } else {


### PR DESCRIPTION
## Ticket
- ID: R49
- Priority: P1
- Risk Tier: T1
- GitHub Issue: Closes #58

## Objective
- Enforce issue-closure discipline by requiring PR descriptions to include a valid auto-close reference.

## Scope
- Added PR governance check that fails if PR body lacks `Closes/Fixes/Resolves` issue reference.
- Supports `#123`, `owner/repo#123`, and full GitHub issue URL forms.
- Clarified PR template issue line to explicitly require close-keyword forms.

## Non-goals
- No changes to runtime app behavior.
- No changes to branch protection rules.

## Files Changed
- `.github/workflows/pr_governance.yml`
- `.github/pull_request_template.md`

## Verification
- Commands run:
  - `ruby -ryaml -e 'YAML.load_file(".github/workflows/pr_governance.yml"); puts "YAML OK"'`
  - `node -e '...regex sanity checks...'`
- Results:
  - Workflow YAML parsed successfully.
  - Regex matched valid close references and rejected non-closing references.
- Not tested:
  - Full GitHub Actions run in this local environment.

## Risk
- Low risk (T1). Scope is policy/metadata checks only.

## SLO Impact
- None.

## Rollback
- Revert commit `7e45c480a` to remove the new close-reference enforcement.

## Release Notes
- Internal governance update; no user-facing behavior change.
