### PR TITLE
fix: scale Coil memory cache to device RAM capacity (R138)

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/App.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/App.kt
@@ -1,6 +1,7 @@
 package eu.kanade.tachiyomi
 
 import android.annotation.SuppressLint
+import android.app.ActivityManager
 import android.app.Application
 import android.app.PendingIntent
 import android.content.BroadcastReceiver
@@ -19,6 +20,7 @@ import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import coil3.ImageLoader
 import coil3.SingletonImageLoader
+import coil3.memory.MemoryCache
 import coil3.network.okhttp.OkHttpNetworkFetcherFactory
 import coil3.request.allowRgb565
 import coil3.request.crossfade
@@ -231,6 +233,18 @@ class App : Application(), DefaultLifecycleObserver, SingletonImageLoader.Factor
                 add(MangaKeyer())
                 add(AnimeCoverKeyer())
                 add(MangaCoverKeyer())
+            }
+
+            // Scale memory cache to device capability: 15% of app memory class
+            val activityManager = getSystemService(ACTIVITY_SERVICE) as ActivityManager
+            val deviceMemoryMb = activityManager.memoryClass.toLong()
+            val cacheSizePercent = 15L
+            val memoryCacheMb = deviceMemoryMb * cacheSizePercent / 100
+            val memoryCacheBytes = memoryCacheMb * 1024L * 1024L
+            memoryCache {
+                MemoryCache.Builder()
+                    .maxSizeBytes(memoryCacheBytes)
+                    .build()
             }
 
             crossfade((300 * this@App.animatorDurationScale).toInt())


### PR DESCRIPTION
## Ticket
Closes #226

## Objective
Scale Coil's image memory cache to 15% of the device's app memory class, so cache size is appropriate for both low-end and high-end devices rather than using Coil's fixed default.

## Background
Investigation revealed that image downsampling for grid views was already working correctly:
- `TachiyomiImageDecoder` uses `DecodeUtils.calculateInSampleSize()` to decode at view-appropriate resolution
- Coil 3's `AsyncImage` automatically measures composed layout bounds and passes dimensions to the decoder
- No changes to composables or fetchers were needed

## Scope
- Added memory-aware `MemoryCache` sizing in `App.newImageLoader()` using `ActivityManager.getMemoryClass()`
- Cache size = 15% of device app memory class (e.g. ~30MB on a 192MB device, ~77MB on a 512MB device)

## Non-goals
- Downsampling logic (already implemented in TachiyomiImageDecoder)
- Reader/player image loading (untouched)
- `Size.ORIGINAL` usages in detail/cover dialog views (untouched)

## Files Changed
- `App.kt` (+14 lines): memory-aware MemoryCache sizing

## Verification
- `./gradlew :app:assembleDebug` ✅
- `./gradlew :app:spotlessApply` ✅

## Risk
T1 - Single file, additive change to image cache configuration only.

## Rollback
Revert commit. Cache reverts to Coil's built-in default sizing.

## Release Notes
Image memory cache now scales to device RAM, reducing memory pressure on low-end devices.