### PR TITLE
docs: add code style guidelines (R30)

### DIFF
--- a/docs/governance/agent-workflow.md
+++ b/docs/governance/agent-workflow.md
@@ -26,6 +26,32 @@ This repository follows ticket-driven delivery with explicit verification and re
     - ❌ `feat: change applicationId (#35)` - FAILS validation
 - Body must include: Ticket, Objective, Scope, Non-goals, Files Changed, Verification, Risk, Rollback, Release Notes.
 
+## Code Style Guidelines
+
+### Avoid Fully Qualified Class Names
+**Always use imports instead of inline fully qualified class names.**
+
+Bad:
+```kotlin
+updateStrategy = eu.kanade.tachiyomi.source.model.UpdateStrategy.ALWAYS_UPDATE,
+```
+
+Good:
+```kotlin
+import eu.kanade.tachiyomi.source.model.UpdateStrategy
+updateStrategy = UpdateStrategy.ALWAYS_UPDATE,
+```
+
+**Why:** Improves readability, follows Kotlin conventions, avoids ktlint violations.
+
+### Pre-Submission Checks
+Run before pushing any PR:
+
+1. **Check for fully qualified names:** `grep -r "= [a-z]*\.[a-z]*\.[a-z]*\." app/src/ core/`
+2. **Format code:** `./gradlew spotlessApply`
+3. **Run tests:** `./gradlew :module:testDebugUnitTest`
+4. **Rebase on main:** `git fetch origin && git rebase origin/main`
+
 ## High-Risk Rules
 For `P0` or `T3` work:
 - Labels required: `breaking-change`, `rollback-tested`


### PR DESCRIPTION
## Ticket
- ID: R30 (informal - code quality improvement)
- Priority: P2
- Risk Tier: T1
- GitHub Issue: N/A (documentation only)

## Objective
Document code style patterns and pre-submission checks to prevent common issues found in PRs.

## Scope
- Added "Code Style Guidelines" section to agent-workflow.md
- Documents requirement to use imports instead of fully qualified class names
- Adds pre-submission checklist (import checks, spotless, tests, rebase)

## Non-goals
- Does not modify any code
- Does not change existing processes

## Files Changed
- docs/governance/agent-workflow.md

## Verification
- Documentation reviewed for clarity
- Patterns validated against PR 114, 115, 116 fixes

## Risk
- None (documentation only)

## Release Notes
- No user-facing changes

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>