### PR TITLE
chore: migrate context receivers to context parameters (R376)

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/util/ExceptionFormatter.kt
+++ b/app/src/main/java/eu/kanade/presentation/util/ExceptionFormatter.kt
@@ -11,22 +11,22 @@ import tachiyomi.domain.source.manga.model.SourceNotInstalledException
 import tachiyomi.i18n.MR
 import java.net.UnknownHostException
 
-context(Context)
+context(context: Context)
 val Throwable.formattedMessage: String
     get() {
         when (this) {
-            is HttpException -> return stringResource(MR.strings.exception_http, code)
+            is HttpException -> return context.stringResource(MR.strings.exception_http, code)
             is UnknownHostException -> {
-                return if (!isOnline()) {
-                    stringResource(MR.strings.exception_offline)
+                return if (!context.isOnline()) {
+                    context.stringResource(MR.strings.exception_offline)
                 } else {
-                    stringResource(MR.strings.exception_unknown_host, message ?: "")
+                    context.stringResource(MR.strings.exception_unknown_host, message ?: "")
                 }
             }
-            is NoChaptersException, is NoEpisodesException -> return stringResource(
+            is NoChaptersException, is NoEpisodesException -> return context.stringResource(
                 MR.strings.no_results_found,
             )
-            is SourceNotInstalledException, is AnimeSourceNotInstalledException -> return stringResource(
+            is SourceNotInstalledException, is AnimeSourceNotInstalledException -> return context.stringResource(
                 MR.strings.loader_not_implemented_error,
             )
         }

--- a/app/src/main/java/eu/kanade/presentation/util/FastScrollAnimateItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/util/FastScrollAnimateItem.kt
@@ -4,5 +4,7 @@ import androidx.compose.foundation.lazy.LazyItemScope
 import androidx.compose.ui.Modifier
 
 // https://issuetracker.google.com/352584409
-context(LazyItemScope)
-fun Modifier.animateItemFastScroll() = this.animateItem(fadeInSpec = null, fadeOutSpec = null)
+context(scope: LazyItemScope)
+fun Modifier.animateItemFastScroll() = with(scope) {
+    this@animateItemFastScroll.animateItem(fadeInSpec = null, fadeOutSpec = null)
+}

--- a/buildSrc/src/main/kotlin/mihon/buildlogic/ProjectExtensions.kt
+++ b/buildSrc/src/main/kotlin/mihon/buildlogic/ProjectExtensions.kt
@@ -46,7 +46,7 @@ internal fun Project.configureAndroid(commonExtension: CommonExtension<*, *, *, 
         compilerOptions {
             jvmTarget.set(AndroidConfig.JvmTarget)
             freeCompilerArgs.addAll(
-                "-Xcontext-receivers",
+                "-Xcontext-parameters",
                 "-opt-in=kotlin.RequiresOptIn",
             )
 

--- a/core/common/src/main/java/eu/kanade/tachiyomi/network/OkHttpExtensions.kt
+++ b/core/common/src/main/java/eu/kanade/tachiyomi/network/OkHttpExtensions.kt
@@ -132,18 +132,18 @@ fun OkHttpClient.newCachelessCallWithProgress(request: Request, listener: Progre
     return progressClient.newCall(request)
 }
 
-context(Json)
+context(json: Json)
 inline fun <reified T> Response.parseAs(): T {
     return decodeFromJsonResponse(serializer(), this)
 }
 
-context(Json)
+context(json: Json)
 fun <T> decodeFromJsonResponse(
     deserializer: DeserializationStrategy<T>,
     response: Response,
 ): T {
     return response.body.source().use {
-        decodeFromBufferedSource(deserializer, it)
+        json.decodeFromBufferedSource(deserializer, it)
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ sqldelight = "2.0.2"
 sqlite = "2.4.0"
 voyager = "1.0.1"
 spotless = "7.0.2"
-ktlint-core = "1.5.0"
+ktlint-core = "1.7.1"
 
 [libraries]
 desugar = "com.android.tools:desugar_jdk_libs:2.1.5"


### PR DESCRIPTION
## Ticket
- ID: R376
- Priority: P2
- Risk Tier: T2
- GitHub Issue: Closes #376

## Objective
- Remove deprecated Kotlin context receiver compiler usage before it becomes a hard error by migrating to context parameters.

## Scope
- Replace `-Xcontext-receivers` with `-Xcontext-parameters` in build logic.
- Migrate context receiver declarations in:
  - `core/common/.../OkHttpExtensions.kt`
  - `app/.../ExceptionFormatter.kt`
  - `app/.../FastScrollAnimateItem.kt`
- Keep behavior unchanged while updating syntax and call patterns.
- Update ktlint parser version so spotless can parse Kotlin context-parameter syntax.

## Non-goals
- No cleanup of unrelated existing Kotlin warnings.
- No refactors outside the ticketed compiler flag and syntax migration path.

## Files Changed
- `buildSrc/src/main/kotlin/mihon/buildlogic/ProjectExtensions.kt`
- `core/common/src/main/java/eu/kanade/tachiyomi/network/OkHttpExtensions.kt`
- `app/src/main/java/eu/kanade/presentation/util/ExceptionFormatter.kt`
- `app/src/main/java/eu/kanade/presentation/util/FastScrollAnimateItem.kt`
- `gradle/libs.versions.toml`

## Verification
- Commands run:
  - `rg -n "Xcontext-receivers" -S .`
  - `rg -n "^\\s*context\\(" --glob '!**/build/**' --glob '!**/.gradle/**' .`
  - `./gradlew :app:compileDebugKotlin --warning-mode=all --console=plain`
  - `./gradlew spotlessCheck`
  - `./gradlew :app:compileDebugKotlin`
- Results:
  - Deprecated context-receivers warning is no longer emitted.
  - `spotlessCheck` passes.
  - `:app:compileDebugKotlin` passes.
- Not tested:
  - Runtime/manual UI testing not performed (build + static verification only).

## Risk
- Main risk is source-level context syntax compatibility with tooling.
- Mitigation: compile + spotless validation, plus targeted parser update to keep lint compatibility with Kotlin 2.2 context-parameter syntax.

## SLO Impact
- None expected. This is compile-time/build tooling migration only.

## Rollback
- Revert this PR commit to restore previous compiler flag and context syntax.

## Release Notes
- Internal build/tooling maintenance: migrated context receivers to context parameters to stay compatible with upcoming Kotlin compiler behavior.

## Checklist
- [x] Naming conventions followed (use "Rayniyomi" in user-facing text, see [naming conventions](../docs/governance/naming-conventions.md))
- [x] Branch rebased on latest main and verification re-run (see [rebase policy](../docs/governance/agent-workflow.md#rebase-before-merge-policy-r45))
- [x] New coroutine scopes have documented owner and cancellation path
- [x] No new `runBlocking` on UI/main thread paths

## Definition of Done (DoD)
- [x] Acceptance criteria met and non-goals respected
- [x] Verification matrix completed (Risk Tier: T2)
- [x] Self-review completed
- [x] Rebased on latest `main` and revalidated (mandatory for merge)
- [ ] Sprint board updated (branch, commit, checks, PR link)
- [x] Release notes drafted (if applicable)
