### PR TITLE
lint: add check for runBlocking in UI callbacks (R13)

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,56 @@
+# Scripts
+
+Development and maintenance scripts for the rayniyomi project.
+
+## Lint Checks
+
+### lint-runblocking.sh
+
+Detects `runBlocking` usage in UI callbacks where it can cause ANR (Application Not Responding).
+
+**Usage:**
+```bash
+./scripts/lint-runblocking.sh
+```
+
+**What it checks:**
+- Activity lifecycle methods (`onCreate`, `onResume`, `onStart`, `onPause`, `onStop`, `onDestroy`)
+- `BroadcastReceiver.onReceive` methods
+- ViewModel initialization and methods
+
+**Exit codes:**
+- `0`: No violations or only warnings
+- `1`: Errors found
+
+**Integration:**
+This check can be integrated into CI pipelines:
+```yaml
+# Example GitHub Actions step
+- name: Lint runBlocking usage
+  run: ./scripts/lint-runblocking.sh
+```
+
+**Recommended fixes:**
+When the lint check finds violations, consider these alternatives:
+- Use `viewModelScope.launch` or `lifecycleScope.launch` for coroutine execution
+- Use suspend functions and call them from existing coroutine contexts
+- Use `launch` with appropriate dispatcher (`Dispatchers.IO` for I/O operations)
+
+**Example:**
+```kotlin
+// ❌ Bad: Blocks the UI thread
+class MyViewModel : ViewModel() {
+    init {
+        val data = runBlocking { repository.getData() }
+    }
+}
+
+// ✅ Good: Non-blocking
+class MyViewModel : ViewModel() {
+    init {
+        viewModelScope.launch {
+            val data = repository.getData()
+        }
+    }
+}
+```

--- a/scripts/lint-runblocking.sh
+++ b/scripts/lint-runblocking.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+# Lint check for runBlocking usage in UI callbacks
+# This script detects runBlocking calls in:
+# - Activity lifecycle methods (onCreate, onResume, onStart, onPause, onStop, onDestroy)
+# - BroadcastReceiver.onReceive
+# - ViewModel initialization and methods
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Color codes for output
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+
+VIOLATIONS=0
+WARNINGS=0
+
+echo "🔍 Checking for runBlocking in UI callbacks..."
+echo ""
+
+# Function to check a file for runBlocking in specific contexts
+check_file() {
+    local file="$1"
+    local relative_path="${file#$PROJECT_ROOT/}"
+
+    # Check if file extends Activity or ViewModel
+    local is_activity=0
+    local is_viewmodel=0
+    local is_receiver=0
+
+    if grep -q "Activity\|AppCompatActivity\|FragmentActivity\|ComponentActivity" "$file"; then
+        is_activity=1
+    fi
+
+    if grep -q "ViewModel\|AndroidViewModel" "$file"; then
+        is_viewmodel=1
+    fi
+
+    if grep -q "BroadcastReceiver" "$file"; then
+        is_receiver=1
+    fi
+
+    # Skip if not a relevant file type
+    if [ $is_activity -eq 0 ] && [ $is_viewmodel -eq 0 ] && [ $is_receiver -eq 0 ]; then
+        return
+    fi
+
+    # Check for runBlocking usage
+    if grep -q "runBlocking" "$file"; then
+        # Get line numbers and context
+        local violations=$(grep -n "runBlocking" "$file")
+
+        # Check if in Activity lifecycle methods
+        if [ $is_activity -eq 1 ]; then
+            local in_lifecycle=$(grep -B 5 "runBlocking" "$file" | grep -E "override fun (onCreate|onResume|onStart|onPause|onStop|onDestroy)")
+            if [ ! -z "$in_lifecycle" ]; then
+                echo -e "${RED}ERROR:${NC} $relative_path"
+                echo "  Found runBlocking in Activity lifecycle method:"
+                echo "$violations" | while IFS= read -r line; do
+                    echo "    Line: $line"
+                done
+                echo ""
+                VIOLATIONS=$((VIOLATIONS + 1))
+                return
+            fi
+        fi
+
+        # Check if in ViewModel
+        if [ $is_viewmodel -eq 1 ]; then
+            echo -e "${RED}ERROR:${NC} $relative_path"
+            echo "  Found runBlocking in ViewModel:"
+            echo "$violations" | while IFS= read -r line; do
+                echo "    Line: $line"
+            done
+            echo ""
+            VIOLATIONS=$((VIOLATIONS + 1))
+            return
+        fi
+
+        # Check if in BroadcastReceiver.onReceive
+        if [ $is_receiver -eq 1 ]; then
+            local in_onreceive=$(grep -B 5 "runBlocking" "$file" | grep "override fun onReceive")
+            if [ ! -z "$in_onreceive" ]; then
+                echo -e "${RED}ERROR:${NC} $relative_path"
+                echo "  Found runBlocking in BroadcastReceiver.onReceive:"
+                echo "$violations" | while IFS= read -r line; do
+                    echo "    Line: $line"
+                done
+                echo ""
+                VIOLATIONS=$((VIOLATIONS + 1))
+                return
+            fi
+        fi
+
+        # If we found runBlocking but not in a critical context, warn
+        echo -e "${YELLOW}WARNING:${NC} $relative_path"
+        echo "  Found runBlocking (review context):"
+        echo "$violations" | while IFS= read -r line; do
+            echo "    Line: $line"
+        done
+        echo ""
+        WARNINGS=$((WARNINGS + 1))
+    fi
+}
+
+# Find all Kotlin files in app and data modules
+while IFS= read -r file; do
+    check_file "$file"
+done < <(find "$PROJECT_ROOT/app/src/main" "$PROJECT_ROOT/data/src/main" -name "*.kt" 2>/dev/null)
+
+# Summary
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+if [ $VIOLATIONS -eq 0 ] && [ $WARNINGS -eq 0 ]; then
+    echo -e "${GREEN}✓ No runBlocking violations found in UI callbacks${NC}"
+    exit 0
+elif [ $VIOLATIONS -eq 0 ]; then
+    echo -e "${YELLOW}⚠ Found $WARNINGS warnings (review recommended)${NC}"
+    exit 0
+else
+    echo -e "${RED}✗ Found $VIOLATIONS errors and $WARNINGS warnings${NC}"
+    echo ""
+    echo "runBlocking blocks the calling thread and can cause ANR if used in:"
+    echo "  - Activity lifecycle methods (onCreate, onResume, etc.)"
+    echo "  - BroadcastReceiver.onReceive"
+    echo "  - ViewModel initialization or methods"
+    echo ""
+    echo "Recommended fixes:"
+    echo "  - Use viewModelScope.launch or lifecycleScope.launch"
+    echo "  - Use suspend functions and call from coroutines"
+    echo "  - Use launch with appropriate dispatcher (Dispatchers.IO for I/O)"
+    exit 1
+fi


### PR DESCRIPTION
## Ticket
- ID: R13
- Priority: P2
- Risk Tier: T1
- GitHub Issue: Closes #22

## Objective
Add a lint script to detect dangerous runBlocking usage in UI components (Activity, BroadcastReceiver, ViewModel) to prevent main-thread blocking.

## Scope
- Created scripts/lint-runblocking.sh with pattern detection
- Detects runBlocking in Activity, BroadcastReceiver, ViewModel files
- Added scripts/README.md documenting usage and safe alternatives
- Provides clear guidance on async alternatives (async, launch, lifecycleScope)

## Non-goals
- Does not fix existing violations (3 detected: App.kt, NotificationReceiver.kt, ThemeManager.kt)
- Does not enforce as CI gate (ready for integration)

## Files Changed
- scripts/lint-runblocking.sh (136 lines added)
- scripts/README.md (56 lines added)

## Verification
- Commands run:
  - `./scripts/lint-runblocking.sh`
- Results:
  - Script executes successfully
  - Detected 3 existing violations (expected)
  - Exit code 1 when violations found (CI-friendly)
  - Clear output with file:line:context
- Not tested:
  - CI integration (ready for future setup)

## Risk
- Low risk: Lint script only, no production code changes
- Regression risk: None (detection tool only)

## SLO Impact
- None (tooling improvement)

## Rollback
- Remove script files if needed; no production impact

## Release Notes
- No user-facing changes (developer tooling improvement)

## Checklist
- [x] Naming conventions followed
- [x] Branch rebased on latest main and verification re-run

## Definition of Done (DoD)
- [x] Acceptance criteria met (lint script working)
- [x] Verification matrix completed (Risk Tier: T1)
- [x] Self-review completed
- [x] Rebased on latest `main` and revalidated
- [ ] Sprint board updated
- [x] Release notes drafted (no user-facing impact)

🤖 Generated via Haiku validation experiment (Phase A3)

Co-Authored-By: Claude Haiku <noreply@anthropic.com>