### PR TITLE
perf: increase OkHttp network cache from 5MB to 50MB (R133)

### DIFF
--- a/core/common/src/main/java/eu/kanade/tachiyomi/network/NetworkHelper.kt
+++ b/core/common/src/main/java/eu/kanade/tachiyomi/network/NetworkHelper.kt
@@ -28,7 +28,7 @@ class NetworkHelper(
             .cache(
                 Cache(
                     directory = File(context.cacheDir, "network_cache"),
-                    maxSize = 5L * 1024 * 1024, // 5 MiB
+                    maxSize = 50L * 1024 * 1024, // 50 MiB
                 ),
             )
             .addInterceptor(UncaughtExceptionInterceptor())


### PR DESCRIPTION
## Objective
Increase OkHttp network cache from 5MB to 50MB to reduce API re-fetching and improve browsing performance in this media-heavy app.

## Scope
Single-line change in NetworkHelper.kt:
- Change `maxSize = 5L * 1024 * 1024` to `maxSize = 50L * 1024 * 1024`
- Cache directory location unchanged (`network_cache`)

**File modified:**
- `core/common/src/main/java/eu/kanade/tachiyomi/network/NetworkHelper.kt` (line 31)

## Verification
- [x] `./gradlew spotlessApply` - passed
- [x] `./gradlew :core:common:compileDebugKotlin` - passed
- [x] spotlessCheck pre-push hook - passed

**Expected behavior:** Reduced API re-fetching for source listings, metadata, and repeated requests. Users should see faster browsing and fewer network calls for cached responses.

## Risk
**Risk Tier:** T1 (Low)

**Impact:** Cache size increase only (5MB → 50MB). No functional changes to caching behavior or cache directory location.

**Rollback:** Revert commit. OkHttp will revert to 5MB cache size. No data loss or corruption risk.

Closes #214