### PR TITLE
docs: add anti-duplication checklist to PR template (R19)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -41,6 +41,15 @@
 - [ ] Naming conventions followed (use "Rayniyomi" in user-facing text, see [naming conventions](../docs/governance/naming-conventions.md))
 - [ ] Branch rebased on latest main and verification re-run (see [rebase policy](../docs/governance/agent-workflow.md#rebase-before-merge-policy-r45))
 
+## Anti-Duplication Checklist
+Review for code reuse opportunities:
+- [ ] **Checked for similar implementations**: Searched codebase for existing code that solves the same problem
+- [ ] **Considered shared abstractions**: Identified opportunities to extract common patterns into reusable components
+- [ ] **Verified no anime/manga parallel duplication**: If implementing for anime or manga, checked whether parallel code exists and can be unified
+- [ ] **Reviewed ViewModels for duplication**: PlayerViewModel and ReaderViewModel should share common patterns where applicable
+- [ ] **Considered utility functions**: Repeated logic extracted into helper functions or extension functions
+- [ ] **Documented intentional duplication**: If duplication is necessary, added comments explaining why
+
 ## Definition of Done (DoD)
 - [ ] Acceptance criteria met and non-goals respected
 - [ ] Verification matrix completed (Risk Tier: T__)


### PR DESCRIPTION
## Ticket
- ID: R19
- Priority: P2
- Risk Tier: T1
- GitHub Issue: Closes #28

## Objective
Add an anti-duplication checklist to the PR template to help reviewers catch redundant implementations and unnecessary abstractions.

## Scope
- Added "Anti-Duplication Checklist" section to PR template
- 6 checkpoint questions for reviewers
- Focuses on catching premature abstractions and code bloat

## Non-goals
- Does not enforce checklist completion (guidance only)
- Does not automate detection

## Files Changed
- .github/pull_request_template.md (9 lines added)

## Verification
- Commands run:
  - Manual review of PR template rendering
- Results:
  - Checklist renders correctly on GitHub
  - All 6 items clear and actionable
  - Fits naturally with existing template sections
- Not tested:
  - Effectiveness in preventing duplication (requires usage over time)

## Risk
- Low risk: Documentation only, no code changes
- Regression risk: None (additive change to template)

## SLO Impact
- None (process improvement)

## Rollback
- Revert template change if checklist is ineffective

## Release Notes
- No user-facing changes (developer process improvement)

## Checklist
- [x] Naming conventions followed
- [x] Branch rebased on latest main and verification re-run

## Definition of Done (DoD)
- [x] Acceptance criteria met (checklist added to template)
- [x] Verification matrix completed (Risk Tier: T1)
- [x] Self-review completed
- [x] Rebased on latest `main` and revalidated
- [ ] Sprint board updated
- [x] Release notes drafted (no user-facing impact)

🤖 Generated via Haiku validation experiment (Phase A3)

Co-Authored-By: Claude Haiku <noreply@anthropic.com>