### PR TITLE
perf: harden player loading for large lists (R61)

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/loader/HosterLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/loader/HosterLoader.kt
@@ -15,6 +15,9 @@ import kotlin.coroutines.cancellation.CancellationException
 
 class HosterLoader {
     companion object {
+        private const val HOSTER_LOAD_PARALLELISM = 4
+        private val hosterLoadDispatcher = Dispatchers.IO.limitedParallelism(HOSTER_LOAD_PARALLELISM)
+
         /**
          * Check for the best video from the current hosterState.
          *
@@ -79,7 +82,7 @@ class HosterLoader {
             val hosterStates = MutableList<HosterState>(hosterList.size) { HosterState.Idle("") }
 
             return try {
-                withContext(Dispatchers.IO) {
+                withContext(hosterLoadDispatcher) {
                     hosterList.mapIndexed { hosterIdx, hoster ->
                         async {
                             val hosterState = EpisodeLoader.loadHosterVideos(source, hoster)


### PR DESCRIPTION
## Objective
Harden player loading for very large episode/video lists to reduce blocking and unbounded hoster work.

## Scope
- move episode list init/filtering into PlayerEpisodeListManager and make init async
- skip download checks when no episode filters are active
- bound hoster loading concurrency and use iterative video fallback
- add tests for download-filter behavior

## Verification
- ./gradlew spotlessCheck
- ./gradlew :app:compileDebugKotlin
- ./gradlew :app:testDebugUnitTest --tests eu.kanade.tachiyomi.ui.player.PlayerEpisodeListManagerTest

## Risk
- Medium (T2): player loading, episode list filtering, and hoster/video selection flow

## Rollback
- Revert this PR to restore previous player loading behavior; no migrations

Closes #69