### PR TITLE
perf: add stable keys to library LazyList items (R132)

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/library/anime/AnimeLibraryComfortableGrid.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/anime/AnimeLibraryComfortableGrid.kt
@@ -4,8 +4,9 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.util.fastAny
 import eu.kanade.presentation.library.components.DownloadsBadge
 import eu.kanade.presentation.library.components.EntryComfortableGridItem
 import eu.kanade.presentation.library.components.LanguageBadge
@@ -28,6 +29,10 @@ internal fun AnimeLibraryComfortableGrid(
     searchQuery: String?,
     onGlobalSearchClicked: () -> Unit,
 ) {
+    val selectionIds = remember(selection) {
+        derivedStateOf { selection.map { it.id }.toSet() }
+    }
+
     LazyLibraryGrid(
         modifier = Modifier.fillMaxSize(),
         columns = columns,
@@ -37,11 +42,12 @@ internal fun AnimeLibraryComfortableGrid(
 
         items(
             items = items,
+            key = { it.libraryAnime.id },
             contentType = { "anime_library_comfortable_grid_item" },
         ) { libraryItem ->
             val anime = libraryItem.libraryAnime.anime
             EntryComfortableGridItem(
-                isSelected = selection.fastAny { it.id == libraryItem.libraryAnime.id },
+                isSelected = libraryItem.libraryAnime.id in selectionIds.value,
                 title = anime.title,
                 coverData = AnimeCover(
                     animeId = anime.id,

--- a/app/src/main/java/eu/kanade/presentation/library/anime/AnimeLibraryCompactGrid.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/anime/AnimeLibraryCompactGrid.kt
@@ -4,8 +4,9 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.util.fastAny
 import eu.kanade.presentation.library.components.DownloadsBadge
 import eu.kanade.presentation.library.components.EntryCompactGridItem
 import eu.kanade.presentation.library.components.LanguageBadge
@@ -29,6 +30,10 @@ fun AnimeLibraryCompactGrid(
     searchQuery: String?,
     onGlobalSearchClicked: () -> Unit,
 ) {
+    val selectionIds = remember(selection) {
+        derivedStateOf { selection.map { it.id }.toSet() }
+    }
+
     LazyLibraryGrid(
         modifier = Modifier.fillMaxSize(),
         columns = columns,
@@ -38,11 +43,12 @@ fun AnimeLibraryCompactGrid(
 
         items(
             items = items,
+            key = { it.libraryAnime.id },
             contentType = { "anime_library_compact_grid_item" },
         ) { libraryItem ->
             val anime = libraryItem.libraryAnime.anime
             EntryCompactGridItem(
-                isSelected = selection.fastAny { it.id == libraryItem.libraryAnime.id },
+                isSelected = libraryItem.libraryAnime.id in selectionIds.value,
                 title = anime.title.takeIf { showTitle },
                 coverData = AnimeCover(
                     animeId = anime.id,

--- a/app/src/main/java/eu/kanade/presentation/library/anime/AnimeLibraryList.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/anime/AnimeLibraryList.kt
@@ -5,9 +5,10 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.util.fastAny
 import eu.kanade.presentation.library.components.DownloadsBadge
 import eu.kanade.presentation.library.components.EntryListItem
 import eu.kanade.presentation.library.components.GlobalSearchItem
@@ -32,6 +33,10 @@ internal fun AnimeLibraryList(
     searchQuery: String?,
     onGlobalSearchClicked: () -> Unit,
 ) {
+    val selectionIds = remember(selection) {
+        derivedStateOf { selection.map { it.id }.toSet() }
+    }
+
     FastScrollLazyColumn(
         modifier = Modifier.fillMaxSize(),
         contentPadding = contentPadding + PaddingValues(vertical = 8.dp),
@@ -48,11 +53,12 @@ internal fun AnimeLibraryList(
 
         items(
             items = items,
+            key = { it.libraryAnime.id },
             contentType = { "anime_library_list_item" },
         ) { libraryItem ->
             val anime = libraryItem.libraryAnime.anime
             EntryListItem(
-                isSelected = selection.fastAny { it.id == libraryItem.libraryAnime.id },
+                isSelected = libraryItem.libraryAnime.id in selectionIds.value,
                 title = anime.title,
                 coverData = AnimeCover(
                     animeId = anime.id,

--- a/app/src/main/java/eu/kanade/presentation/library/manga/MangaLibraryComfortableGrid.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/manga/MangaLibraryComfortableGrid.kt
@@ -4,8 +4,9 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.util.fastAny
 import eu.kanade.presentation.library.components.DownloadsBadge
 import eu.kanade.presentation.library.components.EntryComfortableGridItem
 import eu.kanade.presentation.library.components.LanguageBadge
@@ -28,6 +29,10 @@ internal fun MangaLibraryComfortableGrid(
     searchQuery: String?,
     onGlobalSearchClicked: () -> Unit,
 ) {
+    val selectionIds = remember(selection) {
+        derivedStateOf { selection.map { it.id }.toSet() }
+    }
+
     LazyLibraryGrid(
         modifier = Modifier.fillMaxSize(),
         columns = columns,
@@ -37,11 +42,12 @@ internal fun MangaLibraryComfortableGrid(
 
         items(
             items = items,
+            key = { it.libraryManga.id },
             contentType = { "manga_library_comfortable_grid_item" },
         ) { libraryItem ->
             val manga = libraryItem.libraryManga.manga
             EntryComfortableGridItem(
-                isSelected = selection.fastAny { it.id == libraryItem.libraryManga.id },
+                isSelected = libraryItem.libraryManga.id in selectionIds.value,
                 title = manga.title,
                 coverData = MangaCover(
                     mangaId = manga.id,

--- a/app/src/main/java/eu/kanade/presentation/library/manga/MangaLibraryCompactGrid.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/manga/MangaLibraryCompactGrid.kt
@@ -4,8 +4,9 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.util.fastAny
 import eu.kanade.presentation.library.components.DownloadsBadge
 import eu.kanade.presentation.library.components.EntryCompactGridItem
 import eu.kanade.presentation.library.components.LanguageBadge
@@ -29,6 +30,10 @@ internal fun MangaLibraryCompactGrid(
     searchQuery: String?,
     onGlobalSearchClicked: () -> Unit,
 ) {
+    val selectionIds = remember(selection) {
+        derivedStateOf { selection.map { it.id }.toSet() }
+    }
+
     LazyLibraryGrid(
         modifier = Modifier.fillMaxSize(),
         columns = columns,
@@ -38,11 +43,12 @@ internal fun MangaLibraryCompactGrid(
 
         items(
             items = items,
+            key = { it.libraryManga.id },
             contentType = { "manga_library_compact_grid_item" },
         ) { libraryItem ->
             val manga = libraryItem.libraryManga.manga
             EntryCompactGridItem(
-                isSelected = selection.fastAny { it.id == libraryItem.libraryManga.id },
+                isSelected = libraryItem.libraryManga.id in selectionIds.value,
                 title = manga.title.takeIf { showTitle },
                 coverData = MangaCover(
                     mangaId = manga.id,

--- a/app/src/main/java/eu/kanade/presentation/library/manga/MangaLibraryList.kt
+++ b/app/src/main/java/eu/kanade/presentation/library/manga/MangaLibraryList.kt
@@ -5,9 +5,10 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.util.fastAny
 import eu.kanade.presentation.library.components.DownloadsBadge
 import eu.kanade.presentation.library.components.EntryListItem
 import eu.kanade.presentation.library.components.GlobalSearchItem
@@ -32,6 +33,10 @@ internal fun MangaLibraryList(
     searchQuery: String?,
     onGlobalSearchClicked: () -> Unit,
 ) {
+    val selectionIds = remember(selection) {
+        derivedStateOf { selection.map { it.id }.toSet() }
+    }
+
     FastScrollLazyColumn(
         modifier = Modifier.fillMaxSize(),
         contentPadding = contentPadding + PaddingValues(vertical = 8.dp),
@@ -48,11 +53,12 @@ internal fun MangaLibraryList(
 
         items(
             items = items,
+            key = { it.libraryManga.id },
             contentType = { "manga_library_list_item" },
         ) { libraryItem ->
             val manga = libraryItem.libraryManga.manga
             EntryListItem(
-                isSelected = selection.fastAny { it.id == libraryItem.libraryManga.id },
+                isSelected = libraryItem.libraryManga.id in selectionIds.value,
                 title = manga.title,
                 coverData = MangaCover(
                     mangaId = manga.id,


### PR DESCRIPTION
## Objective
Add stable keys to library LazyList items to reduce unnecessary recomposition and optimize selection state tracking for large libraries.

## Scope
- Add `key` parameter to all `items()` calls in 6 library composables (manga/anime compact grid, comfortable grid, list)
- Convert selection linear search (`fastAny()`) to Set-based O(1) lookup using `derivedStateOf`
- Remove unused `fastAny` imports

**Files modified:**
- `MangaLibraryCompactGrid.kt`
- `MangaLibraryComfortableGrid.kt`
- `MangaLibraryList.kt`
- `AnimeLibraryCompactGrid.kt`
- `AnimeLibraryComfortableGrid.kt`
- `AnimeLibraryList.kt`

## Verification
- [x] `./gradlew :app:spotlessApply` - passed
- [x] `./gradlew :app:compileDebugKotlin` - passed
- [x] No visual changes
- [x] Code compiles without errors

**Expected behavior:** Compose will now preserve UI state when library is reordered/filtered. Multi-select performance improves in large libraries (200+ items).

## Risk
**Risk Tier:** T1 (Low)

**Impact:** Performance optimization only. No functional changes to library behavior. Keys based on stable IDs (manga.id/anime.id).

**Rollback:** Revert commit. No data migration or state cleanup needed.

Closes #213