### PR TITLE
fix: apply Google Services plugin only for release builds (hotfix)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,7 +11,9 @@ plugins {
     id("com.github.zellius.shortcut-helper")
     kotlin("plugin.serialization")
     alias(libs.plugins.aboutLibraries)
-    alias(libs.plugins.google.services)
+    // Only apply Google Services plugin for release builds (Firebase Analytics/Crashlytics)
+    // Debug builds don't need it and google-services.json only contains release package
+    alias(libs.plugins.google.services) apply false
 }
 
 shortcutHelper.setFilePath("./shortcuts.xml")
@@ -360,6 +362,12 @@ tasks.register("printLightNovelCompatibilitySnapshot") {
             """.trimIndent(),
         )
     }
+}
+
+// Apply Google Services plugin conditionally for non-debug builds
+// This allows debug builds to work without xyz.rayniyomi.dev in Firebase
+if (gradle.startParameter.taskNames.none { it.contains("Debug", ignoreCase = true) }) {
+    apply(plugin = "com.google.gms.google-services")
 }
 
 buildscript {


### PR DESCRIPTION
Fixes debug builds failing with Google Services plugin.

Debug builds don't need Firebase and google-services.json only contains xyz.rayniyomi (not xyz.rayniyomi.dev).

This allows local development without adding debug package to Firebase Console.