### PR TITLE
refactor: extract shared entry ScreenModel helper composition (R137)

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/entries/anime/AnimeScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/entries/anime/AnimeScreenModel.kt
@@ -477,7 +477,7 @@ class AnimeScreenModel(
      * @param categories the selected categories.
      */
     private fun moveAnimeToCategories(categories: List<Category>) {
-        val categoryIds = EntryCategoryActions.toCategoryIds(categories)
+        val categoryIds = categories.map { it.id }
         moveAnimeToCategory(categoryIds)
     }
 
@@ -493,7 +493,7 @@ class AnimeScreenModel(
      * @param category the selected category, or null for default category.
      */
     private fun moveAnimeToCategory(category: Category?) {
-        moveAnimeToCategories(EntryCategoryActions.toCategoryList(category))
+        moveAnimeToCategories(listOfNotNull(category))
     }
 
     // Anime info - end
@@ -1557,7 +1557,7 @@ class AnimeScreenModel(
                     itemId = { it.id },
                     itemNumber = { it.episode.episodeNumber },
                     calculateGap = { higher, lower -> calculateEpisodeGap(higher.episode, lower.episode) },
-                    mapItem = { it as EpisodeList },
+                    mapItem = { it },
                     mapMissing = { id, count -> EpisodeList.MissingCount(id = id, count = count) },
                 )
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/entries/common/EntryCategoryActions.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/entries/common/EntryCategoryActions.kt
@@ -6,7 +6,7 @@ import tachiyomi.core.common.preference.CheckboxState
 import tachiyomi.core.common.preference.mapAsCheckboxState
 import tachiyomi.domain.category.model.Category
 
-object EntryCategoryActions {
+internal object EntryCategoryActions {
     fun buildInitialSelection(
         categories: List<Category>,
         selectedCategoryIds: List<Long>,
@@ -14,13 +14,5 @@ object EntryCategoryActions {
         return categories
             .mapAsCheckboxState { it.id in selectedCategoryIds }
             .toImmutableList()
-    }
-
-    fun toCategoryIds(categories: List<Category>): List<Long> {
-        return categories.map { it.id }
-    }
-
-    fun toCategoryList(category: Category?): List<Category> {
-        return listOfNotNull(category)
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/entries/common/EntryDownloadStateUpdater.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/entries/common/EntryDownloadStateUpdater.kt
@@ -1,6 +1,6 @@
 package eu.kanade.tachiyomi.ui.entries.common
 
-object EntryDownloadStateUpdater {
+internal object EntryDownloadStateUpdater {
     fun <T> update(
         items: List<T>,
         entryId: Long,
@@ -11,8 +11,7 @@ object EntryDownloadStateUpdater {
         if (modifiedIndex < 0) return items
 
         return items.toMutableList().apply {
-            val item = removeAt(modifiedIndex)
-            add(modifiedIndex, updateItem(item))
+            this[modifiedIndex] = updateItem(this[modifiedIndex])
         }
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/entries/common/EntryListGapSeparator.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/entries/common/EntryListGapSeparator.kt
@@ -2,7 +2,7 @@ package eu.kanade.tachiyomi.ui.entries.common
 
 import kotlin.math.floor
 
-object EntryListGapSeparator {
+internal object EntryListGapSeparator {
     fun <T, R> withMissingCount(
         items: List<T>,
         sortDescending: Boolean,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/entries/common/EntrySelectionController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/entries/common/EntrySelectionController.kt
@@ -1,19 +1,20 @@
 package eu.kanade.tachiyomi.ui.entries.common
 
-data class SelectionRangeState(
-    var first: Int = -1,
-    var last: Int = -1,
-)
-
-interface SelectableEntryItem {
+internal interface SelectableEntryItem {
     val id: Long
     val selected: Boolean
 }
 
-class EntrySelectionController(
+internal class EntrySelectionController(
     private val selectedIds: MutableSet<Long>,
-    private val rangeState: SelectionRangeState = SelectionRangeState(),
 ) {
+    private class SelectionRangeState(
+        var first: Int = -1,
+        var last: Int = -1,
+    )
+
+    private val rangeState = SelectionRangeState()
+
     fun <T : SelectableEntryItem> toggleSelection(
         items: List<T>,
         itemId: Long,
@@ -55,7 +56,7 @@ class EntrySelectionController(
                 range.forEach { index ->
                     val inbetweenItem = newItems[index]
                     if (!inbetweenItem.selected) {
-                        selectedIds.add(inbetweenItem.id)
+                        addOrRemoveSelection(inbetweenItem.id, true)
                         newItems[index] = updateSelection(inbetweenItem, true)
                     }
                 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/entries/common/EntryTrackingSummaryObserver.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/entries/common/EntryTrackingSummaryObserver.kt
@@ -2,12 +2,12 @@ package eu.kanade.tachiyomi.ui.entries.common
 
 import eu.kanade.tachiyomi.data.track.Tracker
 
-data class EntryTrackingSummary(
+internal data class EntryTrackingSummary(
     val trackingCount: Int,
     val hasLoggedInTrackers: Boolean,
 )
 
-object EntryTrackingSummaryObserver {
+internal object EntryTrackingSummaryObserver {
     fun <T> summarize(
         tracks: List<T>,
         loggedInTrackers: List<Tracker>,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/entries/manga/MangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/entries/manga/MangaScreenModel.kt
@@ -468,7 +468,7 @@ class MangaScreenModel(
      * @param categories the selected categories.
      */
     private fun moveMangaToCategories(categories: List<Category>) {
-        val categoryIds = EntryCategoryActions.toCategoryIds(categories)
+        val categoryIds = categories.map { it.id }
         moveMangaToCategory(categoryIds)
     }
 
@@ -484,7 +484,7 @@ class MangaScreenModel(
      * @param category the selected category, or null for default category.
      */
     private fun moveMangaToCategory(category: Category?) {
-        moveMangaToCategories(EntryCategoryActions.toCategoryList(category))
+        moveMangaToCategories(listOfNotNull(category))
     }
 
     // Manga info - end
@@ -1141,7 +1141,7 @@ class MangaScreenModel(
                     itemId = { it.id },
                     itemNumber = { it.chapter.chapterNumber },
                     calculateGap = { higher, lower -> calculateChapterGap(higher.chapter, lower.chapter) },
-                    mapItem = { it as ChapterList },
+                    mapItem = { it },
                     mapMissing = { id, count -> ChapterList.MissingCount(id = id, count = count) },
                 )
             }

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/entries/common/EntryCommonHelpersTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/entries/common/EntryCommonHelpersTest.kt
@@ -2,6 +2,7 @@ package eu.kanade.tachiyomi.ui.entries.common
 
 import eu.kanade.tachiyomi.data.track.AnimeTracker
 import eu.kanade.tachiyomi.data.track.Tracker
+import io.mockk.mockk
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
@@ -156,7 +157,7 @@ class EntryCommonHelpersTest {
         override val id: Long,
     ) : Tracker {
         override val name: String = "test"
-        override val client: OkHttpClient = OkHttpClient()
+        override val client: OkHttpClient = mockk()
         override val supportsReadingDates: Boolean = false
         override val supportsPrivateTracking: Boolean = false
         override val isLoggedIn: Boolean = true


### PR DESCRIPTION
## Objective
Extract shared composition helpers from anime/manga entry ScreenModels to reduce duplicate logic while preserving behavior.

## Scope
- Added shared helpers under `ui/entries/common`:
  - `EntrySelectionController`
  - `EntryListGapSeparator`
  - `EntryCategoryActions`
  - `EntryTrackingSummaryObserver`
  - `EntryDownloadStateUpdater`
- Refactored both ScreenModels to use shared helpers:
  - `AnimeScreenModel`
  - `MangaScreenModel`
- Added helper parity tests:
  - `EntryCommonHelpersTest`

## Out of Scope
- No full generic `EntryScreenModel<T>` rewrite
- No broad `Entry` naming changes
- No DB/schema/API changes

## Verification
- [x] `./gradlew spotlessCheck`
- [x] `./gradlew :app:compileDebugKotlin`
- [x] `./gradlew :app:testDebugUnitTest`
- [x] `./gradlew :app:assembleDebug`

## Risk
- **Tier:** T2
- **Assessment:** Medium-low. Multi-file refactor, but logic extraction is callback-based and preserves existing behavior paths.

## Rollback
- Revert this PR commit to restore inlined logic in both ScreenModels.

Closes #264