### PR TITLE
ci: harden PR spotless check stability (R391)

### DIFF
--- a/.github/workflows/build_pull_request.yml
+++ b/.github/workflows/build_pull_request.yml
@@ -38,10 +38,10 @@ jobs:
       - name: Set up gradle
         uses: gradle/actions/setup-gradle@94baf225fe0a508e581a564467443d0e2379123b # v4.3.0
         with:
-          cache-read-only: false
+          cache-disabled: true
 
       - name: Check code format
-        run: ./gradlew spotlessCheck --build-cache
+        run: ./gradlew spotlessCheck --no-build-cache --no-configuration-cache --refresh-dependencies -Dorg.gradle.workers.max=1
 
   build:
     name: Build app


### PR DESCRIPTION
## Ticket
- ID: R391
- Priority: P1
- Risk Tier: T1
- GitHub Issue: Closes #391

## Objective
- Stop flaky PR `Check code format` failures caused by ktlint `ServiceConfigurationError` in GitHub Actions.

## Scope
- Update only the `spotless` job in `.github/workflows/build_pull_request.yml`.
- Disable Gradle cache for this job.
- Run spotless with no build/configuration cache, refresh dependencies, and single-worker execution.

## Non-goals
- No app code changes.
- No build/test job behavior changes.

## Files Changed
- `.github/workflows/build_pull_request.yml`

## Verification
- Commands run:
  - `./gradlew spotlessCheck`
  - `./gradlew :app:compileDebugKotlin`
- Results:
  - Both passed locally.
- Not tested:
  - Full CI on this branch pending GitHub Actions.

## Risk
- Slightly longer format-check runtime in CI due reduced caching/concurrency.
- Mitigated by limiting changes to the format-check job only.

## SLO Impact
- None on runtime product SLOs.

## Rollback
- Revert this PR to restore previous spotless workflow settings.

## Release Notes
- Internal CI stability improvement; no user-facing app behavior changes.
