### PR TITLE
test: add tests for tracker unsupported-search behavior (R29)

### DIFF
--- a/app/src/test/java/eu/kanade/tachiyomi/data/track/TrackerUnsupportedSearchTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/data/track/TrackerUnsupportedSearchTest.kt
@@ -1,0 +1,96 @@
+package eu.kanade.tachiyomi.data.track
+
+import eu.kanade.tachiyomi.data.track.kavita.Kavita
+import eu.kanade.tachiyomi.data.track.suwayomi.Suwayomi
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests verifying graceful handling of unsupported search in trackers (R27 changes).
+ *
+ * R27 replaced TODO() exceptions with empty list returns in searchManga()
+ * for Kavita and Suwayomi trackers where search is not supported.
+ */
+class TrackerUnsupportedSearchTest {
+
+    @Test
+    fun `Kavita searchManga returns empty list for unsupported search`() = runTest {
+        val tracker = Kavita(id = 1L)
+
+        val result = tracker.searchManga("test query")
+
+        result shouldBe emptyList()
+    }
+
+    @Test
+    fun `Kavita searchManga does not throw exception`() = runTest {
+        val tracker = Kavita(id = 1L)
+
+        // Should not throw TODO or any exception
+        val result = runCatching {
+            tracker.searchManga("any query")
+        }
+
+        result.isSuccess shouldBe true
+        result.getOrNull() shouldBe emptyList()
+    }
+
+    @Test
+    fun `Suwayomi searchManga returns empty list for unsupported search`() = runTest {
+        val tracker = Suwayomi(id = 2L)
+
+        val result = tracker.searchManga("test query")
+
+        result shouldBe emptyList()
+    }
+
+    @Test
+    fun `Suwayomi searchManga does not throw exception`() = runTest {
+        val tracker = Suwayomi(id = 2L)
+
+        // Should not throw TODO or any exception
+        val result = runCatching {
+            tracker.searchManga("any query")
+        }
+
+        result.isSuccess shouldBe true
+        result.getOrNull() shouldBe emptyList()
+    }
+
+    @Test
+    fun `Kavita searchManga with empty query returns empty list`() = runTest {
+        val tracker = Kavita(id = 1L)
+
+        val result = tracker.searchManga("")
+
+        result shouldBe emptyList()
+    }
+
+    @Test
+    fun `Suwayomi searchManga with empty query returns empty list`() = runTest {
+        val tracker = Suwayomi(id = 2L)
+
+        val result = tracker.searchManga("")
+
+        result shouldBe emptyList()
+    }
+
+    @Test
+    fun `Kavita searchManga with special characters returns empty list`() = runTest {
+        val tracker = Kavita(id = 1L)
+
+        val result = tracker.searchManga("!@#$%^&*()")
+
+        result shouldBe emptyList()
+    }
+
+    @Test
+    fun `Suwayomi searchManga with special characters returns empty list`() = runTest {
+        val tracker = Suwayomi(id = 2L)
+
+        val result = tracker.searchManga("!@#$%^&*()")
+
+        result shouldBe emptyList()
+    }
+}


### PR DESCRIPTION
## Ticket
- ID: R29
- Priority: P2
- Risk Tier: T1
- GitHub Issue: Closes #38

## Objective
Add tests validating the graceful handling of unsupported search functionality in Kavita and Suwayomi trackers.

## Scope
- Created TrackerUnsupportedSearchTest with 8 passing tests
- Tests validate empty list returns for unsupported search
- Includes Kavita.searchManga() implementation (from R27 dependency)
- Includes Suwayomi.searchManga() implementation (from R27 dependency)

## Non-goals
- Does not implement actual search functionality
- Does not test other tracker types

## Files Changed
- app/src/test/java/eu/kanade/tachiyomi/data/track/TrackerUnsupportedSearchTest.kt (96 lines added)
- app/src/main/java/eu/kanade/tachiyomi/data/track/kavita/Kavita.kt (1 line changed, from R27)
- app/src/main/java/eu/kanade/tachiyomi/data/track/suwayomi/Suwayomi.kt (1 line changed, from R27)

## Verification
- Commands run:
  - `./gradlew :app:testDebugUnitTest --tests "*TrackerUnsupportedSearchTest*"`
- Results:
  - 8/8 tests passing
  - Empty result validation confirmed
  - No exception throwing validated
  - No compilation errors
- Not tested:
  - Actual tracker API integration (unit tests only)

## Risk
- Low risk: Test code + graceful handling implementation
- Regression risk: Improves crash-free behavior (was throwing TODO exceptions)
- Mitigation: Empty results are better UX than crashes

## SLO Impact
- Improves crash-free rate (prevents TODO exceptions)

## Rollback
- Revert commits to restore original behavior

## Release Notes
- Fixed: Tracker search no longer crashes on unsupported trackers (Kavita, Suwayomi)

## Checklist
- [x] Naming conventions followed
- [x] Branch rebased on latest main and verification re-run

## Definition of Done (DoD)
- [x] Acceptance criteria met (8 tests + implementation)
- [x] Verification matrix completed (Risk Tier: T1)
- [x] Self-review completed
- [x] Rebased on latest `main` and revalidated
- [ ] Sprint board updated
- [x] Release notes drafted

🤖 Generated via Haiku validation experiment (Phase A2)
Note: Includes R27 implementation as dependency

Co-Authored-By: Claude Haiku <noreply@anthropic.com>