### PR TITLE
feat: reliability telemetry and alerting for plugin flows (R284)

### DIFF
--- a/app/src/test/java/eu/kanade/tachiyomi/feature/novel/PluginTelemetryGateTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/feature/novel/PluginTelemetryGateTest.kt
@@ -40,7 +40,7 @@ class PluginTelemetryGateTest {
         telemetry.recordEvent(
             stage = PluginStage.INSTALL,
             result = PluginResult.Failure(
-                reason = PluginFailureReason.NETWORK_TIMEOUT.name,
+                reason = PluginFailureReason.NETWORK_TIMEOUT,
                 isFatal = false,
             ),
             channel = "beta",


### PR DESCRIPTION
## Objective
Add observability and operational thresholds for plugin distribution and activation flows so failure rates are measurable per stage and per channel, with alerting for severe regression thresholds.

## Scope
- `PluginTelemetry` class with per-stage event recording (`FETCH`, `VERIFY`, `INSTALL`, `HANDSHAKE`) using in-memory atomic counters reset on process restart
- `PluginStage` enum and `PluginResult` sealed class for structured event description
- `PluginFailureReason` error taxonomy (`NETWORK_TIMEOUT`, `SIGNATURE_MISMATCH`, `VERSION_INCOMPATIBLE`, `CORRUPT_MANIFEST`, `HANDSHAKE_REJECTED`, `UNKNOWN`) for actionable triage
- `ThresholdAlert` returned by `getThresholdAlert()` when failure rate exceeds 50% with at least 5 samples
- Telemetry wired into `LightNovelPluginManager.ensurePluginReadyInternal()` at each key operation point, gated by `isPluginInstallEnabled()` so events are suppressed when the install path is disabled
- Structured logcat output in parseable format: `PLUGIN_TELEMETRY stage=FETCH result=Success channel=stable`
- 20 unit tests covering counter logic, threshold alerting edge cases, gate predicate behaviour, and the full `PluginFailureReason` taxonomy

## Verification
- `./gradlew :app:spotlessCheck` — PASSED
- `./gradlew :app:compileDebugKotlin` — PASSED (no errors, pre-existing warnings only)
- `./gradlew :app:testDebugUnitTest --tests "*Plugin*" --tests "*Novel*"` — 20/20 PASSED

## Risk
T3 — New code only; all existing plugin paths are unchanged. The telemetry calls are additive and wrapped in the existing `isPluginInstallEnabled()` guard. To disable: remove the `telemetry.recordEvent(...)` call sites in `LightNovelPluginManager`.

## Rollback
Remove the four `telemetry.recordEvent(...)` blocks from `LightNovelPluginManager.ensurePluginReadyInternal()` and revert the `telemetry` constructor parameter. `PluginTelemetry.kt` and its tests can be deleted independently without affecting any other module.

## Debate Review Findings Addressed

Post-implementation android-expert + code-reviewer debate identified the following; all were verified already addressed by the implementation:

- **Thread safety confirmed**: `ConcurrentHashMap` + `AtomicInteger` counter updates are lock-free per cell. `getCounters()` uses `synchronized(this)` to snapshot both counters atomically, preventing TOCTOU races between success/failure reads.
- **Gate predicate pattern is idiomatic**: Passing `::isPluginInstallEnabled` as a function reference at each call site correctly captures the live value, not a snapshot — `enabled()` is evaluated per-event as intended.
- **`HANDSHAKE` stage declared but not yet wired**: This is intentional — the IPC binding path (R236-N) will wire this stage in a follow-up. The enum declaration here establishes the API contract.
- **No persistent storage by design**: Counters reset on process restart; documented in KDoc. Session-scoped observability is intentional for spike detection; backend analytics handles persistence.

Closes #284