### PR TITLE
fix: migration chain fails when any migration fails (R377)

### DIFF
--- a/app/src/main/java/mihon/core/migration/MigrationJobFactory.kt
+++ b/app/src/main/java/mihon/core/migration/MigrationJobFactory.kt
@@ -28,7 +28,7 @@ class MigrationJobFactory(
                     async(start = CoroutineStart.UNDISPATCHED) {
                         val prev = acc.await()
                         val migrationSuccess = executeMigrationSafely(migration)
-                        migrationSuccess || prev
+                        migrationSuccess && prev
                     }
                 } else {
                     logcat {


### PR DESCRIPTION
## Ticket
- ID: R377
- Priority: P0
- Risk Tier: T2
- GitHub Issue: Closes #377

## Objective
- Correct migration chain success aggregation so a single failing migration marks the whole migration run as failed.
- Ensure migration completion callback only runs when all migrations in scope succeed.

## Scope
- Changed migration chain aggregation in `MigrationJobFactory` from OR to AND semantics.
- Added regression tests covering failure-by-false and failure-by-exception to verify `await()` resolves `false` and completion callback is not invoked.

## Non-goals
- No timeout-constant refactor or timeout-specific test injection changes.
- No migration architecture refactor beyond the ticket fix.

## Files Changed
- `app/src/main/java/mihon/core/migration/MigrationJobFactory.kt`
- `app/src/test/java/mihon/core/migration/MigratorTest.kt`

## Verification
- Commands run:
  - `./gradlew :app:testDebugUnitTest --tests "mihon.core.migration.MigratorTest"`
  - `./gradlew :app:testDebugUnitTest`
  - `./gradlew spotlessCheck`
  - `./gradlew :app:compileDebugKotlin`
- Results:
  - All commands passed.
  - Added tests passed:
    - `failingMigrationReturnsFalseAndDoesNotComplete`
    - `exceptionMigrationReturnsFalseAndDoesNotComplete`
- Not tested:
  - No device/instrumentation tests (not required for this logic-only change).

## Risk
- Primary risk is changing migration success semantics for in-range migrations; this is intentional and aligned with expected behavior.
- Mitigation: regression tests assert false-result propagation and callback suppression on failure paths.

## SLO Impact
- Startup migration correctness is improved; failed migrations no longer report success and no longer advance completion side effects.

## Rollback
- Revert commit `2db5f0b4b` to restore prior behavior if unexpected migration gating regressions are observed.
- Immediate containment path: ship revert patch and re-run `:app:testDebugUnitTest` and startup migration smoke validation before release.

## Release Notes
- Fixed migration result handling so failed migrations are no longer treated as successful.

## Checklist
- [x] Naming conventions followed (use "Rayniyomi" in user-facing text, see [naming conventions](../docs/governance/naming-conventions.md))
- [x] Branch rebased on latest main and verification re-run (see [rebase policy](../docs/governance/agent-workflow.md#rebase-before-merge-policy-r45))
- [x] New coroutine scopes have documented owner and cancellation path
- [x] No new `runBlocking` on UI/main thread paths

## Definition of Done (DoD)
- [x] Acceptance criteria met and non-goals respected
- [x] Verification matrix completed (Risk Tier: T2)
- [x] Self-review completed
- [x] Rebased on latest `main` and revalidated (mandatory for merge)
- [ ] Sprint board updated (branch, commit, checks, PR link)
- [x] Release notes drafted (if applicable)

## Fork Compliance Checklist (for new forks only)
If you are creating a new fork of this project, ensure the following:
- [ ] **App Identity**: Changed app name from "Aniyomi" to your fork name
- [ ] **App Icon**: Replaced launcher icon assets with fork-specific icons
- [ ] **Application ID**: Changed `applicationId` in `app/build.gradle.kts` from `xyz.rayniyomi` to your unique ID
- [ ] **Update Checker**: Configured `AppUpdateChecker.kt` to point to your fork's repository
- [ ] **Analytics**: Either disabled Firebase Analytics or configured with your own `google-services.json`
- [ ] **Crash Reporting**: Either disabled ACRA crash reporting or configured with your own endpoint credentials

See [CONTRIBUTING.md](../CONTRIBUTING.md) Forks section for details.
