### PR TITLE
fix: implement reactive changes() in InMemoryPreferenceStore (R26)

### DIFF
--- a/core/common/src/main/java/tachiyomi/core/common/preference/InMemoryPreferenceStore.kt
+++ b/core/common/src/main/java/tachiyomi/core/common/preference/InMemoryPreferenceStore.kt
@@ -2,10 +2,9 @@ package tachiyomi.core.common.preference
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.asStateFlow
 
 /**
  * Local-copy implementation of PreferenceStore mostly for test and preview purposes
@@ -72,6 +71,8 @@ class InMemoryPreferenceStore(
         private var data: T?,
         private val defaultValue: T,
     ) : Preference<T> {
+        private val flow = MutableStateFlow(data ?: defaultValue)
+
         override fun key(): String = key
 
         override fun get(): T = data ?: defaultValue()
@@ -80,18 +81,20 @@ class InMemoryPreferenceStore(
 
         override fun delete() {
             data = null
+            flow.value = defaultValue()
         }
 
         override fun defaultValue(): T = defaultValue
 
-        override fun changes(): Flow<T> = flow { data }
+        override fun changes(): Flow<T> = flow.asStateFlow()
 
         override fun stateIn(scope: CoroutineScope): StateFlow<T> {
-            return changes().stateIn(scope, SharingStarted.Eagerly, get())
+            return flow
         }
 
         override fun set(value: T) {
             data = value
+            flow.value = value
         }
     }
 }

--- a/core/common/src/test/java/tachiyomi/core/common/preference/InMemoryPreferenceStoreTest.kt
+++ b/core/common/src/test/java/tachiyomi/core/common/preference/InMemoryPreferenceStoreTest.kt
@@ -1,6 +1,8 @@
 package tachiyomi.core.common.preference
 
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
 
 class InMemoryPreferenceStoreTest {
@@ -309,5 +311,54 @@ class InMemoryPreferenceStoreTest {
         all.size shouldBe 1
         all.containsKey("initial_key") shouldBe true
         all.containsKey("runtime_key") shouldBe false
+    }
+
+    // changes() behavior
+
+    @Test
+    fun `changes emits initial value on first collection`() = runBlocking {
+        val store = InMemoryPreferenceStore()
+        val pref = store.getString("test_key", "default_value")
+
+        val firstValue = pref.changes().first()
+
+        firstValue shouldBe "default_value"
+    }
+
+    @Test
+    fun `changes emits updated value after set`() = runBlocking {
+        val store = InMemoryPreferenceStore()
+        val pref = store.getString("test_key", "default_value")
+
+        pref.set("new_value")
+        val emittedValue = pref.changes().first()
+
+        emittedValue shouldBe "new_value"
+    }
+
+    @Test
+    fun `changes emits default value after delete`() = runBlocking {
+        val store = InMemoryPreferenceStore()
+        val pref = store.getString("test_key", "default_value")
+
+        pref.set("new_value")
+        pref.delete()
+        val emittedValue = pref.changes().first()
+
+        emittedValue shouldBe "default_value"
+    }
+
+    @Test
+    fun `changes emits to multiple collectors`() = runBlocking {
+        val store = InMemoryPreferenceStore()
+        val pref = store.getInt("test_key", 0)
+
+        pref.set(42)
+
+        val value1 = pref.changes().first()
+        val value2 = pref.changes().first()
+
+        value1 shouldBe 42
+        value2 shouldBe 42
     }
 }


### PR DESCRIPTION
## Objective

Fix InMemoryPreferenceStore.changes() to properly emit values when preferences change, replacing the broken implementation that didn't emit anything.

## Scope

**Files changed:**
- `core/common/src/main/java/tachiyomi/core/common/preference/InMemoryPreferenceStore.kt` - Fixed changes() implementation
- `core/common/src/test/java/tachiyomi/core/common/preference/InMemoryPreferenceStoreTest.kt` - Added 4 tests for reactive behavior

**Problem:**
The original implementation was:
```kotlin
override fun changes(): Flow<T> = flow { data }
```

This doesn't emit anything - it just references `data` without calling `emit()`, resulting in a broken Flow that never emits values.

**Solution:**
- Added `MutableStateFlow` to track reactive state changes
- `changes()` returns the StateFlow via `asStateFlow()`
- `set()` updates both `data` and `flow.value`
- `delete()` updates both `data` and `flow.value` (emits default)
- `stateIn()` simplified to return the internal StateFlow

**Pattern:**
Follows AndroidPreferenceStore's reactive pattern (which uses SharedPreferences callbacks), but adapted for in-memory testing without external callbacks.

## Verification

### Build Verification
```bash
./gradlew :core:common:compileDebugUnitTestKotlin  # ✅ Compiles without errors
./gradlew :core:common:testDebugUnitTest            # ✅ All existing tests pass
./gradlew :core:common:spotlessApply                # ✅ Formatting applied
```

### Test Results
- ✅ All 28 existing tests pass
- ✅ Code compiles without errors or warnings
- ✅ Implementation follows Flow best practices

### Tests Added
1. `changes emits initial value on first collection` - Verifies Flow emits on first collection
2. `changes emits updated value after set` - Verifies reactivity on value changes
3. `changes emits default value after delete` - Verifies delete triggers emission
4. `changes emits to multiple collectors` - Verifies multiple collectors work correctly

## Risk

**Risk Tier:** T1 (Low-risk bug fix)

**Blast Radius:** InMemoryPreferenceStore only
- Only affects test and preview code (not production)
- Fixes broken functionality that wasn't working before
- Existing tests continue to pass

**Why low risk:**
- Pure bug fix - changes() wasn't working before
- Follows proven reactive pattern from AndroidPreferenceStore
- Existing functionality unchanged (get/set/delete/isSet all work the same)

## Rollback

If issues arise:
```bash
git revert f10cb22ce
git push ryacub main
```

Simple revert since this fixes previously broken functionality.

Fixes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)