### PR TITLE
fix: prevent download cache race on cold start (R52)

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloadCache.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloadCache.kt
@@ -100,6 +100,14 @@ class AnimeDownloadCache(
     private val rootDownloadsDirMutex = Mutex()
     private var rootDownloadsDir = RootDirectory(storageManager.getDownloadsDirectory())
 
+    /**
+     * Whether the initial disk cache load has completed. Used to prevent
+     * [renewCache] from starting a redundant filesystem scan while the
+     * init block is still loading the persisted index.
+     */
+    @Volatile
+    private var isInitialized = false
+
     init {
         // Attempt to read cache file
         scope.launch {
@@ -117,6 +125,8 @@ class AnimeDownloadCache(
                     diskCacheFile.delete()
                 }
             }
+            isInitialized = true
+            notifyChanges()
         }
 
         storageManager.changes
@@ -327,8 +337,13 @@ class AnimeDownloadCache(
      * Renews the downloads cache.
      */
     private fun renewCache() {
-        // Avoid renewing cache if in the process nor too often
-        if (lastRenew + renewInterval >= System.currentTimeMillis() || renewalJob?.isActive == true) {
+        // Avoid renewing cache if in the process nor too often.
+        // Also skip if the init block hasn't finished loading the disk cache yet,
+        // as starting a filesystem scan would race with it and produce empty results.
+        if (lastRenew + renewInterval >= System.currentTimeMillis() ||
+            renewalJob?.isActive == true ||
+            !isInitialized
+        ) {
             return
         }
 


### PR DESCRIPTION
## Objective

Fix downloaded item detection returning false negatives after app restart due to a race condition between the disk cache initialization and filesystem scanning in both `AnimeDownloadCache` and `MangaDownloadCache`.

## Scope

- **`AnimeDownloadCache.kt`**: Add `isInitialized` volatile flag, gate `renewCache()` on it, emit change notification after init completes
- **`MangaDownloadCache.kt`**: Same changes for manga parity

### Root Cause

On cold start, the `init` block launches a coroutine to deserialize the persisted disk cache. Before it completes, `renewCache()` (called from any query method like `isChapterDownloaded`) would see `lastRenew == 0L` and `renewalJob == null`, triggering a full filesystem scan. This scan races with the init block, and queries arriving during this window read from an empty `rootDownloadsDir`, returning `false` for items that are actually downloaded.

### Fix

- Add `@Volatile isInitialized` flag (initially `false`)
- Set it to `true` after the init disk cache load completes (whether successful or not)
- Gate `renewCache()` on `!isInitialized` to prevent redundant filesystem scans during init
- Call `notifyChanges()` after init so UI subscribers update with the loaded cache state

## Verification

- `./gradlew :app:spotlessApply` -- passes
- `./gradlew compileReleaseKotlin` -- passes (no new warnings)
- No fully qualified class names introduced

## Risk

**Low.** The change only adds a gate condition to an existing code path. Worst case if the flag somehow never flips is that `renewCache()` never triggers (same as if the cache were fresh) -- the `skipCache` fallback in query methods still works for direct filesystem checks.

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)