### PR TITLE
chore: update fork identity to rayniyomi (R40)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,15 +1,17 @@
-Looking to report an issue/bug or make a feature request? Please refer to the [README file](https://github.com/aniyomiorg/aniyomi#issues-feature-requests-and-contributing).
+Looking to report an issue/bug or make a feature request? Please refer to the [README file](https://github.com/ryacub/rayniyomi#readme).
 
 ---
 
-Thanks for your interest in contributing to Aniyomi!
+Thanks for your interest in contributing to Rayniyomi!
+
+**Note:** Rayniyomi is a fork of [Aniyomi](https://github.com/aniyomiorg/aniyomi). For contributing to the upstream project, see [Aniyomi's contributing guide](https://github.com/aniyomiorg/aniyomi/blob/main/CONTRIBUTING.md).
 
 
 # Code contributions
 
 Pull requests are welcome!
 
-If you're interested in taking on [an open issue](https://github.com/aniyomiorg/aniyomi/issues), please comment on it so others are aware.
+If you're interested in taking on [an open issue](https://github.com/ryacub/rayniyomi/issues), please comment on it so others are aware.
 You do not need to ask for permission nor an assignment.
 
 ## Pull Request policy
@@ -45,11 +47,12 @@ Before you start, please note that the ability to use following technologies is 
 
 ## Getting help
 
-- Join [the Discord server](https://discord.gg/F32UjdJZrR) for online help and to ask questions while developing.
+- For Rayniyomi-specific questions, open an issue in this repository.
+- For general development questions, you may also reference [Aniyomi's Discord server](https://discord.gg/F32UjdJZrR).
 
 # Translations
 
-Translations are done externally via Weblate. See [our website](https://aniyomi.org/docs/contribute#translation) for more details.
+Translations are inherited from upstream Aniyomi. For translation contributions, see [Aniyomi's translation guide](https://aniyomi.org/docs/contribute#translation).
 
 
 # Forks


### PR DESCRIPTION
## Ticket
- ID: R40
- Priority: P2
- Risk Tier: T1
- GitHub Issue: Closes #49

## Objective
Update CONTRIBUTING.md references from aniyomiorg/aniyomi to ryacub/rayniyomi while maintaining attribution to upstream project.

## Scope
- Updated repository URLs to ryacub/rayniyomi
- Updated contribution workflow references
- Maintained upstream attribution and credit
- Clarified fork relationship

## Non-goals
- Does not change other documentation files
- Does not modify code references

## Files Changed
- CONTRIBUTING.md (8 insertions, 5 deletions)

## Verification
- Commands run:
  - Manual review of CONTRIBUTING.md
- Results:
  - All URLs point to ryacub/rayniyomi
  - Upstream attribution maintained
  - Contribution workflow accurate for fork
  - Markdown renders correctly
- Not tested:
  - N/A (documentation only)

## Risk
- Low risk: Documentation only, no code changes
- Regression risk: None (improves accuracy)

## SLO Impact
- None (documentation improvement)

## Rollback
- Revert to upstream URLs if needed

## Release Notes
- No user-facing changes (contribution documentation update)

## Checklist
- [x] Naming conventions followed (uses "Rayniyomi" and fork URLs)
- [x] Branch rebased on latest main and verification re-run

## Definition of Done (DoD)
- [x] Acceptance criteria met (fork identity updated)
- [x] Verification matrix completed (Risk Tier: T1)
- [x] Self-review completed
- [x] Rebased on latest `main` and revalidated
- [ ] Sprint board updated
- [x] Release notes drafted (no user-facing impact)

🤖 Generated via Haiku validation experiment (Phase A3)

Co-Authored-By: Claude Haiku <noreply@anthropic.com>