### PR TITLE
fix: replace BitmapFactory with Icon.createWithResource in notifiers (R347)

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupNotifier.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupNotifier.kt
@@ -1,7 +1,7 @@
 package eu.kanade.tachiyomi.data.backup
 
 import android.content.Context
-import android.graphics.BitmapFactory
+import android.graphics.drawable.Icon
 import androidx.core.app.NotificationCompat
 import com.hippo.unifile.UniFile
 import eu.kanade.tachiyomi.R
@@ -26,7 +26,7 @@ class BackupNotifier(private val context: Context) {
     private val progressNotificationBuilder = context.notificationBuilder(
         Notifications.CHANNEL_BACKUP_RESTORE_PROGRESS,
     ) {
-        setLargeIcon(BitmapFactory.decodeResource(context.resources, R.mipmap.ic_launcher))
+        setLargeIcon(Icon.createWithResource(context, R.mipmap.ic_launcher))
         setSmallIcon(R.drawable.ic_ani)
         setAutoCancel(false)
         setOngoing(true)
@@ -36,7 +36,7 @@ class BackupNotifier(private val context: Context) {
     private val completeNotificationBuilder = context.notificationBuilder(
         Notifications.CHANNEL_BACKUP_RESTORE_COMPLETE,
     ) {
-        setLargeIcon(BitmapFactory.decodeResource(context.resources, R.mipmap.ic_launcher))
+        setLargeIcon(Icon.createWithResource(context, R.mipmap.ic_launcher))
         setSmallIcon(R.drawable.ic_ani)
         setAutoCancel(false)
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloadNotifier.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloadNotifier.kt
@@ -2,7 +2,7 @@ package eu.kanade.tachiyomi.data.download.anime
 
 import android.app.PendingIntent
 import android.content.Context
-import android.graphics.BitmapFactory
+import android.graphics.drawable.Icon
 import androidx.core.app.NotificationCompat
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.core.security.SecurityPreferences
@@ -31,7 +31,7 @@ internal class AnimeDownloadNotifier(private val context: Context) {
 
     private val progressNotificationBuilder by lazy {
         context.notificationBuilder(Notifications.CHANNEL_DOWNLOADER_PROGRESS) {
-            setLargeIcon(BitmapFactory.decodeResource(context.resources, R.mipmap.ic_launcher))
+            setLargeIcon(Icon.createWithResource(context, R.mipmap.ic_launcher))
             setAutoCancel(false)
             setOnlyAlertOnce(true)
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/manga/MangaDownloadNotifier.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/manga/MangaDownloadNotifier.kt
@@ -2,7 +2,7 @@ package eu.kanade.tachiyomi.data.download.manga
 
 import android.app.PendingIntent
 import android.content.Context
-import android.graphics.BitmapFactory
+import android.graphics.drawable.Icon
 import androidx.core.app.NotificationCompat
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.core.security.SecurityPreferences
@@ -31,7 +31,7 @@ internal class MangaDownloadNotifier(private val context: Context) {
 
     private val progressNotificationBuilder by lazy {
         context.notificationBuilder(Notifications.CHANNEL_DOWNLOADER_PROGRESS) {
-            setLargeIcon(BitmapFactory.decodeResource(context.resources, R.mipmap.ic_launcher))
+            setLargeIcon(Icon.createWithResource(context, R.mipmap.ic_launcher))
             setAutoCancel(false)
             setOnlyAlertOnce(true)
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/anime/AnimeLibraryUpdateNotifier.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/anime/AnimeLibraryUpdateNotifier.kt
@@ -5,7 +5,7 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
-import android.graphics.BitmapFactory
+import android.graphics.drawable.Icon
 import android.net.Uri
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
@@ -62,20 +62,13 @@ class AnimeLibraryUpdateNotifier(
     }
 
     /**
-     * Bitmap of the app for notifications.
-     */
-    private val notificationBitmap by lazy {
-        BitmapFactory.decodeResource(context.resources, R.mipmap.ic_launcher)
-    }
-
-    /**
      * Cached progress notification to avoid creating a lot.
      */
     val progressNotificationBuilder by lazy {
         context.notificationBuilder(Notifications.CHANNEL_LIBRARY_PROGRESS) {
             setContentTitle(context.stringResource(MR.strings.app_name))
             setSmallIcon(R.drawable.ic_refresh_24dp)
-            setLargeIcon(notificationBitmap)
+            setLargeIcon(Icon.createWithResource(context, R.mipmap.ic_launcher))
             setOngoing(true)
             setOnlyAlertOnce(true)
             addAction(
@@ -218,7 +211,7 @@ class AnimeLibraryUpdateNotifier(
             }
 
             setSmallIcon(R.drawable.ic_ani)
-            setLargeIcon(notificationBitmap)
+            setLargeIcon(Icon.createWithResource(context, R.mipmap.ic_launcher))
 
             setGroup(Notifications.GROUP_NEW_EPISODES)
             setGroupAlertBehavior(NotificationCompat.GROUP_ALERT_SUMMARY)


### PR DESCRIPTION
## Objective

Fix memory leak where notification builders were allocating ~50-100KB Bitmap objects via `BitmapFactory.decodeResource()` and holding them indefinitely in memory.

## Scope

4 files changed, import swapped and `setLargeIcon` call updated:

| File | Change |
|------|--------|
| `AnimeDownloadNotifier.kt` | `BitmapFactory` → `Icon.createWithResource` |
| `MangaDownloadNotifier.kt` | `BitmapFactory` → `Icon.createWithResource` |
| `BackupNotifier.kt` | `BitmapFactory` → `Icon.createWithResource` (×2) |
| `AnimeLibraryUpdateNotifier.kt` | Removed `notificationBitmap` lazy val, replaced both `setLargeIcon` calls |

## Why this is correct

`NotificationCompat.Builder.setLargeIcon(Icon)` is available on minSdk 26+ (our minSdk). `Icon.createWithResource()` takes a resource ID and lets the system handle bitmap decoding and scaling on demand — no heap allocation in app code.

## Verification

- [x] No remaining `BitmapFactory` references in the 4 files
- [x] No remaining `notificationBitmap` references
- [x] Build compiles cleanly

## Risk

**T1 (Low)** — Notification appearance unchanged, only internal allocation mechanism.

Closes #347