### PR TITLE
fix: cancel MainScope in reader holders to prevent coroutine leaks (R121)

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
@@ -14,6 +14,7 @@ import eu.kanade.tachiyomi.ui.webview.WebViewActivity
 import eu.kanade.tachiyomi.widget.ViewPagerAdapter
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.supervisorScope
@@ -71,6 +72,7 @@ class PagerPageHolder(
         super.onDetachedFromWindow()
         loadJob?.cancel()
         loadJob = null
+        scope.cancel()
     }
 
     private fun initProgressIndicator() {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerTransitionHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerTransitionHolder.kt
@@ -18,6 +18,7 @@ import eu.kanade.tachiyomi.util.system.dpToPx
 import eu.kanade.tachiyomi.widget.ViewPagerAdapter
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import tachiyomi.core.common.i18n.stringResource
@@ -73,6 +74,7 @@ class PagerTransitionHolder(
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
         stateJob?.cancel()
+        scope.cancel()
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonPageHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonPageHolder.kt
@@ -19,6 +19,7 @@ import eu.kanade.tachiyomi.ui.webview.WebViewActivity
 import eu.kanade.tachiyomi.util.system.dpToPx
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.supervisorScope
@@ -70,7 +71,7 @@ class WebtoonPageHolder(
      */
     private var page: ReaderPage? = null
 
-    private val scope = MainScope()
+    private var scope = MainScope()
 
     /**
      * Job for loading the page.
@@ -89,6 +90,7 @@ class WebtoonPageHolder(
      * Binds the given [page] with this view holder, subscribing to its state.
      */
     fun bind(page: ReaderPage) {
+        scope = MainScope()
         this.page = page
         loadJob?.cancel()
         loadJob = scope.launch { loadPageAndProcessStatus() }
@@ -118,6 +120,7 @@ class WebtoonPageHolder(
         frame.recycle()
         progressIndicator.setProgress(0)
         progressContainer.isVisible = true
+        scope.cancel()
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonTransitionHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonTransitionHolder.kt
@@ -15,6 +15,7 @@ import eu.kanade.tachiyomi.ui.reader.viewer.ReaderTransitionView
 import eu.kanade.tachiyomi.util.system.dpToPx
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import tachiyomi.core.common.i18n.stringResource
@@ -28,7 +29,7 @@ class WebtoonTransitionHolder(
     viewer: WebtoonViewer,
 ) : WebtoonBaseHolder(layout, viewer) {
 
-    private val scope = MainScope()
+    private var scope = MainScope()
     private var stateJob: Job? = null
 
     private val transitionView = ReaderTransitionView(context)
@@ -64,6 +65,7 @@ class WebtoonTransitionHolder(
      * Binds the given [transition] with this view holder, subscribing to its state.
      */
     fun bind(transition: ChapterTransition) {
+        scope = MainScope()
         transitionView.bind(transition, viewer.downloadManager, viewer.activity.viewModel.manga)
 
         transition.to?.let { observeStatus(it, transition) }
@@ -74,6 +76,7 @@ class WebtoonTransitionHolder(
      */
     override fun recycle() {
         stateJob?.cancel()
+        scope.cancel()
     }
 
     /**


### PR DESCRIPTION
## Objective
Cancel `MainScope()` in all 4 reader holder classes to prevent coroutine scope leaks on recycle/detach.

## Summary
- Add `scope.cancel()` to all 4 reader holder classes that create `MainScope()` but never cancel it
- Pager holders (`PagerPageHolder`, `PagerTransitionHolder`): cancel scope in `onDetachedFromWindow()`
- Webtoon holders (`WebtoonPageHolder`, `WebtoonTransitionHolder`): cancel scope in `recycle()` and recreate in `bind()` since RecyclerView reuses holders

## Scope
- `PagerPageHolder.kt` — add `scope.cancel()` in `onDetachedFromWindow()`
- `PagerTransitionHolder.kt` — add `scope.cancel()` in `onDetachedFromWindow()`
- `WebtoonPageHolder.kt` — change `val` to `var`, cancel in `recycle()`, recreate in `bind()`
- `WebtoonTransitionHolder.kt` — change `val` to `var`, cancel in `recycle()`, recreate in `bind()`

## Verification
- [x] `./gradlew :app:compileDebugKotlin` passes
- [x] `./gradlew :app:spotlessApply` produces no changes
- [ ] Manual: Open reader in pager mode, navigate pages, exit — no crashes
- [ ] Manual: Open reader in webtoon mode, scroll through pages, exit — no crashes

## Risk
**Low.** Adds missing cleanup calls. No behavioral change to the reader UI — only ensures coroutine scopes are properly cancelled when views are detached or recycled.

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)