### PR TITLE
refactor: make ReaderViewModel.setMangaReadingMode non-blocking (R03)

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -680,7 +680,7 @@ class ReaderViewModel @JvmOverloads constructor(
      */
     fun setMangaReadingMode(readingMode: ReadingMode) {
         val manga = manga ?: return
-        runBlocking(Dispatchers.IO) {
+        viewModelScope.launchIO {
             setMangaViewerFlags.awaitSetReadingMode(
                 manga.id,
                 readingMode.flagValue.toLong(),


### PR DESCRIPTION
## Summary
Converts `ReaderViewModel.setMangaReadingMode` from blocking to async execution.

## Changes
- Changed `runBlocking(Dispatchers.IO)` to `viewModelScope.launchIO`
- Follows pattern from `setMangaOrientationType` (line 722)
- No `withUIContext` wrapper needed (state updates are safe)

## Verification
- ✅ Code compiles successfully
- ✅ Follows reference pattern exactly
- ✅ T1 checklist review passed

## Related
- Closes #12 (R03)
- Phase A1 Conservative Test

🤖 Generated with Claude Code (Phase A1 Testing)