### PR TITLE
fix: use VERSION_BUMP_TOKEN to push to protected branch (R330)

### DIFF
--- a/.github/workflows/auto_version_bump.yml
+++ b/.github/workflows/auto_version_bump.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: main
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.VERSION_BUMP_TOKEN }}
 
       - name: Set up git
         run: |


### PR DESCRIPTION
## Objective
Fix the auto version bump workflow to successfully push to the protected `main` branch.

## Scope
- **Changed:** `.github/workflows/auto_version_bump.yml` (1 line - authentication token)
- **Impact:** Auto version bump workflow authentication
- **No changes to:** Version bump logic, commit message format, or workflow triggers

## Problem
PR #331 merged successfully but the auto version bump workflow failed with:
```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - Changes must be made through a pull request.
```

**Root cause:** `GITHUB_TOKEN` cannot push to protected branches - this is a fundamental GitHub limitation.

## Solution
Use a Personal Access Token (PAT) with elevated permissions instead of `GITHUB_TOKEN`.

## Changes
- Updated `.github/workflows/auto_version_bump.yml`
- Changed `token: ${{ secrets.GITHUB_TOKEN }}` → `token: ${{ secrets.VERSION_BUMP_TOKEN }}`

## Verification
- [x] Workflow updated to use VERSION_BUMP_TOKEN
- [x] VERSION_BUMP_TOKEN created and added as secret (User completed)
- [ ] After merge, next PR will test the workflow

## Risk
T1 (Low) — Only changes authentication token, no functional changes to version bump logic

Closes #330