### PR TITLE
refactor: extract shared DownloadQueueOperations for anime/manga downloaders (R14)

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloadStore.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloadStore.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.core.content.edit
 import eu.kanade.tachiyomi.animesource.online.AnimeHttpSource
 import eu.kanade.tachiyomi.data.download.anime.model.AnimeDownload
+import eu.kanade.tachiyomi.data.download.core.DownloadQueueStore
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
@@ -24,7 +25,7 @@ class AnimeDownloadStore(
     private val json: Json = Injekt.get(),
     private val getAnime: GetAnime = Injekt.get(),
     private val getEpisode: GetEpisode = Injekt.get(),
-) {
+) : DownloadQueueStore<AnimeDownload> {
 
     /**
      * Preference file where active downloads are stored.
@@ -43,7 +44,7 @@ class AnimeDownloadStore(
      *
      * @param downloads the list of downloads to add.
      */
-    fun addAll(downloads: List<AnimeDownload>) {
+    override fun addAll(downloads: List<AnimeDownload>) {
         preferences.edit {
             downloads.forEach { putString(getKey(it), serialize(it)) }
         }
@@ -54,7 +55,7 @@ class AnimeDownloadStore(
      *
      * @param download the download to remove.
      */
-    fun remove(download: AnimeDownload) {
+    override fun remove(download: AnimeDownload) {
         preferences.edit {
             remove(getKey(download))
         }
@@ -65,7 +66,7 @@ class AnimeDownloadStore(
      *
      * @param downloads the download to remove.
      */
-    fun removeAll(downloads: List<AnimeDownload>) {
+    override fun removeAll(downloads: List<AnimeDownload>) {
         preferences.edit {
             downloads.forEach { remove(getKey(it)) }
         }
@@ -74,7 +75,7 @@ class AnimeDownloadStore(
     /**
      * Removes all the downloads from the store.
      */
-    fun clear() {
+    override fun clear() {
         preferences.edit {
             clear()
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/core/DownloadQueueOperations.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/core/DownloadQueueOperations.kt
@@ -1,0 +1,82 @@
+package eu.kanade.tachiyomi.data.download.core
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+
+/**
+ * Generic queue mutation operations shared by anime and manga downloaders.
+ *
+ * Uses composition with function parameters to avoid forcing download models
+ * to implement a common interface (which would blast into 18+ files).
+ *
+ * @param D the download type (AnimeDownload or MangaDownload)
+ * @param _queueState the mutable state flow backing the download queue
+ * @param store the persistence store for queue operations
+ * @param itemId extracts the item ID (episode or chapter) from a download
+ * @param isActive returns true if the download is in DOWNLOADING or QUEUE state
+ * @param markQueued sets the download status to QUEUE
+ * @param markInactive sets the download status to NOT_DOWNLOADED if currently active
+ */
+class DownloadQueueOperations<D : Any>(
+    private val _queueState: MutableStateFlow<List<D>>,
+    private val store: DownloadQueueStore<D>,
+    private val itemId: (D) -> Long,
+    private val isActive: (D) -> Boolean,
+    private val markQueued: (D) -> Unit,
+    private val markInactive: (D) -> Unit,
+) {
+
+    fun addAll(downloads: List<D>) {
+        _queueState.update {
+            downloads.forEach { download -> markQueued(download) }
+            store.addAll(downloads)
+            it + downloads
+        }
+    }
+
+    fun remove(download: D) {
+        _queueState.update {
+            store.remove(download)
+            markInactive(download)
+            it - download
+        }
+    }
+
+    fun removeIf(predicate: (D) -> Boolean) {
+        _queueState.update { queue ->
+            val downloads = queue.filter { predicate(it) }
+            store.removeAll(downloads)
+            downloads.forEach { markInactive(it) }
+            queue - downloads.toSet()
+        }
+    }
+
+    fun internalClear() {
+        _queueState.update {
+            it.forEach { download -> markInactive(download) }
+            store.clear()
+            emptyList()
+        }
+    }
+
+    fun addToStart(downloads: List<D>) {
+        _queueState.update { currentQueue ->
+            downloads.forEach { download ->
+                markQueued(download)
+                store.addAll(listOf(download))
+            }
+            val existingIds = currentQueue.map { itemId(it) }.toSet()
+            val newDownloads = downloads.filterNot { itemId(it) in existingIds }
+            newDownloads + currentQueue
+        }
+    }
+
+    fun moveToFront(download: D) {
+        _queueState.update { currentQueue ->
+            val filtered = currentQueue.filterNot { itemId(it) == itemId(download) }
+            markQueued(download)
+            store.addAll(listOf(download))
+            listOf(download) + filtered
+        }
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/core/DownloadQueueStore.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/core/DownloadQueueStore.kt
@@ -1,0 +1,11 @@
+package eu.kanade.tachiyomi.data.download.core
+
+/**
+ * Interface for queue persistence operations shared by anime and manga download stores.
+ */
+interface DownloadQueueStore<D> {
+    fun addAll(downloads: List<D>)
+    fun remove(download: D)
+    fun removeAll(downloads: List<D>)
+    fun clear()
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/manga/MangaDownloadStore.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/manga/MangaDownloadStore.kt
@@ -2,6 +2,7 @@ package eu.kanade.tachiyomi.data.download.manga
 
 import android.content.Context
 import androidx.core.content.edit
+import eu.kanade.tachiyomi.data.download.core.DownloadQueueStore
 import eu.kanade.tachiyomi.data.download.manga.model.MangaDownload
 import eu.kanade.tachiyomi.source.online.HttpSource
 import kotlinx.coroutines.runBlocking
@@ -24,7 +25,7 @@ class MangaDownloadStore(
     private val json: Json = Injekt.get(),
     private val getManga: GetManga = Injekt.get(),
     private val getChapter: GetChapter = Injekt.get(),
-) {
+) : DownloadQueueStore<MangaDownload> {
 
     /**
      * Preference file where active downloads are stored.
@@ -43,7 +44,7 @@ class MangaDownloadStore(
      *
      * @param downloads the list of downloads to add.
      */
-    fun addAll(downloads: List<MangaDownload>) {
+    override fun addAll(downloads: List<MangaDownload>) {
         preferences.edit {
             downloads.forEach { putString(getKey(it), serialize(it)) }
         }
@@ -54,7 +55,7 @@ class MangaDownloadStore(
      *
      * @param download the download to remove.
      */
-    fun remove(download: MangaDownload) {
+    override fun remove(download: MangaDownload) {
         preferences.edit {
             remove(getKey(download))
         }
@@ -65,7 +66,7 @@ class MangaDownloadStore(
      *
      * @param downloads the download to remove.
      */
-    fun removeAll(downloads: List<MangaDownload>) {
+    override fun removeAll(downloads: List<MangaDownload>) {
         preferences.edit {
             downloads.forEach { remove(getKey(it)) }
         }
@@ -74,7 +75,7 @@ class MangaDownloadStore(
     /**
      * Removes all the downloads from the store.
      */
-    fun clear() {
+    override fun clear() {
         preferences.edit {
             clear()
         }


### PR DESCRIPTION
## Objective

Extract duplicated queue mutation logic (~65 lines each) from `AnimeDownloader` and `MangaDownloader` into a generic `DownloadQueueOperations<D>` class, reducing maintenance burden and drift risk.

## Scope

| File | Change |
|---|---|
| `core/DownloadQueueStore.kt` | **New** - Generic interface for queue persistence (4 methods) |
| `core/DownloadQueueOperations.kt` | **New** - 6 shared queue methods: `addAll`, `remove`, `removeIf`, `internalClear`, `addToStart`, `moveToFront` |
| `AnimeDownloadStore.kt` | Implement `DownloadQueueStore<AnimeDownload>` (add interface + `override`) |
| `MangaDownloadStore.kt` | Implement `DownloadQueueStore<MangaDownload>` (add interface + `override`) |
| `AnimeDownloader.kt` | Delegate queue ops to `queueOps` instance (-70 lines) |
| `MangaDownloader.kt` | Delegate queue ops to `queueOps` instance (-70 lines) |

**Out of scope:** Download model interface, DownloadStore full abstraction, DownloadCache, manager-level methods, UI layer.

**Behavioral notes:**
- `removeIf` now uses `.toSet()` in both paths (was anime-only; perf improvement for manga, no behavioral change)
- `updateQueue` stays in each downloader (anime has early `==` return; manga has different `wasRunning` ordering)
- All public method signatures unchanged (zero blast radius to callers)

## Verification

- [x] `./gradlew :app:spotlessApply` passes
- [x] `./gradlew :app:compileDebugKotlin` succeeds
- [x] `./gradlew :app:testDebugUnitTest` all tests pass
- [ ] Manual: queue manga chapters, verify download starts/pauses/clears correctly
- [ ] Manual: queue anime episodes, verify same behavior

## Risk

**Risk Tier: T1 (Low)**

Pure refactor with no behavioral changes to public APIs. Composition via lambdas keeps blast radius to 6 files. Both downloaders' `updateQueue` methods are preserved in-place with their specific sequencing differences.

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)