### PR TITLE
docs: document ReaderChapterListManager fetchChapters ANR context (R246)

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderChapterListManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderChapterListManager.kt
@@ -98,6 +98,13 @@ internal class ReaderChapterListManager(
 
     // Private helper methods
 
+    /**
+     * Fetches chapters asynchronously from the DB layer.
+     *
+     * This path is suspend-only because reader initialization runs from UI-driven flows in
+     * [ReaderActivity] and [ReaderViewModel]. Keeping this as a suspend call avoids reintroducing
+     * blocking bridges (for example, runBlocking) that previously caused startup/read-open ANR risk.
+     */
     private suspend fun fetchChapters(manga: Manga): List<Chapter> {
         return getChaptersByMangaId.await(manga.id, applyScanlatorFilter = true)
     }


### PR DESCRIPTION
## Objective
Document why `ReaderChapterListManager.fetchChapters` must remain suspend/non-blocking to avoid ANR regressions in reader initialization flows.

## Scope
- ticket: R246
- single-file docs update in `ReaderChapterListManager`
- no behavior or API changes

## Verification
- `./gradlew spotlessCheck`
- `./gradlew :app:compileDebugKotlin`
- pre-push hook reran and passed `spotlessCheck` + `:app:compileDebugKotlin`

## Risk
- low (documentation-only change)

## Rollback
- revert commit `a3eb2f664`

Closes #246
