### PR TITLE
fix: register OkHttpClient as DI singleton to resolve launch crash (R336)

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/di/AppModule.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/di/AppModule.kt
@@ -203,6 +203,7 @@ class AppModule(val app: Application) : InjektModule {
         addSingletonFactory { AnimeBackgroundCache(app) }
 
         addSingletonFactory { NetworkHelper(app, get()) }
+        addSingletonFactory { get<NetworkHelper>().client }
         addSingletonFactory { JavaScriptEngine(app) }
 
         addSingletonFactory<MangaSourceManager> { AndroidMangaSourceManager(app, get(), get()) }


### PR DESCRIPTION
## Objective
Complete the fix for the P0 launch crash. PR #341 partially addressed this but the real root cause was OkHttpClient never being registered in the DI container.

## Root Cause
Any code calling \`get<OkHttpClient>()\` from Injekt would throw \`InjektionException\` because \`OkHttpClient\` was never registered as a singleton — only \`NetworkHelper\` was. The crash chain was:

\`\`\`
AppModule registers AnimeDownloadManager
  → AnimeDownloadManager creates AnimeDownloader
    → AnimeDownloader resolves MultiThreadDownloader via Injekt.get()
      → MultiThreadDownloader factory calls get<OkHttpClient>()
        → InjektionException: No registered instance or factory for OkHttpClient
\`\`\`

Firebase/Crashlytics never initialized because the crash happened during \`Application.onCreate()\`.

## Scope
- \`AppModule.kt\` — add one singleton registration: \`addSingletonFactory { get<NetworkHelper>().client }\`

## Verification
- Clean debug build installed and launched successfully on device ✅
- spotless ✅, compileDebugKotlin ✅, unit tests ✅, build ✅

## Risk
T1 — adds one singleton registration. No logic change. Follows existing DI patterns in AppModule.

Closes #336
Closes #337