### PR TITLE
fix: replace force unwraps in ShizukuInstaller and AnimeDownloader (R359)

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloader.kt
@@ -467,7 +467,7 @@ class AnimeDownloader(
         tmpDir.findFile("$filename.tmp")?.delete()
 
         // Try to find the video file
-        val videoFile = tmpDir.listFiles()?.firstOrNull { it.name!!.startsWith("$filename.mkv") }
+        val videoFile = tmpDir.listFiles()?.firstOrNull { it.name?.startsWith("$filename.mkv") == true }
 
         try {
             // If the video is already downloaded, do nothing. Otherwise download from network

--- a/app/src/main/java/eu/kanade/tachiyomi/extension/anime/installer/ShizukuInstallerAnime.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/extension/anime/installer/ShizukuInstallerAnime.kt
@@ -16,6 +16,7 @@ import rikka.shizuku.Shizuku
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.i18n.MR
 import java.io.BufferedReader
+import java.io.IOException
 import java.io.InputStream
 
 class ShizukuInstallerAnime(private val service: Service) : InstallerAnime(service) {
@@ -49,7 +50,9 @@ class ShizukuInstallerAnime(private val service: Service) : InstallerAnime(servi
             var sessionId: String? = null
             try {
                 val size = service.getUriSize(entry.uri) ?: throw IllegalStateException()
-                service.contentResolver.openInputStream(entry.uri)!!.use {
+                val inputStream = service.contentResolver.openInputStream(entry.uri)
+                    ?: throw IOException("Could not open extension file: ${entry.uri}")
+                inputStream.use {
                     val userId = Process.myUserHandle().hashCode()
                     val createCommand = "pm install-create --user $userId -r -i ${service.packageName} -S $size"
                     val createResult = exec(createCommand)


### PR DESCRIPTION
## Objective

Replace crash-prone `!!` force unwraps in extension installer and download queue.

## Scope

### ShizukuInstallerAnime.kt — #359
`contentResolver.openInputStream(entry.uri)!!` replaced with local val + `?: throw IOException(...)` for a clear, descriptive error instead of a silent NPE on URI permission/access failures.

### AnimeDownloader.kt — #360
`it.name!!` in the video file filter replaced with `it.name?.startsWith(...) == true` — `UniFile.name` is nullable and the `!!` would crash when any file in the temporary directory has no name.

## Verification

- [x] spotlessApply passed
- [x] Pre-push spotlessCheck hook passed (BUILD SUCCESSFUL)
- [x] Branch pushed to ryacub remote

## Risk

**T1 (Low)** — Changes are confined to error paths only. No business logic changed.

Closes #359
Closes #360