### PR TITLE
feat: light novel plugin MVP APK module (R276)

### DIFF
--- a/lightnovel-plugin/build.gradle.kts
+++ b/lightnovel-plugin/build.gradle.kts
@@ -1,0 +1,32 @@
+plugins {
+    id("mihon.android.application")
+    kotlin("plugin.serialization")
+}
+
+android {
+    namespace = "xyz.rayniyomi.plugin.lightnovel"
+
+    defaultConfig {
+        applicationId = "xyz.rayniyomi.plugin.lightnovel"
+        versionCode = 1
+        versionName = "0.1.0"
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    buildFeatures {
+        viewBinding = true
+    }
+}
+
+dependencies {
+    implementation(androidx.appcompat)
+    implementation(androidx.corektx)
+    implementation(androidx.bundles.lifecycle)
+
+    implementation(libs.jsoup)
+    implementation(kotlinx.serialization.json)
+    implementation(kotlinx.coroutines.android)
+
+    testImplementation(libs.bundles.test)
+}

--- a/lightnovel-plugin/src/main/AndroidManifest.xml
+++ b/lightnovel-plugin/src/main/AndroidManifest.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application
+        android:allowBackup="true"
+        android:icon="@drawable/ic_lightnovel_plugin"
+        android:label="@string/app_name"
+        android:roundIcon="@drawable/ic_lightnovel_plugin"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.AppCompat.DayNight.NoActionBar">
+
+        <meta-data
+            android:name="rayniyomi.plugin.api_version"
+            android:value="1" />
+        <meta-data
+            android:name="rayniyomi.plugin.min_host_version"
+            android:value="131" />
+
+        <activity
+            android:name=".ReaderActivity"
+            android:exported="false" />
+
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/lightnovel-plugin/src/main/java/xyz/rayniyomi/plugin/lightnovel/MainActivity.kt
+++ b/lightnovel-plugin/src/main/java/xyz/rayniyomi/plugin/lightnovel/MainActivity.kt
@@ -1,0 +1,86 @@
+package xyz.rayniyomi.plugin.lightnovel
+
+import android.content.Intent
+import android.os.Bundle
+import android.widget.ArrayAdapter
+import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import xyz.rayniyomi.plugin.lightnovel.data.NovelBook
+import xyz.rayniyomi.plugin.lightnovel.data.NovelStorage
+import xyz.rayniyomi.plugin.lightnovel.databinding.ActivityMainBinding
+
+class MainActivity : AppCompatActivity() {
+    private lateinit var binding: ActivityMainBinding
+    private lateinit var storage: NovelStorage
+    private lateinit var listAdapter: ArrayAdapter<String>
+
+    private val books = mutableListOf<NovelBook>()
+
+    private val importLauncher = registerForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
+        if (uri == null) return@registerForActivityResult
+
+        lifecycleScope.launch {
+            runCatching {
+                contentResolver.takePersistableUriPermission(
+                    uri,
+                    Intent.FLAG_GRANT_READ_URI_PERMISSION,
+                )
+            }
+
+            val result = withContext(Dispatchers.IO) {
+                runCatching { storage.importEpub(uri) }
+            }
+
+            if (result.isFailure) {
+                Toast.makeText(
+                    this@MainActivity,
+                    getString(R.string.import_failed),
+                    Toast.LENGTH_SHORT,
+                ).show()
+            }
+            refreshBooks()
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityMainBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        storage = NovelStorage(this)
+
+        listAdapter = ArrayAdapter(this, android.R.layout.simple_list_item_1, mutableListOf())
+        binding.booksList.adapter = listAdapter
+        binding.booksList.emptyView = binding.emptyText
+
+        binding.importEpubButton.setOnClickListener {
+            importLauncher.launch(arrayOf("application/epub+zip", "application/octet-stream"))
+        }
+
+        binding.booksList.setOnItemClickListener { _, _, position, _ ->
+            val book = books.getOrNull(position) ?: return@setOnItemClickListener
+            val intent = Intent(this, ReaderActivity::class.java)
+                .putExtra(ReaderActivity.EXTRA_BOOK_ID, book.id)
+            startActivity(intent)
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        refreshBooks()
+    }
+
+    private fun refreshBooks() {
+        books.clear()
+        books.addAll(storage.listBooks())
+
+        listAdapter.clear()
+        listAdapter.addAll(books.map { it.title })
+        listAdapter.notifyDataSetChanged()
+    }
+}

--- a/lightnovel-plugin/src/main/java/xyz/rayniyomi/plugin/lightnovel/ReaderActivity.kt
+++ b/lightnovel-plugin/src/main/java/xyz/rayniyomi/plugin/lightnovel/ReaderActivity.kt
@@ -1,0 +1,155 @@
+package xyz.rayniyomi.plugin.lightnovel
+
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import androidx.appcompat.app.AppCompatActivity
+import xyz.rayniyomi.plugin.lightnovel.data.NovelBook
+import xyz.rayniyomi.plugin.lightnovel.data.NovelStorage
+import xyz.rayniyomi.plugin.lightnovel.databinding.ActivityReaderBinding
+import xyz.rayniyomi.plugin.lightnovel.epub.EpubContent
+import xyz.rayniyomi.plugin.lightnovel.epub.EpubTextExtractor
+
+class ReaderActivity : AppCompatActivity() {
+    private lateinit var binding: ActivityReaderBinding
+    private lateinit var storage: NovelStorage
+    private lateinit var book: NovelBook
+    private lateinit var content: EpubContent
+
+    private var currentChapterIndex = 0
+
+    private val saveHandler = Handler(Looper.getMainLooper())
+    private val saveRunnable = Runnable { persistProgress() }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityReaderBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        storage = NovelStorage(this)
+
+        val bookId = intent.getStringExtra(EXTRA_BOOK_ID)
+            ?: run {
+                finish()
+                return
+            }
+
+        book = storage.getBook(bookId)
+            ?: run {
+                finish()
+                return
+            }
+
+        val bookFile = storage.getBookFile(book)
+        content = runCatching { EpubTextExtractor.parse(bookFile) }
+            .getOrElse {
+                finish()
+                return
+            }
+
+        if (content.chapters.isEmpty()) {
+            finish()
+            return
+        }
+
+        currentChapterIndex = book.lastReadChapter.coerceIn(0, content.chapters.lastIndex)
+
+        binding.previousButton.setOnClickListener {
+            if (currentChapterIndex > 0) {
+                persistProgress()
+                currentChapterIndex -= 1
+                renderChapter(restoreSavedOffset = false)
+            }
+        }
+
+        binding.nextButton.setOnClickListener {
+            if (currentChapterIndex < content.chapters.lastIndex) {
+                persistProgress()
+                currentChapterIndex += 1
+                renderChapter(restoreSavedOffset = false)
+            }
+        }
+
+        binding.chapterScroll.setOnScrollChangeListener { _, _, _, _, _ ->
+            schedulePersist()
+        }
+
+        renderChapter(restoreSavedOffset = true)
+    }
+
+    override fun onPause() {
+        super.onPause()
+        persistProgress()
+    }
+
+    private fun renderChapter(restoreSavedOffset: Boolean) {
+        val chapter = content.chapters[currentChapterIndex]
+
+        binding.bookTitle.text = content.title
+        binding.chapterIndicator.text = getString(
+            R.string.chapter_format,
+            currentChapterIndex + 1,
+            content.chapters.size,
+        )
+        binding.chapterText.text = chapter.text
+
+        binding.previousButton.isEnabled = currentChapterIndex > 0
+        binding.nextButton.isEnabled = currentChapterIndex < content.chapters.lastIndex
+
+        val restoreOffset = if (restoreSavedOffset && currentChapterIndex == book.lastReadChapter) {
+            book.lastReadOffset
+        } else {
+            0
+        }
+
+        binding.chapterScroll.post {
+            val maxScroll = maxScrollY()
+            if (maxScroll <= 0) {
+                return@post
+            }
+            val chapterLength = chapter.text.length.coerceAtLeast(1)
+            val ratio = restoreOffset.toFloat() / chapterLength
+            val targetY = (ratio * maxScroll).toInt().coerceIn(0, maxScroll)
+            binding.chapterScroll.scrollTo(0, targetY)
+        }
+    }
+
+    private fun schedulePersist() {
+        saveHandler.removeCallbacks(saveRunnable)
+        saveHandler.postDelayed(saveRunnable, 250)
+    }
+
+    private fun persistProgress() {
+        saveHandler.removeCallbacks(saveRunnable)
+
+        val chapterText = binding.chapterText.text?.toString().orEmpty()
+        if (chapterText.isEmpty()) {
+            return
+        }
+
+        val maxScroll = maxScrollY().coerceAtLeast(1)
+        val currentScroll = binding.chapterScroll.scrollY.coerceIn(0, maxScroll)
+        val ratio = currentScroll.toFloat() / maxScroll.toFloat()
+        val charOffset = (ratio * chapterText.length).toInt().coerceIn(0, chapterText.length)
+
+        storage.updateProgress(
+            bookId = book.id,
+            chapterIndex = currentChapterIndex,
+            charOffset = charOffset,
+        )
+
+        book = book.copy(
+            lastReadChapter = currentChapterIndex,
+            lastReadOffset = charOffset,
+        )
+    }
+
+    private fun maxScrollY(): Int {
+        val child = binding.chapterScroll.getChildAt(0) ?: return 0
+        return (child.height - binding.chapterScroll.height).coerceAtLeast(0)
+    }
+
+    companion object {
+        const val EXTRA_BOOK_ID = "extra_book_id"
+    }
+}

--- a/lightnovel-plugin/src/main/java/xyz/rayniyomi/plugin/lightnovel/data/NovelModels.kt
+++ b/lightnovel-plugin/src/main/java/xyz/rayniyomi/plugin/lightnovel/data/NovelModels.kt
@@ -1,0 +1,18 @@
+package xyz.rayniyomi.plugin.lightnovel.data
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class NovelBook(
+    val id: String,
+    val title: String,
+    val epubFileName: String,
+    val lastReadChapter: Int = 0,
+    val lastReadOffset: Int = 0,
+    val updatedAt: Long = System.currentTimeMillis(),
+)
+
+@Serializable
+data class NovelLibrary(
+    val books: List<NovelBook> = emptyList(),
+)

--- a/lightnovel-plugin/src/main/java/xyz/rayniyomi/plugin/lightnovel/data/NovelStorage.kt
+++ b/lightnovel-plugin/src/main/java/xyz/rayniyomi/plugin/lightnovel/data/NovelStorage.kt
@@ -1,0 +1,100 @@
+package xyz.rayniyomi.plugin.lightnovel.data
+
+import android.content.Context
+import android.net.Uri
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import xyz.rayniyomi.plugin.lightnovel.epub.EpubTextExtractor
+import java.io.File
+
+class NovelStorage(private val context: Context) {
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+        prettyPrint = true
+    }
+
+    private val rootDir = File(context.filesDir, ROOT_DIR_NAME).also { it.mkdirs() }
+    private val booksDir = File(rootDir, BOOKS_DIR_NAME).also { it.mkdirs() }
+    private val libraryFile = File(rootDir, LIBRARY_FILE_NAME)
+
+    @Synchronized
+    fun listBooks(): List<NovelBook> {
+        return readLibrary().books.sortedByDescending { it.updatedAt }
+    }
+
+    @Synchronized
+    fun getBook(bookId: String): NovelBook? {
+        return readLibrary().books.firstOrNull { it.id == bookId }
+    }
+
+    @Synchronized
+    fun getBookFile(book: NovelBook): File {
+        return File(booksDir, book.epubFileName)
+    }
+
+    @Synchronized
+    fun importEpub(uri: Uri): NovelBook {
+        val id = System.currentTimeMillis().toString()
+        val targetFile = File(booksDir, "$id.epub")
+
+        context.contentResolver.openInputStream(uri).use { input ->
+            requireNotNull(input) { "Unable to open EPUB input stream" }
+            targetFile.outputStream().use { output ->
+                input.copyTo(output)
+            }
+        }
+
+        val parsedTitle = runCatching { EpubTextExtractor.parse(targetFile).title }.getOrNull()
+        val title = parsedTitle?.takeIf { it.isNotBlank() } ?: targetFile.nameWithoutExtension
+
+        val newBook = NovelBook(
+            id = id,
+            title = title,
+            epubFileName = targetFile.name,
+            lastReadChapter = 0,
+            lastReadOffset = 0,
+            updatedAt = System.currentTimeMillis(),
+        )
+
+        val current = readLibrary().books.toMutableList()
+        current.add(newBook)
+        writeLibrary(NovelLibrary(current))
+        return newBook
+    }
+
+    @Synchronized
+    fun updateProgress(bookId: String, chapterIndex: Int, charOffset: Int) {
+        val updated = readLibrary().books.map { book ->
+            if (book.id == bookId) {
+                book.copy(
+                    lastReadChapter = chapterIndex.coerceAtLeast(0),
+                    lastReadOffset = charOffset.coerceAtLeast(0),
+                    updatedAt = System.currentTimeMillis(),
+                )
+            } else {
+                book
+            }
+        }
+        writeLibrary(NovelLibrary(updated))
+    }
+
+    private fun readLibrary(): NovelLibrary {
+        if (!libraryFile.exists()) {
+            return NovelLibrary()
+        }
+        return runCatching {
+            json.decodeFromString<NovelLibrary>(libraryFile.readText())
+        }.getOrElse { NovelLibrary() }
+    }
+
+    private fun writeLibrary(library: NovelLibrary) {
+        libraryFile.writeText(json.encodeToString(library))
+    }
+
+    private companion object {
+        const val ROOT_DIR_NAME = "light_novel_plugin"
+        const val BOOKS_DIR_NAME = "books"
+        const val LIBRARY_FILE_NAME = "library.json"
+    }
+}

--- a/lightnovel-plugin/src/main/java/xyz/rayniyomi/plugin/lightnovel/epub/EpubTextExtractor.kt
+++ b/lightnovel-plugin/src/main/java/xyz/rayniyomi/plugin/lightnovel/epub/EpubTextExtractor.kt
@@ -1,0 +1,105 @@
+package xyz.rayniyomi.plugin.lightnovel.epub
+
+import org.jsoup.Jsoup
+import org.jsoup.parser.Parser
+import java.io.File
+import java.nio.charset.StandardCharsets
+import java.util.zip.ZipFile
+
+data class EpubChapter(
+    val title: String,
+    val text: String,
+)
+
+data class EpubContent(
+    val title: String,
+    val chapters: List<EpubChapter>,
+)
+
+object EpubTextExtractor {
+    fun parse(file: File): EpubContent {
+        ZipFile(file).use { zip ->
+            val packagePath = findPackagePath(zip)
+            val opfDoc = parseXml(zip, packagePath)
+            val epubTitle = findBookTitle(opfDoc) ?: file.nameWithoutExtension
+            val chapterPaths = findChapterPaths(opfDoc)
+            val opfBasePath = packagePath.substringBeforeLast('/', "")
+
+            val chapters = chapterPaths.mapIndexedNotNull { index, href ->
+                val resolvedPath = resolvePath(opfBasePath, href)
+                val htmlEntry = zip.getEntry(resolvedPath) ?: return@mapIndexedNotNull null
+                val chapterDoc = htmlEntry.getInputStream(zip).use {
+                    Jsoup.parse(it.readBytes().toString(StandardCharsets.UTF_8), "", Parser.xmlParser())
+                }
+                val chapterText = chapterDoc.body()?.text()?.trim().orEmpty()
+                if (chapterText.isBlank()) {
+                    null
+                } else {
+                    val chapterTitle = chapterDoc.title().ifBlank { "Chapter ${index + 1}" }
+                    EpubChapter(title = chapterTitle, text = chapterText)
+                }
+            }
+
+            return EpubContent(
+                title = epubTitle,
+                chapters = chapters,
+            )
+        }
+    }
+
+    private fun findPackagePath(zip: ZipFile): String {
+        val container = zip.getEntry("META-INF/container.xml")
+            ?: return "OEBPS/content.opf"
+        val doc = container.getInputStream(zip).use {
+            Jsoup.parse(it.readBytes().toString(StandardCharsets.UTF_8), "", Parser.xmlParser())
+        }
+        return doc.selectFirst("rootfile")?.attr("full-path")
+            ?.takeIf { it.isNotBlank() }
+            ?: "OEBPS/content.opf"
+    }
+
+    private fun parseXml(zip: ZipFile, entryPath: String) =
+        zip.getEntry(entryPath)?.getInputStream(zip)?.use {
+            Jsoup.parse(it.readBytes().toString(StandardCharsets.UTF_8), "", Parser.xmlParser())
+        } ?: error("Missing OPF package document: $entryPath")
+
+    private fun findBookTitle(opfDoc: org.jsoup.nodes.Document): String? {
+        return opfDoc.select("metadata > *")
+            .firstOrNull { it.tagName().endsWith("title") }
+            ?.text()
+            ?.trim()
+            ?.takeIf { it.isNotBlank() }
+    }
+
+    private fun findChapterPaths(opfDoc: org.jsoup.nodes.Document): List<String> {
+        val manifest = opfDoc.select("manifest > item")
+            .associateBy(
+                keySelector = { it.attr("id") },
+                valueTransform = { it.attr("href") },
+            )
+        val spine = opfDoc.select("spine > itemref")
+            .map { it.attr("idref") }
+        return spine.mapNotNull { manifest[it] }
+    }
+
+    private fun resolvePath(basePath: String, href: String): String {
+        if (href.startsWith('/')) {
+            return href.removePrefix("/")
+        }
+
+        val baseParts = basePath.split('/').filter { it.isNotBlank() }.toMutableList()
+        val pathParts = href.split('/')
+
+        pathParts.forEach { part ->
+            when (part) {
+                "", "." -> Unit
+                ".." -> if (baseParts.isNotEmpty()) baseParts.removeAt(baseParts.lastIndex)
+                else -> baseParts.add(part)
+            }
+        }
+
+        return baseParts.joinToString("/")
+    }
+
+    private fun java.util.zip.ZipEntry.getInputStream(zip: ZipFile) = zip.getInputStream(this)
+}

--- a/lightnovel-plugin/src/main/res/drawable/ic_lightnovel_plugin.xml
+++ b/lightnovel-plugin/src/main/res/drawable/ic_lightnovel_plugin.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path
+        android:fillColor="#1B5E20"
+        android:pathData="M0,0h108v108h-108z" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M22,28c0,-5.5 4.5,-10 10,-10h44c5.5,0 10,4.5 10,10v52c0,5.5 -4.5,10 -10,10h-44c-5.5,0 -10,-4.5 -10,-10z" />
+    <path
+        android:fillColor="#1B5E20"
+        android:pathData="M33,30h42v5h-42zM33,41h42v5h-42zM33,52h42v5h-42zM33,63h29v5h-29z" />
+</vector>

--- a/lightnovel-plugin/src/main/res/layout/activity_main.xml
+++ b/lightnovel-plugin/src/main/res/layout/activity_main.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <Button
+        android:id="@+id/importEpubButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/import_epub" />
+
+    <ListView
+        android:id="@+id/booksList"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_marginTop="12dp"
+        android:layout_weight="1" />
+
+    <TextView
+        android:id="@+id/emptyText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:padding="12dp"
+        android:text="@string/no_books"
+        android:visibility="gone" />
+
+</LinearLayout>

--- a/lightnovel-plugin/src/main/res/layout/activity_reader.xml
+++ b/lightnovel-plugin/src/main/res/layout/activity_reader.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="12dp">
+
+    <TextView
+        android:id="@+id/bookTitle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textStyle="bold"
+        android:textSize="18sp" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
+
+        <Button
+            android:id="@+id/previousButton"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/previous_chapter" />
+
+        <TextView
+            android:id="@+id/chapterIndicator"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="12dp" />
+
+        <Button
+            android:id="@+id/nextButton"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/next_chapter" />
+    </LinearLayout>
+
+    <ScrollView
+        android:id="@+id/chapterScroll"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_marginTop="8dp"
+        android:layout_weight="1"
+        android:fillViewport="true">
+
+        <TextView
+            android:id="@+id/chapterText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:lineSpacingExtra="4dp"
+            android:textSize="17sp" />
+    </ScrollView>
+
+</LinearLayout>

--- a/lightnovel-plugin/src/main/res/values/strings.xml
+++ b/lightnovel-plugin/src/main/res/values/strings.xml
@@ -1,0 +1,9 @@
+<resources>
+    <string name="app_name">Light Novel Plugin</string>
+    <string name="import_epub">Import EPUB</string>
+    <string name="import_failed">Failed to import EPUB</string>
+    <string name="no_books">No imported light novels yet.</string>
+    <string name="chapter_format">Chapter %1$d / %2$d</string>
+    <string name="previous_chapter">Previous</string>
+    <string name="next_chapter">Next</string>
+</resources>

--- a/lightnovel-plugin/src/test/java/xyz/rayniyomi/plugin/lightnovel/epub/EpubTextExtractorTest.kt
+++ b/lightnovel-plugin/src/test/java/xyz/rayniyomi/plugin/lightnovel/epub/EpubTextExtractorTest.kt
@@ -1,0 +1,76 @@
+package xyz.rayniyomi.plugin.lightnovel.epub
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+class EpubTextExtractorTest {
+
+    @Test
+    fun `parse extracts title and chapter text`() {
+        val epub = createTestEpub()
+
+        val content = EpubTextExtractor.parse(epub)
+
+        assertEquals("Test Novel", content.title)
+        assertEquals(2, content.chapters.size)
+        assertTrue(content.chapters[0].text.contains("First chapter text"))
+        assertTrue(content.chapters[1].text.contains("Second chapter text"))
+    }
+
+    private fun createTestEpub(): File {
+        val epub = File.createTempFile("novel", ".epub")
+        ZipOutputStream(epub.outputStream()).use { zip ->
+            zip.putText("META-INF/container.xml", CONTAINER_XML)
+            zip.putText("OEBPS/content.opf", OPF_XML)
+            zip.putText("OEBPS/ch1.xhtml", CHAPTER_1)
+            zip.putText("OEBPS/ch2.xhtml", CHAPTER_2)
+        }
+        return epub
+    }
+
+    private fun ZipOutputStream.putText(path: String, text: String) {
+        putNextEntry(ZipEntry(path))
+        write(text.toByteArray())
+        closeEntry()
+    }
+
+    private companion object {
+        const val CONTAINER_XML = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+              <rootfiles>
+                <rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/>
+              </rootfiles>
+            </container>
+        """
+
+        const val OPF_XML = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <package xmlns="http://www.idpf.org/2007/opf" version="2.0">
+              <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+                <dc:title>Test Novel</dc:title>
+              </metadata>
+              <manifest>
+                <item id="ch1" href="ch1.xhtml" media-type="application/xhtml+xml"/>
+                <item id="ch2" href="ch2.xhtml" media-type="application/xhtml+xml"/>
+              </manifest>
+              <spine>
+                <itemref idref="ch1"/>
+                <itemref idref="ch2"/>
+              </spine>
+            </package>
+        """
+
+        const val CHAPTER_1 = """
+            <html><head><title>One</title></head><body><p>First chapter text</p></body></html>
+        """
+
+        const val CHAPTER_2 = """
+            <html><head><title>Two</title></head><body><p>Second chapter text</p></body></html>
+        """
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -58,3 +58,5 @@ include(":presentation-core")
 include(":presentation-widget")
 include(":source-api")
 include(":source-local")
+
+include(":lightnovel-plugin")


### PR DESCRIPTION
## Ticket
- ID: R236-E
- Priority: P1
- Risk Tier: T3
- GitHub Issue: Closes #276

## Objective
- Deliver the Light Novel plugin MVP as an optional APK artifact so host-side feature gating can activate novel reading only when plugin is installed.

## Scope
- Add new `:lightnovel-plugin` Android application module (`xyz.rayniyomi.plugin.lightnovel`).
- Add plugin metadata expected by host plugin manager (`api_version`, `min_host_version`).
- Implement EPUB import flow and local plugin-side storage.
- Implement basic local library listing UI.
- Implement reader screen with chapter navigation and character-offset resume persistence.
- Add EPUB parser for title/chapter extraction from OPF/spine/XHTML.
- Add unit test coverage for EPUB extraction path.

## Non-goals
- Host-to-plugin IPC contract wiring and host UI integration (covered in later tickets).
- Network catalog/discovery for novels.
- Backup/restore and advanced reader features.

## Files Changed
- `settings.gradle.kts`
- `lightnovel-plugin/build.gradle.kts`
- `lightnovel-plugin/src/main/AndroidManifest.xml`
- `lightnovel-plugin/src/main/java/xyz/rayniyomi/plugin/lightnovel/*`
- `lightnovel-plugin/src/main/java/xyz/rayniyomi/plugin/lightnovel/data/*`
- `lightnovel-plugin/src/main/java/xyz/rayniyomi/plugin/lightnovel/epub/*`
- `lightnovel-plugin/src/main/res/*`
- `lightnovel-plugin/src/test/java/xyz/rayniyomi/plugin/lightnovel/epub/EpubTextExtractorTest.kt`

## Verification
- Commands run:
  - `./gradlew spotlessCheck`
  - `./gradlew :app:compileDebugKotlin`
  - `./gradlew :lightnovel-plugin:testDebugUnitTest :lightnovel-plugin:compileDebugKotlin`
- Results:
  - All commands passed.
  - Unit test passed: `EpubTextExtractorTest.parse extracts title and chapter text()`.
- Not tested:
  - Device/emulator end-to-end manual install/read flow.

## Risk
- New module introduces additional build output and release artifact to manage.
- EPUB parsing may fail on malformed/edge-case EPUB structures.
- Resume logic is scroll-ratio based and can drift with dynamic text/layout changes.
- Mitigations: plugin scoped storage, graceful parse failures, targeted unit test on parser path.

## SLO Impact
- No core app runtime SLO impact while plugin is not installed/enabled.
- Plugin runtime impacts are isolated to plugin process/UI.

## Rollback
- Revert this PR to remove `:lightnovel-plugin` from build graph.
- Keep host feature gate disabled (`Enable Light Novels` off / host gate false) to prevent activation.

## Release Notes
- Added MVP Light Novel plugin APK module with local EPUB import, chapter reading, and resume position persistence.

## Checklist
- [x] Naming conventions followed (use "Rayniyomi" in user-facing text, see [naming conventions](../docs/governance/naming-conventions.md))
- [x] Branch rebased on latest main and verification re-run (see [rebase policy](../docs/governance/agent-workflow.md#rebase-before-merge-policy-r45))
- [x] New coroutine scopes have documented owner and cancellation path
- [x] No new `runBlocking` on UI/main thread paths

## Definition of Done (DoD)
- [x] Acceptance criteria met and non-goals respected
- [x] Verification matrix completed (Risk Tier: T3)
- [x] Self-review completed
- [x] Rebased on latest `main` and revalidated (mandatory for merge)
- [ ] Sprint board updated (branch, commit, checks, PR link)
- [x] Release notes drafted (if applicable)

## Fork Compliance Checklist (for new forks only)
If you are creating a new fork of this project, ensure the following:
- [ ] **App Identity**: Changed app name from "Aniyomi" to your fork name
- [ ] **App Icon**: Replaced launcher icon assets with fork-specific icons
- [ ] **Application ID**: Changed `applicationId` in `app/build.gradle.kts` from `xyz.rayniyomi` to your unique ID
- [ ] **Update Checker**: Configured `AppUpdateChecker.kt` to point to your fork's repository
- [ ] **Analytics**: Either disabled Firebase Analytics or configured with your own `google-services.json`
- [ ] **Crash Reporting**: Either disabled ACRA crash reporting or configured with your own endpoint credentials

See [CONTRIBUTING.md](../CONTRIBUTING.md) Forks section for details.
