### PR TITLE
perf: move library filtering to database layer (R139)

### DIFF
--- a/data/src/main/java/tachiyomi/data/entries/anime/AnimeRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/entries/anime/AnimeRepositoryImpl.kt
@@ -12,6 +12,7 @@ import tachiyomi.domain.entries.anime.model.Anime
 import tachiyomi.domain.entries.anime.model.AnimeUpdate
 import tachiyomi.domain.entries.anime.repository.AnimeRepository
 import tachiyomi.domain.library.anime.LibraryAnime
+import tachiyomi.domain.library.model.LibraryFilter
 import tachiyomi.domain.source.anime.model.DeletableAnime
 import java.time.LocalDate
 import java.time.ZoneId
@@ -62,6 +63,32 @@ class AnimeRepositoryImpl(
 
     override fun getLibraryAnimeAsFlow(): Flow<List<LibraryAnime>> {
         return handler.subscribeToList { animelibViewQueries.animelib(AnimeMapper::mapLibraryAnime) }
+    }
+
+    override suspend fun getLibraryAnimeFiltered(filter: LibraryFilter): List<LibraryAnime> {
+        return handler.awaitList {
+            animelibViewQueries.animelibFiltered(
+                filterUnseen = filter.filterUnread.ordinal.toLong(),
+                filterStarted = filter.filterStarted.ordinal.toLong(),
+                filterBookmarked = filter.filterBookmarked.ordinal.toLong(),
+                filterCompleted = filter.filterCompleted.ordinal.toLong(),
+                filterIntervalCustom = filter.filterIntervalCustom.ordinal.toLong(),
+                mapper = AnimeMapper::mapLibraryAnime,
+            )
+        }
+    }
+
+    override fun getLibraryAnimeFilteredAsFlow(filter: LibraryFilter): Flow<List<LibraryAnime>> {
+        return handler.subscribeToList {
+            animelibViewQueries.animelibFiltered(
+                filterUnseen = filter.filterUnread.ordinal.toLong(),
+                filterStarted = filter.filterStarted.ordinal.toLong(),
+                filterBookmarked = filter.filterBookmarked.ordinal.toLong(),
+                filterCompleted = filter.filterCompleted.ordinal.toLong(),
+                filterIntervalCustom = filter.filterIntervalCustom.ordinal.toLong(),
+                mapper = AnimeMapper::mapLibraryAnime,
+            )
+        }
     }
 
     override fun getAnimeFavoritesBySourceId(sourceId: Long): Flow<List<Anime>> {

--- a/data/src/main/java/tachiyomi/data/entries/manga/MangaRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/entries/manga/MangaRepositoryImpl.kt
@@ -10,6 +10,7 @@ import tachiyomi.domain.entries.manga.model.Manga
 import tachiyomi.domain.entries.manga.model.MangaUpdate
 import tachiyomi.domain.entries.manga.repository.MangaRepository
 import tachiyomi.domain.library.manga.LibraryManga
+import tachiyomi.domain.library.model.LibraryFilter
 import java.time.LocalDate
 import java.time.ZoneId
 
@@ -59,6 +60,32 @@ class MangaRepositoryImpl(
 
     override fun getLibraryMangaAsFlow(): Flow<List<LibraryManga>> {
         return handler.subscribeToList { libraryViewQueries.library(MangaMapper::mapLibraryManga) }
+    }
+
+    override suspend fun getLibraryMangaFiltered(filter: LibraryFilter): List<LibraryManga> {
+        return handler.awaitList {
+            libraryViewQueries.libraryFiltered(
+                filterUnread = filter.filterUnread.ordinal.toLong(),
+                filterStarted = filter.filterStarted.ordinal.toLong(),
+                filterBookmarked = filter.filterBookmarked.ordinal.toLong(),
+                filterCompleted = filter.filterCompleted.ordinal.toLong(),
+                filterIntervalCustom = filter.filterIntervalCustom.ordinal.toLong(),
+                mapper = MangaMapper::mapLibraryManga,
+            )
+        }
+    }
+
+    override fun getLibraryMangaFilteredAsFlow(filter: LibraryFilter): Flow<List<LibraryManga>> {
+        return handler.subscribeToList {
+            libraryViewQueries.libraryFiltered(
+                filterUnread = filter.filterUnread.ordinal.toLong(),
+                filterStarted = filter.filterStarted.ordinal.toLong(),
+                filterBookmarked = filter.filterBookmarked.ordinal.toLong(),
+                filterCompleted = filter.filterCompleted.ordinal.toLong(),
+                filterIntervalCustom = filter.filterIntervalCustom.ordinal.toLong(),
+                mapper = MangaMapper::mapLibraryManga,
+            )
+        }
     }
 
     override fun getMangaFavoritesBySourceId(sourceId: Long): Flow<List<Manga>> {

--- a/data/src/main/sqldelight/view/libraryView.sq
+++ b/data/src/main/sqldelight/view/libraryView.sq
@@ -35,3 +35,15 @@ WHERE M.favorite = 1;
 library:
 SELECT *
 FROM libraryView;
+
+-- Filtered library query. Filter params use TriState ordinal:
+-- 0 = DISABLED (no filter), 1 = ENABLED_IS (include), 2 = ENABLED_NOT (exclude)
+libraryFiltered:
+SELECT *
+FROM libraryView
+WHERE
+    (:filterUnread = 0 OR (:filterUnread = 1 AND (totalCount - readCount) > 0) OR (:filterUnread = 2 AND (totalCount - readCount) = 0))
+    AND (:filterStarted = 0 OR (:filterStarted = 1 AND readCount > 0) OR (:filterStarted = 2 AND readCount = 0))
+    AND (:filterBookmarked = 0 OR (:filterBookmarked = 1 AND bookmarkCount > 0) OR (:filterBookmarked = 2 AND bookmarkCount = 0))
+    AND (:filterCompleted = 0 OR (:filterCompleted = 1 AND status = 2) OR (:filterCompleted = 2 AND status != 2))
+    AND (:filterIntervalCustom = 0 OR (:filterIntervalCustom = 1 AND calculate_interval < 0) OR (:filterIntervalCustom = 2 AND calculate_interval >= 0));

--- a/data/src/main/sqldelightanime/view/animelibView.sq
+++ b/data/src/main/sqldelightanime/view/animelibView.sq
@@ -40,3 +40,15 @@ WHERE M.favorite = 1;
 animelib:
 SELECT *
 FROM animelibView;
+
+-- Filtered animelib query. Filter params use TriState ordinal:
+-- 0 = DISABLED (no filter), 1 = ENABLED_IS (include), 2 = ENABLED_NOT (exclude)
+animelibFiltered:
+SELECT *
+FROM animelibView
+WHERE
+    (:filterUnseen = 0 OR (:filterUnseen = 1 AND (totalCount - seenCount) > 0) OR (:filterUnseen = 2 AND (totalCount - seenCount) = 0))
+    AND (:filterStarted = 0 OR (:filterStarted = 1 AND seenCount > 0) OR (:filterStarted = 2 AND seenCount = 0))
+    AND (:filterBookmarked = 0 OR (:filterBookmarked = 1 AND bookmarkCount > 0) OR (:filterBookmarked = 2 AND bookmarkCount = 0))
+    AND (:filterCompleted = 0 OR (:filterCompleted = 1 AND status = 2) OR (:filterCompleted = 2 AND status != 2))
+    AND (:filterIntervalCustom = 0 OR (:filterIntervalCustom = 1 AND calculate_interval < 0) OR (:filterIntervalCustom = 2 AND calculate_interval >= 0));

--- a/domain/src/main/java/tachiyomi/domain/entries/anime/interactor/GetLibraryAnime.kt
+++ b/domain/src/main/java/tachiyomi/domain/entries/anime/interactor/GetLibraryAnime.kt
@@ -8,6 +8,7 @@ import logcat.LogPriority
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.entries.anime.repository.AnimeRepository
 import tachiyomi.domain.library.anime.LibraryAnime
+import tachiyomi.domain.library.model.LibraryFilter
 import kotlin.time.Duration.Companion.seconds
 
 class GetLibraryAnime(
@@ -18,8 +19,26 @@ class GetLibraryAnime(
         return animeRepository.getLibraryAnime()
     }
 
+    suspend fun await(filter: LibraryFilter): List<LibraryAnime> {
+        return animeRepository.getLibraryAnimeFiltered(filter)
+    }
+
     fun subscribe(): Flow<List<LibraryAnime>> {
         return animeRepository.getLibraryAnimeAsFlow()
+            .retry {
+                if (it is NullPointerException) {
+                    delay(0.5.seconds)
+                    true
+                } else {
+                    false
+                }
+            }.catch {
+                this@GetLibraryAnime.logcat(LogPriority.ERROR, it)
+            }
+    }
+
+    fun subscribe(filter: LibraryFilter): Flow<List<LibraryAnime>> {
+        return animeRepository.getLibraryAnimeFilteredAsFlow(filter)
             .retry {
                 if (it is NullPointerException) {
                     delay(0.5.seconds)

--- a/domain/src/main/java/tachiyomi/domain/entries/anime/repository/AnimeRepository.kt
+++ b/domain/src/main/java/tachiyomi/domain/entries/anime/repository/AnimeRepository.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.flow.Flow
 import tachiyomi.domain.entries.anime.model.Anime
 import tachiyomi.domain.entries.anime.model.AnimeUpdate
 import tachiyomi.domain.library.anime.LibraryAnime
+import tachiyomi.domain.library.model.LibraryFilter
 import tachiyomi.domain.source.anime.model.DeletableAnime
 
 interface AnimeRepository {
@@ -24,6 +25,10 @@ interface AnimeRepository {
     suspend fun getLibraryAnime(): List<LibraryAnime>
 
     fun getLibraryAnimeAsFlow(): Flow<List<LibraryAnime>>
+
+    suspend fun getLibraryAnimeFiltered(filter: LibraryFilter): List<LibraryAnime>
+
+    fun getLibraryAnimeFilteredAsFlow(filter: LibraryFilter): Flow<List<LibraryAnime>>
 
     fun getAnimeFavoritesBySourceId(sourceId: Long): Flow<List<Anime>>
 

--- a/domain/src/main/java/tachiyomi/domain/entries/manga/interactor/GetLibraryManga.kt
+++ b/domain/src/main/java/tachiyomi/domain/entries/manga/interactor/GetLibraryManga.kt
@@ -8,6 +8,7 @@ import logcat.LogPriority
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.entries.manga.repository.MangaRepository
 import tachiyomi.domain.library.manga.LibraryManga
+import tachiyomi.domain.library.model.LibraryFilter
 import kotlin.time.Duration.Companion.seconds
 
 class GetLibraryManga(
@@ -18,8 +19,26 @@ class GetLibraryManga(
         return mangaRepository.getLibraryManga()
     }
 
+    suspend fun await(filter: LibraryFilter): List<LibraryManga> {
+        return mangaRepository.getLibraryMangaFiltered(filter)
+    }
+
     fun subscribe(): Flow<List<LibraryManga>> {
         return mangaRepository.getLibraryMangaAsFlow()
+            .retry {
+                if (it is NullPointerException) {
+                    delay(0.5.seconds)
+                    true
+                } else {
+                    false
+                }
+            }.catch {
+                this@GetLibraryManga.logcat(LogPriority.ERROR, it)
+            }
+    }
+
+    fun subscribe(filter: LibraryFilter): Flow<List<LibraryManga>> {
+        return mangaRepository.getLibraryMangaFilteredAsFlow(filter)
             .retry {
                 if (it is NullPointerException) {
                     delay(0.5.seconds)

--- a/domain/src/main/java/tachiyomi/domain/entries/manga/repository/MangaRepository.kt
+++ b/domain/src/main/java/tachiyomi/domain/entries/manga/repository/MangaRepository.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.flow.Flow
 import tachiyomi.domain.entries.manga.model.Manga
 import tachiyomi.domain.entries.manga.model.MangaUpdate
 import tachiyomi.domain.library.manga.LibraryManga
+import tachiyomi.domain.library.model.LibraryFilter
 
 interface MangaRepository {
 
@@ -22,6 +23,10 @@ interface MangaRepository {
     suspend fun getLibraryManga(): List<LibraryManga>
 
     fun getLibraryMangaAsFlow(): Flow<List<LibraryManga>>
+
+    suspend fun getLibraryMangaFiltered(filter: LibraryFilter): List<LibraryManga>
+
+    fun getLibraryMangaFilteredAsFlow(filter: LibraryFilter): Flow<List<LibraryManga>>
 
     fun getMangaFavoritesBySourceId(sourceId: Long): Flow<List<Manga>>
 

--- a/domain/src/main/java/tachiyomi/domain/library/model/LibraryFilter.kt
+++ b/domain/src/main/java/tachiyomi/domain/library/model/LibraryFilter.kt
@@ -1,0 +1,31 @@
+package tachiyomi.domain.library.model
+
+import tachiyomi.core.common.preference.TriState
+
+/**
+ * Filter parameters for DB-layer library queries.
+ *
+ * filterUnread: filter by unread/unseen count > 0
+ * filterStarted: filter by read/seen count > 0
+ * filterBookmarked: filter by bookmark count > 0
+ * filterCompleted: filter by completed status
+ * filterIntervalCustom: filter by custom fetch interval (fetchInterval < 0)
+ */
+data class LibraryFilter(
+    val filterUnread: TriState = TriState.DISABLED,
+    val filterStarted: TriState = TriState.DISABLED,
+    val filterBookmarked: TriState = TriState.DISABLED,
+    val filterCompleted: TriState = TriState.DISABLED,
+    val filterIntervalCustom: TriState = TriState.DISABLED,
+) {
+    val hasActiveFilters: Boolean
+        get() = filterUnread != TriState.DISABLED ||
+            filterStarted != TriState.DISABLED ||
+            filterBookmarked != TriState.DISABLED ||
+            filterCompleted != TriState.DISABLED ||
+            filterIntervalCustom != TriState.DISABLED
+
+    companion object {
+        val NONE = LibraryFilter()
+    }
+}

--- a/domain/src/test/java/tachiyomi/domain/entries/anime/interactor/GetLibraryAnimeFilterTest.kt
+++ b/domain/src/test/java/tachiyomi/domain/entries/anime/interactor/GetLibraryAnimeFilterTest.kt
@@ -1,0 +1,132 @@
+package tachiyomi.domain.entries.anime.interactor
+
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
+import tachiyomi.core.common.preference.TriState
+import tachiyomi.domain.entries.anime.model.Anime
+import tachiyomi.domain.entries.anime.repository.AnimeRepository
+import tachiyomi.domain.library.anime.LibraryAnime
+import tachiyomi.domain.library.model.LibraryFilter
+
+@Execution(ExecutionMode.CONCURRENT)
+class GetLibraryAnimeFilterTest {
+
+    private val animeRepository: AnimeRepository = mockk()
+    private val interactor = GetLibraryAnime(animeRepository)
+
+    private fun createLibraryAnime(
+        id: Long = 1L,
+        seenCount: Long = 0L,
+        totalCount: Long = 10L,
+        bookmarkCount: Long = 0L,
+        statusCompleted: Boolean = false,
+        fetchInterval: Int = 7,
+    ): LibraryAnime {
+        val anime = Anime.create().copy(
+            id = id,
+            status = if (statusCompleted) 2L else 1L,
+            fetchInterval = fetchInterval,
+        )
+        return LibraryAnime(
+            anime = anime,
+            category = 0L,
+            totalCount = totalCount,
+            seenCount = seenCount,
+            bookmarkCount = bookmarkCount,
+            fillermarkCount = 0L,
+            latestUpload = 0L,
+            episodeFetchedAt = 0L,
+            lastSeen = 0L,
+        )
+    }
+
+    @Test
+    fun `await with DISABLED filters returns all anime`() = runTest {
+        val filterSlot = slot<LibraryFilter>()
+        coEvery { animeRepository.getLibraryAnimeFiltered(capture(filterSlot)) } returns listOf(
+            createLibraryAnime(id = 1L, seenCount = 0L),
+            createLibraryAnime(id = 2L, seenCount = 5L),
+        )
+
+        val filter = LibraryFilter(
+            filterUnread = TriState.DISABLED,
+            filterStarted = TriState.DISABLED,
+            filterBookmarked = TriState.DISABLED,
+            filterCompleted = TriState.DISABLED,
+            filterIntervalCustom = TriState.DISABLED,
+        )
+
+        val result = interactor.await(filter)
+
+        result shouldHaveSize 2
+    }
+
+    @Test
+    fun `await with ENABLED_IS unseen filter passes correct filter to repository`() = runTest {
+        val filterSlot = slot<LibraryFilter>()
+        coEvery { animeRepository.getLibraryAnimeFiltered(capture(filterSlot)) } returns listOf(
+            createLibraryAnime(id = 1L, seenCount = 0L, totalCount = 5L),
+        )
+
+        val filter = LibraryFilter(
+            filterUnread = TriState.ENABLED_IS,
+            filterStarted = TriState.DISABLED,
+            filterBookmarked = TriState.DISABLED,
+            filterCompleted = TriState.DISABLED,
+            filterIntervalCustom = TriState.DISABLED,
+        )
+
+        interactor.await(filter)
+
+        filterSlot.captured.filterUnread shouldBe TriState.ENABLED_IS
+    }
+
+    @Test
+    fun `await with ENABLED_IS started filter passes correct filter to repository`() = runTest {
+        val filterSlot = slot<LibraryFilter>()
+        coEvery { animeRepository.getLibraryAnimeFiltered(capture(filterSlot)) } returns listOf(
+            createLibraryAnime(id = 2L, seenCount = 3L),
+        )
+
+        val filter = LibraryFilter(
+            filterUnread = TriState.DISABLED,
+            filterStarted = TriState.ENABLED_IS,
+            filterBookmarked = TriState.DISABLED,
+            filterCompleted = TriState.DISABLED,
+            filterIntervalCustom = TriState.DISABLED,
+        )
+
+        interactor.await(filter)
+
+        filterSlot.captured.filterStarted shouldBe TriState.ENABLED_IS
+    }
+
+    @Test
+    fun `await with combined filters passes all filters to repository`() = runTest {
+        val filterSlot = slot<LibraryFilter>()
+        coEvery { animeRepository.getLibraryAnimeFiltered(capture(filterSlot)) } returns emptyList()
+
+        val filter = LibraryFilter(
+            filterUnread = TriState.ENABLED_IS,
+            filterStarted = TriState.ENABLED_NOT,
+            filterBookmarked = TriState.DISABLED,
+            filterCompleted = TriState.ENABLED_IS,
+            filterIntervalCustom = TriState.ENABLED_NOT,
+        )
+
+        val result = interactor.await(filter)
+
+        result.shouldBeEmpty()
+        filterSlot.captured.filterUnread shouldBe TriState.ENABLED_IS
+        filterSlot.captured.filterStarted shouldBe TriState.ENABLED_NOT
+        filterSlot.captured.filterCompleted shouldBe TriState.ENABLED_IS
+    }
+}

--- a/domain/src/test/java/tachiyomi/domain/entries/manga/interactor/GetLibraryMangaFilterTest.kt
+++ b/domain/src/test/java/tachiyomi/domain/entries/manga/interactor/GetLibraryMangaFilterTest.kt
@@ -1,0 +1,193 @@
+package tachiyomi.domain.entries.manga.interactor
+
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
+import tachiyomi.core.common.preference.TriState
+import tachiyomi.domain.entries.manga.model.Manga
+import tachiyomi.domain.entries.manga.repository.MangaRepository
+import tachiyomi.domain.library.manga.LibraryManga
+import tachiyomi.domain.library.model.LibraryFilter
+
+@Execution(ExecutionMode.CONCURRENT)
+class GetLibraryMangaFilterTest {
+
+    private val mangaRepository: MangaRepository = mockk()
+    private val interactor = GetLibraryManga(mangaRepository)
+
+    private fun createLibraryManga(
+        id: Long = 1L,
+        readCount: Long = 0L,
+        totalChapters: Long = 10L,
+        bookmarkCount: Long = 0L,
+        statusCompleted: Boolean = false,
+        fetchInterval: Int = 7,
+    ): LibraryManga {
+        val manga = Manga.create().copy(
+            id = id,
+            status = if (statusCompleted) 2L else 1L,
+            fetchInterval = fetchInterval,
+        )
+        return LibraryManga(
+            manga = manga,
+            category = 0L,
+            totalChapters = totalChapters,
+            readCount = readCount,
+            bookmarkCount = bookmarkCount,
+            latestUpload = 0L,
+            chapterFetchedAt = 0L,
+            lastRead = 0L,
+        )
+    }
+
+    @Test
+    fun `await with DISABLED filters returns all manga`() = runTest {
+        val filterSlot = slot<LibraryFilter>()
+        coEvery { mangaRepository.getLibraryMangaFiltered(capture(filterSlot)) } returns listOf(
+            createLibraryManga(id = 1L, readCount = 0L),
+            createLibraryManga(id = 2L, readCount = 5L),
+        )
+
+        val filter = LibraryFilter(
+            filterUnread = TriState.DISABLED,
+            filterStarted = TriState.DISABLED,
+            filterBookmarked = TriState.DISABLED,
+            filterCompleted = TriState.DISABLED,
+            filterIntervalCustom = TriState.DISABLED,
+        )
+
+        val result = interactor.await(filter)
+
+        result shouldHaveSize 2
+    }
+
+    @Test
+    fun `await with ENABLED_IS unread filter passes correct filter to repository`() = runTest {
+        val filterSlot = slot<LibraryFilter>()
+        coEvery { mangaRepository.getLibraryMangaFiltered(capture(filterSlot)) } returns listOf(
+            createLibraryManga(id = 1L, readCount = 0L, totalChapters = 5L),
+        )
+
+        val filter = LibraryFilter(
+            filterUnread = TriState.ENABLED_IS,
+            filterStarted = TriState.DISABLED,
+            filterBookmarked = TriState.DISABLED,
+            filterCompleted = TriState.DISABLED,
+            filterIntervalCustom = TriState.DISABLED,
+        )
+
+        interactor.await(filter)
+
+        filterSlot.captured.filterUnread shouldBe TriState.ENABLED_IS
+    }
+
+    @Test
+    fun `await with ENABLED_IS started filter passes correct filter to repository`() = runTest {
+        val filterSlot = slot<LibraryFilter>()
+        coEvery { mangaRepository.getLibraryMangaFiltered(capture(filterSlot)) } returns listOf(
+            createLibraryManga(id = 2L, readCount = 3L),
+        )
+
+        val filter = LibraryFilter(
+            filterUnread = TriState.DISABLED,
+            filterStarted = TriState.ENABLED_IS,
+            filterBookmarked = TriState.DISABLED,
+            filterCompleted = TriState.DISABLED,
+            filterIntervalCustom = TriState.DISABLED,
+        )
+
+        interactor.await(filter)
+
+        filterSlot.captured.filterStarted shouldBe TriState.ENABLED_IS
+    }
+
+    @Test
+    fun `await with ENABLED_IS bookmarked filter passes correct filter to repository`() = runTest {
+        val filterSlot = slot<LibraryFilter>()
+        coEvery { mangaRepository.getLibraryMangaFiltered(capture(filterSlot)) } returns listOf(
+            createLibraryManga(id = 3L, bookmarkCount = 2L),
+        )
+
+        val filter = LibraryFilter(
+            filterUnread = TriState.DISABLED,
+            filterStarted = TriState.DISABLED,
+            filterBookmarked = TriState.ENABLED_IS,
+            filterCompleted = TriState.DISABLED,
+            filterIntervalCustom = TriState.DISABLED,
+        )
+
+        interactor.await(filter)
+
+        filterSlot.captured.filterBookmarked shouldBe TriState.ENABLED_IS
+    }
+
+    @Test
+    fun `await with ENABLED_IS completed filter passes correct filter to repository`() = runTest {
+        val filterSlot = slot<LibraryFilter>()
+        coEvery { mangaRepository.getLibraryMangaFiltered(capture(filterSlot)) } returns listOf(
+            createLibraryManga(id = 4L, statusCompleted = true),
+        )
+
+        val filter = LibraryFilter(
+            filterUnread = TriState.DISABLED,
+            filterStarted = TriState.DISABLED,
+            filterBookmarked = TriState.DISABLED,
+            filterCompleted = TriState.ENABLED_IS,
+            filterIntervalCustom = TriState.DISABLED,
+        )
+
+        interactor.await(filter)
+
+        filterSlot.captured.filterCompleted shouldBe TriState.ENABLED_IS
+    }
+
+    @Test
+    fun `await with ENABLED_NOT unread filter passes correct filter to repository`() = runTest {
+        val filterSlot = slot<LibraryFilter>()
+        coEvery { mangaRepository.getLibraryMangaFiltered(capture(filterSlot)) } returns listOf(
+            createLibraryManga(id = 5L, readCount = 10L, totalChapters = 10L),
+        )
+
+        val filter = LibraryFilter(
+            filterUnread = TriState.ENABLED_NOT,
+            filterStarted = TriState.DISABLED,
+            filterBookmarked = TriState.DISABLED,
+            filterCompleted = TriState.DISABLED,
+            filterIntervalCustom = TriState.DISABLED,
+        )
+
+        interactor.await(filter)
+
+        filterSlot.captured.filterUnread shouldBe TriState.ENABLED_NOT
+    }
+
+    @Test
+    fun `await with combined filters passes all filters to repository`() = runTest {
+        val filterSlot = slot<LibraryFilter>()
+        coEvery { mangaRepository.getLibraryMangaFiltered(capture(filterSlot)) } returns emptyList()
+
+        val filter = LibraryFilter(
+            filterUnread = TriState.ENABLED_IS,
+            filterStarted = TriState.ENABLED_NOT,
+            filterBookmarked = TriState.DISABLED,
+            filterCompleted = TriState.ENABLED_IS,
+            filterIntervalCustom = TriState.ENABLED_NOT,
+        )
+
+        val result = interactor.await(filter)
+
+        result.shouldBeEmpty()
+        filterSlot.captured.filterUnread shouldBe TriState.ENABLED_IS
+        filterSlot.captured.filterStarted shouldBe TriState.ENABLED_NOT
+        filterSlot.captured.filterBookmarked shouldBe TriState.DISABLED
+        filterSlot.captured.filterCompleted shouldBe TriState.ENABLED_IS
+        filterSlot.captured.filterIntervalCustom shouldBe TriState.ENABLED_NOT
+    }
+}


### PR DESCRIPTION
## Ticket
Closes #227

## Objective
Move library filtering from in-memory screen models to SQL queries, reducing memory pressure on large libraries by loading only filtered results from the database.

## Scope
- Added `LibraryFilter` data class with TriState fields (DISABLED/ENABLED_IS/ENABLED_NOT)
- Added filtered SQL query variants for manga and anime library views
- Added filtered `await(filter)` and `subscribe(filter)` overloads to interactors
- Updated `MangaLibraryScreenModel` and `AnimeLibraryScreenModel` to pass filter state to DB queries via `flatMapLatest`
- Renamed `applyFilters()` → `applyRemainingFilters()` for clarity

## Filters moved to DB layer
unread/unseen, started, bookmarked, completed, custom interval

## Filters remaining in-memory
Downloaded (DownloadManager state), tracking (in-memory tracker state) — cannot be pushed to DB

## Non-goals
- No UI changes
- No sort order changes
- No category management changes

## Files Changed
15 files: new LibraryFilter model, SQL query variants, repository/interactor overloads, screen model updates, 2 new test files

## Verification
- `./gradlew :app:assembleDebug` ✅
- `./gradlew :app:spotlessApply :domain:spotlessApply :data:spotlessApply` ✅
- `./gradlew :domain:testDebugUnitTest` ✅ (11 new tests + all existing passing)
- `./gradlew :app:testDebugUnitTest` ✅

## Risk
T2 - Data layer changes. Filtering behaviour preserved (same results, different execution layer). Download/tracking filters unchanged.

## Rollback
Revert commit. No schema migrations — filters revert to in-memory only, no data loss.

## Release Notes
Library filtering now runs at the database layer for improved performance on large libraries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)