### PR TITLE
fix: restore anime auto-download on library update (R51)

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/anime/AnimeLibraryUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/anime/AnimeLibraryUpdateJob.kt
@@ -303,6 +303,7 @@ class AnimeLibraryUpdateJob(private val context: Context, workerParams: WorkerPa
                                             val episodesToDownload = filterEpisodesForDownload.await(anime, newEpisodes)
 
                                             if (episodesToDownload.isNotEmpty()) {
+                                                downloadEpisodes(anime, episodesToDownload)
                                                 hasDownloads.set(true)
                                             }
 


### PR DESCRIPTION
## Objective
Restore the missing `downloadEpisodes()` call in `AnimeLibraryUpdateJob` that was accidentally removed during upstream commit `8937e92b5` ("Add option to skip downloading duplicate read chapters"). Without this fix, anime episodes are never queued for auto-download when the library is updated — the `hasDownloads` flag is set but nothing is actually downloaded.

## Scope
- **1 file changed, 1 line added:** `AnimeLibraryUpdateJob.kt`
- Added `downloadEpisodes(anime, episodesToDownload)` before `hasDownloads.set(true)` to mirror the manga-side `downloadChapters()` call in `MangaLibraryUpdateJob`

## Verification
- [x] `./gradlew :app:spotlessApply` passes
- [x] `./gradlew compileReleaseKotlin` passes
- [ ] Manual: enable auto-download for an anime source, trigger library update, confirm episodes are queued

## Risk
**Very Low.** Single-line addition restoring accidentally removed functionality. Mirrors the manga implementation exactly.

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)