### PR TITLE
refactor: replace tracker search TODOs with graceful handling (R27)

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/kavita/Kavita.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/kavita/Kavita.kt
@@ -76,7 +76,8 @@ class Kavita(id: Long) : BaseTracker(id, "Kavita"), EnhancedMangaTracker, MangaT
     }
 
     override suspend fun searchManga(query: String): List<MangaTrackSearch> {
-        TODO("Not yet implemented: search")
+        // Search not supported for this tracker
+        return emptyList()
     }
 
     override suspend fun refresh(track: MangaTrack): MangaTrack {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/suwayomi/Suwayomi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/suwayomi/Suwayomi.kt
@@ -67,7 +67,8 @@ class Suwayomi(id: Long) : BaseTracker(id, "Suwayomi"), EnhancedMangaTracker, Ma
     }
 
     override suspend fun searchManga(query: String): List<MangaTrackSearch> {
-        TODO("Not yet implemented")
+        // Search not supported for this tracker
+        return emptyList()
     }
 
     override suspend fun refresh(track: MangaTrack): MangaTrack {


### PR DESCRIPTION
## Ticket
- ID: R27
- Priority: P2
- Risk Tier: T1
- GitHub Issue: Closes #36

## Objective
Replace TODO exceptions in Kavita and Suwayomi tracker search implementations with graceful empty list returns.

## Scope
- Modified Kavita.searchManga() to return empty list instead of throwing TODO
- Modified Suwayomi.searchManga() to return empty list instead of throwing TODO
- Added explanatory comments about unsupported search functionality

## Non-goals
- Does not implement actual search functionality
- Does not modify other tracker implementations

## Files Changed
- app/src/main/java/eu/kanade/tachiyomi/data/track/kavita/Kavita.kt (1 line changed)
- app/src/main/java/eu/kanade/tachiyomi/data/track/suwayomi/Suwayomi.kt (1 line changed)

## Verification
- Commands run:
  - `./gradlew assembleDebug`
- Results:
  - Compilation successful
  - No TODO exceptions remain in these files
  - Graceful handling of unsupported search
- Not tested:
  - Runtime behavior of search (covered by R29 tests)

## Risk
- Low risk: Changes crash-throwing code to graceful empty result
- Regression risk: Users who somehow triggered search will now see empty results instead of crash (improvement)
- Mitigation: Graceful failure is better UX than crash

## SLO Impact
- Improves crash-free rate (prevents TODO exceptions from reaching users)

## Rollback
- Revert commits to restore original TODO behavior

## Release Notes
- Fixed: Tracker search no longer crashes on unsupported trackers (Kavita, Suwayomi)

## Checklist
- [x] Naming conventions followed
- [x] Branch rebased on latest main and verification re-run

## Definition of Done (DoD)
- [x] Acceptance criteria met (graceful handling implemented)
- [x] Verification matrix completed (Risk Tier: T1)
- [x] Self-review completed
- [x] Rebased on latest `main` and revalidated
- [ ] Sprint board updated
- [x] Release notes drafted

🤖 Generated via Haiku validation experiment (Phase A2)

Co-Authored-By: Claude Haiku <noreply@anthropic.com>