### PR TITLE
fix: add manual-worker race guard to anime updater and align error URL (R58)

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/anime/AnimeLibraryUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/anime/AnimeLibraryUpdateJob.kt
@@ -106,6 +106,11 @@ class AnimeLibraryUpdateJob(private val context: Context, workerParams: WorkerPa
                     return Result.retry()
                 }
             }
+
+            // Find a running manual worker. If exists, try again later
+            if (context.workManager.isRunning(WORK_NAME_MANUAL)) {
+                return Result.retry()
+            }
         }
 
         try {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/manga/MangaLibraryUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/manga/MangaLibraryUpdateJob.kt
@@ -424,7 +424,7 @@ class MangaLibraryUpdateJob(private val context: Context, workerParams: WorkerPa
         private const val WORK_NAME_AUTO = "LibraryUpdate-auto"
         private const val WORK_NAME_MANUAL = "LibraryUpdate-manual"
 
-        private const val ERROR_LOG_HELP_URL = "https://aniyomi.org/help/guides/troubleshooting"
+        private const val ERROR_LOG_HELP_URL = "https://aniyomi.org/docs/guides/troubleshooting/"
         private const val MANGA_PER_SOURCE_QUEUE_WARNING_THRESHOLD = 60
 
         /**


### PR DESCRIPTION
## Objective

Add the manual-worker race-condition guard to `AnimeLibraryUpdateJob` that `MangaLibraryUpdateJob` already has, and align the error-log help URL between both files.

## Scope

- **AnimeLibraryUpdateJob.kt**: Add `isRunning(WORK_NAME_MANUAL)` check inside the `WORK_NAME_AUTO` block to prevent auto-updates from running concurrently with manual anime updates
- **MangaLibraryUpdateJob.kt**: Update `ERROR_LOG_HELP_URL` from `/help/guides/troubleshooting` to `/docs/guides/troubleshooting/` to match the anime counterpart

## Verification

- `compileReleaseKotlin` passes
- `spotlessApply` passes
- Race-condition guard present in both anime and manga updaters: `grep -n "isRunning(WORK_NAME_MANUAL)" app/src/main/java/eu/kanade/tachiyomi/data/library/*/`
- Error URLs match between both files: `grep -n "ERROR_LOG_HELP_URL" app/src/main/java/eu/kanade/tachiyomi/data/library/*/`

## Risk

**Low.** Two small changes that bring anime in line with manga. The race-condition guard is a direct copy of battle-tested manga code. The URL fix is cosmetic.

## Test plan
- [x] `compileReleaseKotlin` passes
- [x] `spotlessApply` passes
- [x] Guard confirmed in both files
- [x] URLs confirmed matching

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)