### PR TITLE
fix: make getManifestUrl private and document placeholder cert fingerprints (R236)

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/feature/novel/LightNovelPluginManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/feature/novel/LightNovelPluginManager.kt
@@ -147,7 +147,7 @@ class LightNovelPluginManager(
         context.startActivity(intent)
     }
 
-    fun getManifestUrl(channel: String): String {
+    private fun getManifestUrl(channel: String): String {
         return when (channel) {
             NovelFeaturePreferences.CHANNEL_BETA -> BETA_MANIFEST_URL
             else -> STABLE_MANIFEST_URL
@@ -286,7 +286,9 @@ class LightNovelPluginManager(
         private const val BETA_MANIFEST_URL =
             "https://github.com/ryacub/rayniyomi/releases/download/plugin-beta/lightnovel-plugin-manifest.json"
 
-        // Primary + rotation cert fingerprints for the optional Light Novel plugin.
+        // TODO(R236-B): Replace with real SHA-256 certificate fingerprints before enabling in release.
+        // These placeholder values keep the gate fail-closed; plugin installs are blocked in release
+        // builds by ENABLE_PLUGIN_INSTALL_FOR_RELEASE = false until real certs are pinned.
         private val TRUSTED_PLUGIN_CERT_SHA256 = setOf(
             "7b7f000000000000000000000000000000000000000000000000000000000000",
             "8c8f000000000000000000000000000000000000000000000000000000000000",


### PR DESCRIPTION
## Objective
Follow-up to #272. One minor fix pushed to the R236-A branch after that PR was squash-merged — `getManifestUrl` was left public and the placeholder cert fingerprints lacked documentation.

Closes #236

## Scope
- Made `LightNovelPluginManager.getManifestUrl` `private` (was inadvertently public; only called internally by `fetchManifest`).
- Added `TODO(R236-B)` comment on `TRUSTED_PLUGIN_CERT_SHA256` explaining that placeholder fingerprints are intentional: plugin installs are blocked in release by `ENABLE_PLUGIN_INSTALL_FOR_RELEASE = false` until real cert fingerprints are pinned in a follow-up.

## Non-goals
- Not replacing the placeholder certificate fingerprints (tracked as R236-B).
- Not changing plugin install behaviour.

## Files Changed
- `app/src/main/java/eu/kanade/tachiyomi/feature/novel/LightNovelPluginManager.kt`

## Verification
- `./gradlew :app:testDebugUnitTest --tests "eu.kanade.tachiyomi.feature.novel.LightNovelFeatureGateTest"` — 3/3 pass
- `./gradlew spotlessCheck` — clean
- `./gradlew :app:compileDebugKotlin` — clean

## Risk
T1: No behaviour change. Visibility narrowing on an internal-only method and a comment addition only.

## Rollback
Revert commit `b8a439366` — removes the `private` modifier and comment. No functional impact either way.