### PR TITLE
fix: replace force unwrap on UniFile.fromUri in image fetchers (R358)

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/coil/AnimeImageFetcher.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/coil/AnimeImageFetcher.kt
@@ -82,7 +82,8 @@ class AnimeImageFetcher(
     }
 
     private fun uniFileLoader(urlString: String): FetchResult {
-        val uniFile = UniFile.fromUri(options.context, urlString.toUri())!!
+        val uniFile = UniFile.fromUri(options.context, urlString.toUri())
+            ?: throw IOException("Failed to resolve URI to UniFile: $urlString")
         val tempFile = uniFile.openInputStream().source().buffer()
         return SourceFetchResult(
             source = ImageSource(source = tempFile, fileSystem = FileSystem.SYSTEM),

--- a/app/src/main/java/eu/kanade/tachiyomi/data/coil/MangaCoverFetcher.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/coil/MangaCoverFetcher.kt
@@ -81,7 +81,8 @@ class MangaCoverFetcher(
     }
 
     private fun uniFileLoader(urlString: String): FetchResult {
-        val uniFile = UniFile.fromUri(options.context, urlString.toUri())!!
+        val uniFile = UniFile.fromUri(options.context, urlString.toUri())
+            ?: throw IOException("Failed to resolve URI to UniFile: $urlString")
         val tempFile = uniFile.openInputStream().source().buffer()
         return SourceFetchResult(
             source = ImageSource(source = tempFile, fileSystem = FileSystem.SYSTEM),


### PR DESCRIPTION
## Objective

Replace crash-prone `!!` force unwraps on `UniFile.fromUri()` in both image fetcher classes.

## Scope

### AnimeImageFetcher.kt + MangaCoverFetcher.kt — #358
`UniFile.fromUri()` returns `UniFile?`. Previously force-unwrapped with `!!`, causing NPE on invalid/inaccessible URIs. Replaced with `?: throw IOException(...)` for a meaningful error.

## Verification

- [x] spotlessApply passed
- [x] Pre-push spotlessCheck passed (BUILD SUCCESSFUL)
- [x] Branch pushed to remote

## Risk

**T1 (Low)** — Error path only. Normal fetch behaviour unchanged. The `IOException` is already imported in both files and is the idiomatic exception type for I/O failures in a Coil fetcher.

Closes #358