### PR TITLE
refactor: restore Anime/Manga wrapper classes with Injekt pattern (R15)

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/create/BackupCreator.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/create/BackupCreator.kt
@@ -6,12 +6,13 @@ import com.hippo.unifile.UniFile
 import eu.kanade.tachiyomi.BuildConfig
 import eu.kanade.tachiyomi.data.backup.BackupFileValidator
 import eu.kanade.tachiyomi.data.backup.create.creators.AnimeBackupCreator
+import eu.kanade.tachiyomi.data.backup.create.creators.AnimeCategoriesBackupCreator
 import eu.kanade.tachiyomi.data.backup.create.creators.AnimeExtensionRepoBackupCreator
 import eu.kanade.tachiyomi.data.backup.create.creators.AnimeSourcesBackupCreator
-import eu.kanade.tachiyomi.data.backup.create.creators.CategoriesBackupCreator
 import eu.kanade.tachiyomi.data.backup.create.creators.CustomButtonBackupCreator
 import eu.kanade.tachiyomi.data.backup.create.creators.ExtensionsBackupCreator
 import eu.kanade.tachiyomi.data.backup.create.creators.MangaBackupCreator
+import eu.kanade.tachiyomi.data.backup.create.creators.MangaCategoriesBackupCreator
 import eu.kanade.tachiyomi.data.backup.create.creators.MangaExtensionRepoBackupCreator
 import eu.kanade.tachiyomi.data.backup.create.creators.MangaSourcesBackupCreator
 import eu.kanade.tachiyomi.data.backup.create.creators.PreferenceBackupCreator
@@ -34,8 +35,6 @@ import okio.sink
 import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.backup.service.BackupPreferences
-import tachiyomi.domain.category.anime.interactor.GetAnimeCategories
-import tachiyomi.domain.category.manga.interactor.GetMangaCategories
 import tachiyomi.domain.entries.anime.interactor.GetAnimeFavorites
 import tachiyomi.domain.entries.anime.model.Anime
 import tachiyomi.domain.entries.anime.repository.AnimeRepository
@@ -62,12 +61,8 @@ class BackupCreator(
     private val mangaRepository: MangaRepository = Injekt.get(),
     private val animeRepository: AnimeRepository = Injekt.get(),
 
-    private val animeCategoriesBackupCreator: CategoriesBackupCreator = CategoriesBackupCreator(
-        getCategories = { Injekt.get<GetAnimeCategories>().await() },
-    ),
-    private val mangaCategoriesBackupCreator: CategoriesBackupCreator = CategoriesBackupCreator(
-        getCategories = { Injekt.get<GetMangaCategories>().await() },
-    ),
+    private val animeCategoriesBackupCreator: AnimeCategoriesBackupCreator = AnimeCategoriesBackupCreator(),
+    private val mangaCategoriesBackupCreator: MangaCategoriesBackupCreator = MangaCategoriesBackupCreator(),
     private val animeBackupCreator: AnimeBackupCreator = AnimeBackupCreator(),
     private val mangaBackupCreator: MangaBackupCreator = MangaBackupCreator(),
     private val preferenceBackupCreator: PreferenceBackupCreator = PreferenceBackupCreator(),

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/create/creators/AnimeCategoriesBackupCreator.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/create/creators/AnimeCategoriesBackupCreator.kt
@@ -1,0 +1,17 @@
+package eu.kanade.tachiyomi.data.backup.create.creators
+
+import eu.kanade.tachiyomi.data.backup.models.BackupCategory
+import tachiyomi.domain.category.anime.interactor.GetAnimeCategories
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+
+class AnimeCategoriesBackupCreator(
+    private val getAnimeCategories: GetAnimeCategories = Injekt.get(),
+) {
+
+    private val creator = CategoriesBackupCreator { getAnimeCategories.await() }
+
+    suspend operator fun invoke(): List<BackupCategory> {
+        return creator()
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/create/creators/MangaCategoriesBackupCreator.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/create/creators/MangaCategoriesBackupCreator.kt
@@ -1,0 +1,17 @@
+package eu.kanade.tachiyomi.data.backup.create.creators
+
+import eu.kanade.tachiyomi.data.backup.models.BackupCategory
+import tachiyomi.domain.category.manga.interactor.GetMangaCategories
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+
+class MangaCategoriesBackupCreator(
+    private val getMangaCategories: GetMangaCategories = Injekt.get(),
+) {
+
+    private val creator = CategoriesBackupCreator { getMangaCategories.await() }
+
+    suspend operator fun invoke(): List<BackupCategory> {
+        return creator()
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/BackupRestorer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/BackupRestorer.kt
@@ -12,11 +12,12 @@ import eu.kanade.tachiyomi.data.backup.models.BackupExtensionRepos
 import eu.kanade.tachiyomi.data.backup.models.BackupManga
 import eu.kanade.tachiyomi.data.backup.models.BackupPreference
 import eu.kanade.tachiyomi.data.backup.models.BackupSourcePreferences
+import eu.kanade.tachiyomi.data.backup.restore.restorers.AnimeCategoriesRestorer
 import eu.kanade.tachiyomi.data.backup.restore.restorers.AnimeExtensionRepoRestorer
 import eu.kanade.tachiyomi.data.backup.restore.restorers.AnimeRestorer
-import eu.kanade.tachiyomi.data.backup.restore.restorers.CategoriesRestorer
 import eu.kanade.tachiyomi.data.backup.restore.restorers.CustomButtonRestorer
 import eu.kanade.tachiyomi.data.backup.restore.restorers.ExtensionsRestorer
+import eu.kanade.tachiyomi.data.backup.restore.restorers.MangaCategoriesRestorer
 import eu.kanade.tachiyomi.data.backup.restore.restorers.MangaExtensionRepoRestorer
 import eu.kanade.tachiyomi.data.backup.restore.restorers.MangaRestorer
 import eu.kanade.tachiyomi.data.backup.restore.restorers.PreferenceRestorer
@@ -26,14 +27,8 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.launch
 import tachiyomi.core.common.i18n.stringResource
-import tachiyomi.data.handlers.anime.AnimeDatabaseHandler
-import tachiyomi.data.handlers.manga.MangaDatabaseHandler
-import tachiyomi.domain.category.anime.interactor.GetAnimeCategories
-import tachiyomi.domain.category.manga.interactor.GetMangaCategories
 import tachiyomi.i18n.MR
 import tachiyomi.i18n.aniyomi.AYMR
-import uy.kohesive.injekt.Injekt
-import uy.kohesive.injekt.api.get
 import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -44,24 +39,8 @@ class BackupRestorer(
     private val notifier: BackupNotifier,
     private val isSync: Boolean,
 
-    private val animeCategoriesRestorer: CategoriesRestorer = CategoriesRestorer(
-        getCategories = { Injekt.get<GetAnimeCategories>().await() },
-        insertCategory = { name, order, flags ->
-            Injekt.get<AnimeDatabaseHandler>().awaitOneExecutable {
-                categoriesQueries.insert(name, order, flags)
-                categoriesQueries.selectLastInsertedRowId()
-            }
-        },
-    ),
-    private val mangaCategoriesRestorer: CategoriesRestorer = CategoriesRestorer(
-        getCategories = { Injekt.get<GetMangaCategories>().await() },
-        insertCategory = { name, order, flags ->
-            Injekt.get<MangaDatabaseHandler>().awaitOneExecutable {
-                categoriesQueries.insert(name, order, flags)
-                categoriesQueries.selectLastInsertedRowId()
-            }
-        },
-    ),
+    private val animeCategoriesRestorer: AnimeCategoriesRestorer = AnimeCategoriesRestorer(),
+    private val mangaCategoriesRestorer: MangaCategoriesRestorer = MangaCategoriesRestorer(),
     private val preferenceRestorer: PreferenceRestorer = PreferenceRestorer(context),
     private val animeExtensionRepoRestorer: AnimeExtensionRepoRestorer = AnimeExtensionRepoRestorer(),
     private val mangaExtensionRepoRestorer: MangaExtensionRepoRestorer = MangaExtensionRepoRestorer(),

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/AnimeCategoriesRestorer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/AnimeCategoriesRestorer.kt
@@ -1,0 +1,27 @@
+package eu.kanade.tachiyomi.data.backup.restore.restorers
+
+import eu.kanade.tachiyomi.data.backup.models.BackupCategory
+import tachiyomi.data.handlers.anime.AnimeDatabaseHandler
+import tachiyomi.domain.category.anime.interactor.GetAnimeCategories
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+
+class AnimeCategoriesRestorer(
+    private val animeHandler: AnimeDatabaseHandler = Injekt.get(),
+    private val getAnimeCategories: GetAnimeCategories = Injekt.get(),
+) {
+
+    private val restorer = CategoriesRestorer(
+        getCategories = { getAnimeCategories.await() },
+        insertCategory = { name, order, flags ->
+            animeHandler.awaitOneExecutable {
+                categoriesQueries.insert(name, order, flags)
+                categoriesQueries.selectLastInsertedRowId()
+            }
+        },
+    )
+
+    suspend operator fun invoke(backupCategories: List<BackupCategory>) {
+        restorer(backupCategories)
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/MangaCategoriesRestorer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/restorers/MangaCategoriesRestorer.kt
@@ -1,0 +1,27 @@
+package eu.kanade.tachiyomi.data.backup.restore.restorers
+
+import eu.kanade.tachiyomi.data.backup.models.BackupCategory
+import tachiyomi.data.handlers.manga.MangaDatabaseHandler
+import tachiyomi.domain.category.manga.interactor.GetMangaCategories
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
+
+class MangaCategoriesRestorer(
+    private val mangaHandler: MangaDatabaseHandler = Injekt.get(),
+    private val getMangaCategories: GetMangaCategories = Injekt.get(),
+) {
+
+    private val restorer = CategoriesRestorer(
+        getCategories = { getMangaCategories.await() },
+        insertCategory = { name, order, flags ->
+            mangaHandler.awaitOneExecutable {
+                categoriesQueries.insert(name, order, flags)
+                categoriesQueries.selectLastInsertedRowId()
+            }
+        },
+    )
+
+    suspend operator fun invoke(backupCategories: List<BackupCategory>) {
+        restorer(backupCategories)
+    }
+}


### PR DESCRIPTION
## Objective

Follow-up to #168. Restore `AnimeCategoriesBackupCreator`, `MangaCategoriesBackupCreator`, `AnimeCategoriesRestorer`, and `MangaCategoriesRestorer` as thin wrapper classes that own their `Injekt.get()` dependencies, matching the codebase pattern where each class self-contains its DI wiring and orchestrators instantiate with `ClassName()`.

Closes #24

## Scope

- **Created:** `AnimeCategoriesBackupCreator` - thin wrapper delegating to `CategoriesBackupCreator`
- **Created:** `MangaCategoriesBackupCreator` - thin wrapper delegating to `CategoriesBackupCreator`
- **Created:** `AnimeCategoriesRestorer` - thin wrapper delegating to `CategoriesRestorer`
- **Created:** `MangaCategoriesRestorer` - thin wrapper delegating to `CategoriesRestorer`
- **Edited:** `BackupCreator` - reverted to `AnimeCategoriesBackupCreator()` / `MangaCategoriesBackupCreator()` pattern
- **Edited:** `BackupRestorer` - reverted to `AnimeCategoriesRestorer()` / `MangaCategoriesRestorer()` pattern

## Verification

- [x] `compileReleaseKotlin` passes
- [x] `spotlessApply` passes
- [x] Orchestrators now match codebase `ClassName()` instantiation pattern

## Risk

**Low.** Pure structural refactor — same delegation, just moved `Injekt.get()` wiring from orchestrators back into dedicated wrapper classes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)