### PR TITLE
fix: restore versionName to 0.18.1.19 and harden bump script (R370)

### DIFF
--- a/.github/workflows/auto_version_bump.yml
+++ b/.github/workflows/auto_version_bump.yml
@@ -32,25 +32,35 @@ jobs:
         run: |
           # Extract current versions
           CURRENT_VERSION_CODE=$(grep 'val appVersionCode = ' app/build.gradle.kts | sed 's/.*= //')
-          CURRENT_VERSION_NAME=$(grep 'versionName = ' app/build.gradle.kts | sed 's/.*versionName = "\(.*\)"/\1/')
+          CURRENT_VERSION_NAME=$(grep 'versionName = "' app/build.gradle.kts | head -1 | sed 's/.*versionName = "\(.*\)"/\1/')
 
           echo "Current versionCode: $CURRENT_VERSION_CODE"
           echo "Current versionName: $CURRENT_VERSION_NAME"
 
-          # Increment versionCode
-          NEW_VERSION_CODE=$((CURRENT_VERSION_CODE + 1))
-
-          # Determine version bump type from PR title
-          PR_TITLE="${{ github.event.pull_request.title }}"
-
-          # Parse current version — 4-part upstream-tracking scheme (e.g. 0.18.1.6)
-          # Upstream prefix (0.18.1) is preserved; only the fork build number is bumped.
+          # Parse version — scheme is {aniyomi_version}.{fork_build}  e.g. 0.18.1.19
+          # prefix "0.18.1" tracks upstream Aniyomi 0.18.1; fork_build counts rayniyomi patches.
+          # The prefix is never auto-bumped — update it manually when pulling a new Aniyomi release.
           UPSTREAM_PREFIX=$(echo "$CURRENT_VERSION_NAME" | sed 's/\.[^.]*$//')
           FORK_BUILD=$(echo "$CURRENT_VERSION_NAME" | sed 's/.*\.//')
+
+          # Validate: both components must be present and FORK_BUILD must be a non-negative integer.
+          if [ -z "$UPSTREAM_PREFIX" ] || ! [[ "$FORK_BUILD" =~ ^[0-9]+$ ]]; then
+            echo "ERROR: Cannot parse versionName '$CURRENT_VERSION_NAME'."
+            echo "  Expected format: X.Y.Z.N  (e.g. 0.18.1.19)"
+            echo "  Got UPSTREAM_PREFIX='$UPSTREAM_PREFIX'  FORK_BUILD='$FORK_BUILD'"
+            echo "Fix versionName in app/build.gradle.kts before merging another PR."
+            exit 1
+          fi
+
+          # Increment versionCode
+          NEW_VERSION_CODE=$((CURRENT_VERSION_CODE + 1))
 
           NEW_FORK_BUILD=$((FORK_BUILD + 1))
           NEW_VERSION_NAME="${UPSTREAM_PREFIX}.${NEW_FORK_BUILD}"
           BUMP_TYPE="fork build"
+
+          # Determine version bump type from PR title (informational only)
+          PR_TITLE="${{ github.event.pull_request.title }}"
 
           echo "Bump type: $BUMP_TYPE"
           echo "New versionCode: $NEW_VERSION_CODE"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -28,7 +28,7 @@ android {
         applicationId = "xyz.rayniyomi"
 
         versionCode = appVersionCode
-        versionName = ".1.11"
+        versionName = "0.18.1.19"
 
         buildConfigField("String", "COMMIT_COUNT", "\"${getCommitCount()}\"")
         buildConfigField("String", "COMMIT_SHA", "\"${getGitSha()}\"")


### PR DESCRIPTION
## Objective

Restore the broken `versionName` and prevent the version bump script from silently writing garbage versions in the future.

## Scope

- `app/build.gradle.kts`: `versionName` corrected from `.1.11` → `0.18.1.19`
- `.github/workflows/auto_version_bump.yml`: added validation guard + `head -1` on grep + updated comments

No Kotlin source changes.

## Root Cause

PR #343 set `versionName = "0.18.1.6"` (4-part). The old `IFS='.' read -r MAJOR MINOR PATCH` parser gave `PATCH = "1.6"`. Bash arithmetic on `"1.6"` failed, leaving `NEW_VERSION_NAME` empty. `sed` then wrote `versionName = ""` into the file. Every subsequent bump parsed an empty MAJOR → producing `.1.0`, `.1.1`, …, `.1.11`.

The workflow was already updated to use sed-based splitting (`sed 's/\.[^.]*$//'`) which handles any number of version parts correctly — but `versionName` was never corrected.

## Version Rationale

`0.18.1.19` = Aniyomi upstream `0.18.1` prefix + 19 rayniyomi-specific patches  
(6 original at build 137 + 13 since the breakage at build 138)

Future bumps: `0.18.1.20`, `0.18.1.21`, etc. Update the prefix manually when pulling a new Aniyomi upstream release.

## Verification

- [x] `versionName = "0.18.1.19"` in `build.gradle.kts`
- [x] Validation guard exits with error if FORK_BUILD is non-numeric or prefix is empty
- [x] `head -1` prevents multi-line grep output corrupting the variable
- [x] Simulated: `echo "0.18.1.19" | sed 's/\.[^.]*$//'` → `0.18.1`, `sed 's/.*\.//'` → `19` ✓
- [x] Next bump would produce `0.18.1.20` ✓

## Risk

**T1 (Low)** — Config and CI workflow only. No Kotlin source changes. No behavior impact on app.

Closes #370