### PR TITLE
fix: resolve launch crash caused by unregistered OkHttpClient in DI (R336)

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/di/AppModule.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/di/AppModule.kt
@@ -224,7 +224,7 @@ class AppModule(val app: Application) : InjektModule {
         addSingletonFactory { DownloadStrategySelector(get()) }
         addSingletonFactory {
             MultiThreadDownloader(
-                client = get(),
+                client = get<NetworkHelper>().client,
                 stateStore = get(),
                 maxThreadsProvider = {
                     get<DownloadPreferences>().multiThreadConnections().get().coerceIn(1, 4)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -44,7 +44,7 @@ plugins {
 
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
-rootProject.name = "Aniyomi"
+rootProject.name = "Rayniyomi"
 include(":app")
 include(":core-metadata")
 include(":core:archive")


### PR DESCRIPTION
## Objective
Fix the P0 launch crash introduced in v1.0.0 where the app crashes immediately on open with no visible error.

## Root Cause
`MultiThreadDownloader` was registered in `AppModule` with `client = get()`, which attempted to resolve `OkHttpClient` directly from the Injekt DI container. `OkHttpClient` was never registered as a singleton — only `NetworkHelper` was. This caused an `InjektionException` on startup:

```
uy.kohesive.injekt.api.InjektionException: No registered instance or factory for type class okhttp3.OkHttpClient
  at AnimeDownloader.<init>(AnimeDownloader.kt:1004)
  at AnimeDownloadManager.<init>(AnimeDownloadManager.kt:69)
  at AppModule.registerInjectables$lambda$24(AppModule.kt:219)
```

The crash happened before Firebase could initialize, explaining why no data appeared in the Crashlytics dashboard.

## Scope
- `AppModule.kt` — pass `get<NetworkHelper>().client` explicitly instead of `get()`
- `settings.gradle.kts` — rename `rootProject.name` from `"Aniyomi"` to `"Rayniyomi"` (bundled housekeeping)

## Verification
- Pre-push hook: spotless ✅, `compileDebugKotlin` ✅
- Root cause confirmed via stack trace from device logcat
- Fix resolves the unregistered type by using the already-registered `NetworkHelper` singleton

## Risk
T1 — one-line DI fix in AppModule. No logic change, no new dependencies. `NetworkHelper.client` was always the intended OkHttpClient for downloads.

Closes #336