### PR TITLE
revert: remove code style guidelines from repo docs

### DIFF
--- a/docs/governance/agent-workflow.md
+++ b/docs/governance/agent-workflow.md
@@ -26,32 +26,6 @@ This repository follows ticket-driven delivery with explicit verification and re
     - ❌ `feat: change applicationId (#35)` - FAILS validation
 - Body must include: Ticket, Objective, Scope, Non-goals, Files Changed, Verification, Risk, Rollback, Release Notes.
 
-## Code Style Guidelines
-
-### Avoid Fully Qualified Class Names
-**Always use imports instead of inline fully qualified class names.**
-
-Bad:
-```kotlin
-updateStrategy = eu.kanade.tachiyomi.source.model.UpdateStrategy.ALWAYS_UPDATE,
-```
-
-Good:
-```kotlin
-import eu.kanade.tachiyomi.source.model.UpdateStrategy
-updateStrategy = UpdateStrategy.ALWAYS_UPDATE,
-```
-
-**Why:** Improves readability, follows Kotlin conventions, avoids ktlint violations.
-
-### Pre-Submission Checks
-Run before pushing any PR:
-
-1. **Check for fully qualified names:** `grep -r "= [a-z]*\.[a-z]*\.[a-z]*\." app/src/ core/`
-2. **Format code:** `./gradlew spotlessApply`
-3. **Run tests:** `./gradlew :module:testDebugUnitTest`
-4. **Rebase on main:** `git fetch origin && git rebase origin/main`
-
 ## High-Risk Rules
 For `P0` or `T3` work:
 - Labels required: `breaking-change`, `rollback-tested`


### PR DESCRIPTION
## Ticket
- ID: Cleanup
- Priority: P2
- Risk Tier: T1
- GitHub Issue: N/A (cleanup)

## Objective
Remove code style guidelines from repository documentation as they belong in .local/ directory (LLM agent flow), not committed to repo.

## Scope
- Removed "Code Style Guidelines" section from agent-workflow.md
- Removed "Pre-Submission Checks" section
- 26 deletions

## Non-goals
- Does not affect actual code style enforcement (ktlint, spotless)
- Does not remove .local/ documentation

## Files Changed
- docs/governance/agent-workflow.md (-26 lines)

## Verification
- Manual review of file
- No code changes, documentation only

## Risk
- Low risk: Documentation removal only
- No impact on code or CI

## SLO Impact
- None

## Rollback
- Revert commit if needed

## Release Notes
- No user-facing changes (internal documentation cleanup)

## Checklist
- [x] Naming conventions followed
- [x] Branch rebased on latest main

## Definition of Done (DoD)
- [x] Documentation cleaned up
- [x] Ready for merge