### PR TITLE
fix: apply Google Services plugin only for release builds (hotfix)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -11,7 +11,9 @@ plugins {
     id("com.github.zellius.shortcut-helper")
     kotlin("plugin.serialization")
     alias(libs.plugins.aboutLibraries)
-    alias(libs.plugins.google.services)
+    // Only apply Google Services plugin for release builds (Firebase Analytics/Crashlytics)
+    // Debug builds don't need it and google-services.json only contains release package
+    alias(libs.plugins.google.services) apply false
 }
 
 shortcutHelper.setFilePath("./shortcuts.xml")
@@ -360,6 +362,12 @@ tasks.register("printLightNovelCompatibilitySnapshot") {
             """.trimIndent(),
         )
     }
+}
+
+// Apply Google Services plugin conditionally for non-debug builds
+// This allows debug builds to work without xyz.rayniyomi.dev in Firebase
+if (gradle.startParameter.taskNames.none { it.contains("Debug", ignoreCase = true) }) {
+    apply(plugin = "com.google.gms.google-services")
 }
 
 buildscript {


### PR DESCRIPTION
## Objective
Fix debug builds failing with Google Services plugin by applying it only for release builds.

## Scope
- **app/build.gradle.kts**: Conditionally apply Google Services plugin based on task names
- Debug builds (xyz.rayniyomi.dev) work without Firebase configuration
- Release builds (xyz.rayniyomi) work with Firebase Analytics/Crashlytics

## Verification
- [x] Debug build passes locally
- [x] Release build passes locally and in CI (v1.0.0 tag)
- [x] v1.0.0 release published successfully

## Risk
Low — Already verified in v1.0.0 release build.

Part of v1.0.0 release cleanup.