### PR TITLE
refactor: make ReaderViewModel.setMangaReadingMode non-blocking (R03)

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -43,7 +43,6 @@ import eu.kanade.tachiyomi.util.lang.takeBytes
 import eu.kanade.tachiyomi.util.storage.DiskUtil
 import eu.kanade.tachiyomi.util.storage.cacheImageDir
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -680,7 +679,7 @@ class ReaderViewModel @JvmOverloads constructor(
      */
     fun setMangaReadingMode(readingMode: ReadingMode) {
         val manga = manga ?: return
-        runBlocking(Dispatchers.IO) {
+        viewModelScope.launchIO {
             setMangaViewerFlags.awaitSetReadingMode(
                 manga.id,
                 readingMode.flagValue.toLong(),


### PR DESCRIPTION
## Objective
Remove blocking UI thread call in `ReaderViewModel.setMangaReadingMode()` to prevent UI freezes when users switch reading modes (Left-to-Right, Right-to-Left, Webtoon, etc.) in the manga reader.

Closes #12

## Scope
Single-line conversion in `ReaderViewModel.kt`:
- Changed `runBlocking(Dispatchers.IO)` to `viewModelScope.launchIO` on line 683
- No signature changes, no caller updates needed
- Pattern matches existing `setMangaOrientationType()` implementation (line 722)

## Verification
- ✅ Build: `./gradlew assembleDebug` - PASS
- ✅ Spotless: `./gradlew spotlessApply` - PASS  
- ✅ Only 1 `runBlocking` remains in file (line 156, separate ticket R22)
- ✅ Clean branch: 1 commit ahead of main, no cross-ticket pollution

**Manual testing:**
1. Open manga chapter in reader
2. Open reader settings → change reading mode
3. Verify: No UI freeze, reader reloads immediately, mode persists

## Risk
**Risk Tier:** T1 (Low)

**Justification:**
- Single-line mechanical change following proven template
- No API changes, no caller modifications required
- Pattern established by R01, R02, and existing `setMangaOrientationType()` method
- All callers use fire-and-forget `(ReadingMode) -> Unit` callback pattern

**Mitigations:**
- Same behavior as working `setMangaOrientationType()` template
- `MutableStateFlow.update` provides atomic state updates
- `viewModelScope` cancels cleanly on ViewModel destruction (safer than `runBlocking`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)