### PR TITLE
ci: add static guardrail for runBlocking in UI-layer code (R122)

### DIFF
--- a/buildSrc/src/main/kotlin/mihon.code.lint.gradle.kts
+++ b/buildSrc/src/main/kotlin/mihon.code.lint.gradle.kts
@@ -33,3 +33,53 @@ spotless {
         endWithNewline()
     }
 }
+
+tasks.register("checkBlockingCalls") {
+    group = "verification"
+    description = "Check for runBlocking usage in UI-layer code"
+
+    doLast {
+        val violations = mutableListOf<String>()
+        val uiPaths = listOf(
+            "eu/kanade/tachiyomi/ui",
+            "eu/kanade/presentation",
+        )
+
+        // Pre-existing violations baselined before guardrail was added.
+        // Remove entries as they are fixed in dedicated tickets.
+        val baseline = setOf(
+            "ReaderChapterListManager.kt",
+        )
+
+        val sourceDir = projectDir.resolve("src/main/java")
+        if (!sourceDir.exists()) return@doLast
+
+        sourceDir.walkTopDown()
+            .filter { it.extension == "kt" }
+            .filter { file -> uiPaths.any { file.path.contains(it) } }
+            .filter { file -> !file.path.contains("/test/") && !file.path.contains("/androidTest/") }
+            .filter { file -> file.name !in baseline }
+            .forEach { file ->
+                file.readLines().forEachIndexed { index, line ->
+                    val trimmed = line.trim()
+                    if (trimmed.contains("runBlocking") &&
+                        !trimmed.startsWith("import ") &&
+                        !trimmed.startsWith("//") &&
+                        !trimmed.startsWith("*") &&
+                        !trimmed.startsWith("/*")) {
+                        violations.add("${file.relativeTo(projectDir)}:${index + 1}: $trimmed")
+                    }
+                }
+            }
+
+        if (violations.isNotEmpty()) {
+            violations.forEach { logger.error("BLOCKING_CALL: $it") }
+            throw GradleException(
+                "Found ${violations.size} runBlocking usage(s) in UI-layer code. " +
+                "Use coroutine scopes instead (viewModelScope.launchIO, lifecycleScope)."
+            )
+        } else {
+            logger.lifecycle("checkBlockingCalls: No blocking calls found in UI-layer code ✓")
+        }
+    }
+}


### PR DESCRIPTION
## Ticket
- ID: R122
- Priority: P2
- Risk Tier: T1
- GitHub Issue: Closes #191

## Objective
Add CI guardrail to prevent runBlocking regressions in UI-layer code after R111, R115, R117, R118, R119 cleanup.

## Scope
- New `checkBlockingCalls` Gradle task in `mihon.code.lint.gradle.kts`
- Scans `eu/kanade/tachiyomi/ui/` and `eu/kanade/presentation/` for `runBlocking`
- Excludes imports, comments, test directories
- Baselines pre-existing violation in `ReaderChapterListManager.kt`

## Non-goals
- No fix for baselined violation (separate ticket)
- No broad lint policy overhaul

## Files Changed
- `buildSrc/src/main/kotlin/mihon.code.lint.gradle.kts` (+50 lines)

## Verification
- Commands run:
  - `./gradlew :app:checkBlockingCalls` - PASS (with baseline)
  - `./gradlew spotlessCheck` - PASS
- Results: Task correctly detects violations and passes with baseline
- Not tested: CI integration (requires merge to verify)

## Risk
- Low: Additive task only, no existing behavior changed
- Baseline ensures no false failures

## SLO Impact
- Prevents future runBlocking regressions in UI paths

## Rollback
- Remove the `checkBlockingCalls` task registration from lint config

## Release Notes
- No user-facing impact (CI tooling only)

## Checklist
- [x] Naming conventions followed
- [x] Branch rebased on latest main and verification re-run
- [x] No new `runBlocking` on UI/main thread paths

## Definition of Done (DoD)
- [x] Acceptance criteria met and non-goals respected
- [x] Verification matrix completed (Risk Tier: T1)
- [x] Self-review completed
- [x] Rebased on latest main and revalidated
- [x] Sprint board updated
- [x] Release notes drafted

🤖 Generated with [Claude Code](https://claude.com/claude-code)