### PR TITLE
fix: guard error-log notification URIs on file creation failure (R378)

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupNotifier.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupNotifier.kt
@@ -8,6 +8,7 @@ import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.core.security.SecurityPreferences
 import eu.kanade.tachiyomi.data.notification.NotificationReceiver
 import eu.kanade.tachiyomi.data.notification.Notifications
+import eu.kanade.tachiyomi.data.notification.shouldAttachRestoreErrorLogAction
 import eu.kanade.tachiyomi.util.storage.getUriCompat
 import eu.kanade.tachiyomi.util.system.cancelNotification
 import eu.kanade.tachiyomi.util.system.notificationBuilder
@@ -137,8 +138,7 @@ class BackupNotifier(private val context: Context) {
     fun showRestoreComplete(
         time: Long,
         errorCount: Int,
-        path: String?,
-        file: String?,
+        errorLogFile: File?,
         sync: Boolean,
     ) {
         val contentTitle = if (sync) {
@@ -169,9 +169,11 @@ class BackupNotifier(private val context: Context) {
             )
 
             clearActions()
-            if (errorCount > 0 && !path.isNullOrEmpty() && !file.isNullOrEmpty()) {
-                val destFile = File(path, file)
-                val uri = destFile.getUriCompat(context)
+            val shareableErrorLogFile = errorLogFile?.takeIf {
+                shouldAttachRestoreErrorLogAction(errorCount, it)
+            }
+            if (shareableErrorLogFile != null) {
+                val uri = shareableErrorLogFile.getUriCompat(context)
 
                 val errorLogIntent = NotificationReceiver.openErrorLogPendingActivity(context, uri)
                 setContentIntent(errorLogIntent)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/BackupRestorer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/BackupRestorer.kt
@@ -76,8 +76,7 @@ class BackupRestorer(
         notifier.showRestoreComplete(
             time,
             errors.size,
-            logFile.parent,
-            logFile.name,
+            logFile,
             isSync,
         )
     }
@@ -342,7 +341,7 @@ class BackupRestorer(
         return lightNovelBackupDataSource.isPluginInstalled()
     }
 
-    private fun writeErrorLog(): File {
+    private fun writeErrorLog(): File? {
         try {
             if (errors.isNotEmpty()) {
                 val file = context.createFileInCacheDir("aniyomi_restore_error.txt")
@@ -356,8 +355,8 @@ class BackupRestorer(
                 return file
             }
         } catch (e: Exception) {
-            // Empty
+            logcat(LogPriority.WARN, e) { "Failed to create backup restore error log file" }
         }
-        return File("")
+        return null
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/manga/MangaLibraryUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/manga/MangaLibraryUpdateJob.kt
@@ -27,6 +27,7 @@ import eu.kanade.tachiyomi.data.library.AutoUpdateCandidate
 import eu.kanade.tachiyomi.data.library.AutoUpdateSkipReason
 import eu.kanade.tachiyomi.data.library.evaluateAutoUpdateCandidate
 import eu.kanade.tachiyomi.data.notification.Notifications
+import eu.kanade.tachiyomi.data.notification.hasShareableErrorLogFile
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.model.UpdateStrategy
 import eu.kanade.tachiyomi.util.storage.getUriCompat
@@ -315,10 +316,17 @@ class MangaLibraryUpdateJob(private val context: Context, workerParams: WorkerPa
 
         if (failedUpdates.isNotEmpty()) {
             val errorFile = writeErrorFile(failedUpdates)
-            notifier.showUpdateErrorNotification(
-                failedUpdates.size,
-                errorFile.getUriCompat(context),
-            )
+            val shareableErrorFile = errorFile?.takeIf { hasShareableErrorLogFile(it) }
+            if (shareableErrorFile != null) {
+                notifier.showUpdateErrorNotification(
+                    failedUpdates.size,
+                    shareableErrorFile.getUriCompat(context),
+                )
+            } else {
+                logcat(LogPriority.WARN) {
+                    "Failed to write manga library update error file; skipping error log notification action"
+                }
+            }
         }
     }
 
@@ -383,7 +391,7 @@ class MangaLibraryUpdateJob(private val context: Context, workerParams: WorkerPa
     /**
      * Writes basic file of update errors to cache dir.
      */
-    private fun writeErrorFile(errors: List<Pair<Manga, String?>>): File {
+    private fun writeErrorFile(errors: List<Pair<Manga, String?>>): File? {
         try {
             if (errors.isNotEmpty()) {
                 val file = context.createFileInCacheDir("aniyomi_update_errors.txt")
@@ -408,8 +416,10 @@ class MangaLibraryUpdateJob(private val context: Context, workerParams: WorkerPa
                 }
                 return file
             }
-        } catch (_: Exception) {}
-        return File("")
+        } catch (e: Exception) {
+            logcat(LogPriority.WARN, e) { "Failed to create manga library update error file" }
+        }
+        return null
     }
 
     companion object {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/notification/ErrorLogGuards.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/notification/ErrorLogGuards.kt
@@ -1,0 +1,11 @@
+package eu.kanade.tachiyomi.data.notification
+
+import java.io.File
+
+internal fun hasShareableErrorLogFile(errorLogFile: File?): Boolean {
+    return errorLogFile?.exists() == true
+}
+
+internal fun shouldAttachRestoreErrorLogAction(errorCount: Int, errorLogFile: File?): Boolean {
+    return errorCount > 0 && hasShareableErrorLogFile(errorLogFile)
+}

--- a/app/src/test/java/eu/kanade/tachiyomi/data/notification/ErrorLogGuardsTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/data/notification/ErrorLogGuardsTest.kt
@@ -1,0 +1,59 @@
+package eu.kanade.tachiyomi.data.notification
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+
+class ErrorLogGuardsTest {
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    @Test
+    fun `hasShareableErrorLogFile returns false for null file`() {
+        assertFalse(hasShareableErrorLogFile(null))
+    }
+
+    @Test
+    fun `hasShareableErrorLogFile returns false for missing file`() {
+        val missingFile = tempDir.resolve("missing.txt").toFile()
+
+        assertFalse(hasShareableErrorLogFile(missingFile))
+    }
+
+    @Test
+    fun `hasShareableErrorLogFile returns true for existing file`() {
+        val existingFile = tempDir.resolve("errors.txt").toFile().apply {
+            writeText("error")
+        }
+
+        assertTrue(hasShareableErrorLogFile(existingFile))
+    }
+
+    @Test
+    fun `shouldAttachRestoreErrorLogAction returns false when no errors`() {
+        val existingFile = tempDir.resolve("errors.txt").toFile().apply {
+            writeText("error")
+        }
+
+        assertFalse(shouldAttachRestoreErrorLogAction(0, existingFile))
+    }
+
+    @Test
+    fun `shouldAttachRestoreErrorLogAction returns false when file missing`() {
+        val missingFile = tempDir.resolve("missing.txt").toFile()
+
+        assertFalse(shouldAttachRestoreErrorLogAction(1, missingFile))
+    }
+
+    @Test
+    fun `shouldAttachRestoreErrorLogAction returns true when errors exist and file exists`() {
+        val existingFile = tempDir.resolve("errors.txt").toFile().apply {
+            writeText("error")
+        }
+
+        assertTrue(shouldAttachRestoreErrorLogAction(1, existingFile))
+    }
+}


### PR DESCRIPTION
## Ticket
- ID: R378
- Priority: P1
- Risk Tier: T2
- GitHub Issue: Closes #378

## Objective
- Prevent crashes when library/backup error-log file creation fails and notifications attempt to build a FileProvider URI from invalid sentinel paths.

## Scope
- Replace sentinel File("") returns with nullable file results in manga/anime library update error log writers.
- Guard update error notifications so URI actions are only created when a real file exists.
- Harden backup restore error-log notification handoff to use nullable File? and file-existence checks.
- Add focused unit tests for error-log file guard logic.

## Non-goals
- No global notification-system refactor.
- No utility-level FileProvider behavior change across the app.
- No unrelated refactors.

## Files Changed
- app/src/main/java/eu/kanade/tachiyomi/data/library/manga/MangaLibraryUpdateJob.kt
- app/src/main/java/eu/kanade/tachiyomi/data/library/anime/AnimeLibraryUpdateJob.kt
- app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/BackupRestorer.kt
- app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupNotifier.kt
- app/src/main/java/eu/kanade/tachiyomi/data/notification/ErrorLogGuards.kt
- app/src/test/java/eu/kanade/tachiyomi/data/notification/ErrorLogGuardsTest.kt

## Verification
- Commands run:
  - ./gradlew :app:testDebugUnitTest --tests "eu.kanade.tachiyomi.data.notification.ErrorLogGuardsTest"
  - ./gradlew spotlessCheck
  - ./gradlew :app:compileDebugKotlin
  - ./gradlew :app:testDebugUnitTest
- Results:
  - All commands passed.
- Not tested:
  - Manual emulator/device notification sanity flows (library update failure and backup restore failure paths).

## Risk
- Low-to-medium: notifications may omit "Show errors" action when error log creation fails.
- Mitigation: action is now gated strictly on existing file checks; successful log-file paths remain unchanged.

## SLO Impact
- None expected.

## Rollback
- Revert this PR commit to restore prior behavior.

## Release Notes
- Fixed a crash path where update/restore error notifications could fail if the error log file could not be created.

## Checklist
- [x] Naming conventions followed (use "Rayniyomi" in user-facing text, see naming conventions doc)
- [x] Branch rebased on latest main and verification re-run (rebase policy)
- [x] New coroutine scopes have documented owner and cancellation path
- [x] No new runBlocking on UI/main thread paths

## Definition of Done (DoD)
- [x] Acceptance criteria met and non-goals respected
- [x] Verification matrix completed (Risk Tier: T2)
- [x] Self-review completed
- [x] Rebased on latest main and revalidated (mandatory for merge)
- [ ] Sprint board updated (branch, commit, checks, PR link)
- [x] Release notes drafted (if applicable)
