### PR TITLE
fix: implement InMemoryPreferenceStore.getStringSet (R25)

### DIFF
--- a/core/common/src/main/java/tachiyomi/core/common/preference/InMemoryPreferenceStore.kt
+++ b/core/common/src/main/java/tachiyomi/core/common/preference/InMemoryPreferenceStore.kt
@@ -47,8 +47,11 @@ class InMemoryPreferenceStore(
         return if (data == null) default else InMemoryPreference(key, data, defaultValue)
     }
 
+    @Suppress("UNCHECKED_CAST")
     override fun getStringSet(key: String, defaultValue: Set<String>): Preference<Set<String>> {
-        TODO("Not yet implemented")
+        val default = InMemoryPreference(key, null, defaultValue)
+        val data: Set<String>? = preferences[key]?.get() as? Set<String>
+        return if (data == null) default else InMemoryPreference(key, data, defaultValue)
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/core/common/src/test/java/tachiyomi/core/common/preference/InMemoryPreferenceStoreTest.kt
+++ b/core/common/src/test/java/tachiyomi/core/common/preference/InMemoryPreferenceStoreTest.kt
@@ -92,6 +92,23 @@ class InMemoryPreferenceStoreTest {
         pref.get() shouldBe true
     }
 
+    @Test
+    fun `getStringSet returns default when preference not set`() {
+        val store = InMemoryPreferenceStore()
+        val pref = store.getStringSet("test_key", setOf("default1", "default2"))
+
+        pref.get() shouldBe setOf("default1", "default2")
+    }
+
+    @Test
+    fun `getStringSet returns stored value after set`() {
+        val store = InMemoryPreferenceStore()
+        val pref = store.getStringSet("test_key", setOf("default1", "default2"))
+
+        pref.set(setOf("new1", "new2", "new3"))
+        pref.get() shouldBe setOf("new1", "new2", "new3")
+    }
+
     // isSet behavior
 
     @Test
@@ -188,6 +205,14 @@ class InMemoryPreferenceStoreTest {
         pref.defaultValue() shouldBe true
     }
 
+    @Test
+    fun `defaultValue returns correct default for StringSet`() {
+        val store = InMemoryPreferenceStore()
+        val pref = store.getStringSet("test_key", setOf("a", "b", "c"))
+
+        pref.defaultValue() shouldBe setOf("a", "b", "c")
+    }
+
     // Initial preferences
 
     @Test
@@ -203,6 +228,19 @@ class InMemoryPreferenceStoreTest {
 
         pref1.get() shouldBe "value1"
         pref2.get() shouldBe 42L
+    }
+
+    @Test
+    fun `constructor with initial StringSet preferences works`() {
+        val initialPrefs = sequenceOf(
+            InMemoryPreferenceStore.InMemoryPreference<Set<String>>("key_set", setOf("a", "b"), emptySet()),
+        )
+        val store = InMemoryPreferenceStore(initialPrefs)
+
+        val pref = store.getStringSet("key_set", emptySet())
+
+        pref.get() shouldBe setOf("a", "b")
+        pref.isSet() shouldBe true
     }
 
     @Test


### PR DESCRIPTION
## Objective

Implement the missing `getStringSet` method in InMemoryPreferenceStore to complete the PreferenceStore API implementation.

## Scope

**Files changed:**
- `core/common/src/main/java/tachiyomi/core/common/preference/InMemoryPreferenceStore.kt` - Implemented getStringSet method
- `core/common/src/test/java/tachiyomi/core/common/preference/InMemoryPreferenceStoreTest.kt` - Added 4 comprehensive tests

**Implementation:**
- Replaced `TODO("Not yet implemented")` with proper implementation
- Follows the same pattern as existing getters (getString, getLong, getInt, getFloat, getBoolean)
- Pattern: Create default InMemoryPreference, try to cast from preferences map, return default if null

**Tests added:**
1. `getStringSet returns default when preference not set` - Ensures default behavior
2. `getStringSet returns stored value after set` - Validates get/set operations
3. `defaultValue returns correct default for StringSet` - Tests defaultValue() method
4. `constructor with initial StringSet preferences works` - Validates initial preferences

## Verification

### Build Verification
```bash
./gradlew :core:common:testDebugUnitTest --tests "InMemoryPreferenceStoreTest"  # ✅ 32/32 tests pass
./gradlew :core:common:spotlessApply                                             # ✅ Formatting applied
```

### Test Results
- ✅ All 32 tests pass (28 existing + 4 new StringSet tests)
- ✅ No compilation warnings for the implementation
- ✅ Follows existing test patterns

### Code Review
- ✅ Pattern matches getString, getLong, getInt, getFloat, getBoolean
- ✅ Proper null handling with `data ?: defaultValue()`
- ✅ Type safety with `@Suppress("UNCHECKED_CAST")`
- ✅ Tests cover default, set/get, defaultValue, and initial preferences

## Risk

**Risk Tier:** T1 (Low-risk code quality improvement)

**Blast Radius:** InMemoryPreferenceStore only
- Only affects test and preview code (not production)
- InMemoryPreferenceStore is primarily used for testing
- No existing usages of getStringSet (was TODO before)

**Why low risk:**
- Follows proven pattern from 5 other getter methods
- Comprehensive test coverage
- No production dependencies on this code path

## Rollback

If issues arise:
```bash
git revert 65827927c
git push ryacub main
```

Simple revert since this is a pure addition with no dependencies.

Fixes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)