### PR TITLE
fix: add manga download status transparency and low-storage recovery (R381)

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/manga/MangaDownloadJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/manga/MangaDownloadJob.kt
@@ -14,6 +14,7 @@ import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import eu.kanade.tachiyomi.R
+import eu.kanade.tachiyomi.data.download.manga.model.MangaDownload
 import eu.kanade.tachiyomi.data.notification.Notifications
 import eu.kanade.tachiyomi.util.system.NetworkState
 import eu.kanade.tachiyomi.util.system.activeNetworkState
@@ -99,11 +100,15 @@ class MangaDownloadJob(context: Context, workerParams: WorkerParameters) : Corou
             if (noWifi) {
                 downloadManager.downloaderStop(
                     applicationContext.getString(R.string.download_notifier_text_only_wifi),
+                    MangaDownload.DisplayStatus.WAITING_FOR_WIFI,
                 )
             }
             !noWifi
         } else {
-            downloadManager.downloaderStop(applicationContext.getString(R.string.download_notifier_no_network))
+            downloadManager.downloaderStop(
+                applicationContext.getString(R.string.download_notifier_no_network),
+                MangaDownload.DisplayStatus.WAITING_FOR_NETWORK,
+            )
             false
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/manga/MangaDownloadManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/manga/MangaDownloadManager.kt
@@ -105,7 +105,10 @@ class MangaDownloadManager(
         }
         return downloader.start()
     }
-    fun downloaderStop(reason: String? = null) = downloader.stop(reason)
+    fun downloaderStop(
+        reason: String? = null,
+        blockedStatus: MangaDownload.DisplayStatus? = null,
+    ) = downloader.stop(reason, blockedStatus)
 
     val isDownloaderRunning
         get() = MangaDownloadJob.isRunningFlow(context)
@@ -455,7 +458,10 @@ class MangaDownloadManager(
         .flatMapLatest { downloads ->
             downloads
                 .map { download ->
-                    download.statusFlow.drop(1).map { download }
+                    kotlinx.coroutines.flow.merge(
+                        download.statusFlow.drop(1).map { download },
+                        download.displayStatusFlow.drop(1).map { download },
+                    )
                 }
                 .merge()
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/manga/model/MangaDownloadStatusTracker.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/manga/model/MangaDownloadStatusTracker.kt
@@ -1,0 +1,38 @@
+package eu.kanade.tachiyomi.data.download.manga.model
+
+object MangaDownloadStatusTracker {
+    const val STALL_THRESHOLD_MS = 10_000L
+
+    data class QueueStatusSummary(
+        val downloading: Int = 0,
+        val waitingForSlot: Int = 0,
+        val stalled: Int = 0,
+    )
+
+    fun shouldMarkStalled(download: MangaDownload, nowMs: Long): Boolean {
+        if (download.status != MangaDownload.State.DOWNLOADING) return false
+        if (download.displayStatus == MangaDownload.DisplayStatus.RETRYING) return false
+        val lastProgressAt = download.lastProgressAt
+        if (lastProgressAt <= 0L) return false
+        return nowMs - lastProgressAt >= STALL_THRESHOLD_MS
+    }
+
+    fun summarize(downloads: List<MangaDownload>): QueueStatusSummary {
+        var downloading = 0
+        var waitingForSlot = 0
+        var stalled = 0
+        downloads.forEach { download ->
+            when (download.displayStatus) {
+                MangaDownload.DisplayStatus.DOWNLOADING -> downloading++
+                MangaDownload.DisplayStatus.WAITING_FOR_SLOT -> waitingForSlot++
+                MangaDownload.DisplayStatus.STALLED -> stalled++
+                else -> Unit
+            }
+        }
+        return QueueStatusSummary(
+            downloading = downloading,
+            waitingForSlot = waitingForSlot,
+            stalled = stalled,
+        )
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/download/manga/MangaDownloadHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/download/manga/MangaDownloadHolder.kt
@@ -62,7 +62,7 @@ class MangaDownloadHolder(private val view: View, val adapter: MangaDownloadAdap
         if (pages == null) {
             binding.downloadProgress.progress = 0
             binding.downloadProgress.max = 1
-            binding.downloadProgressText.text = ""
+            binding.downloadProgressText.text = download.displayReasonText(view.context).orEmpty()
         } else {
             binding.downloadProgress.max = pages.size * 100
             notifyProgress()
@@ -86,7 +86,13 @@ class MangaDownloadHolder(private val view: View, val adapter: MangaDownloadAdap
      */
     fun notifyDownloadedPages() {
         val pages = download.pages ?: return
-        binding.downloadProgressText.text = "${download.downloadedImages}/${pages.size}"
+        val progressText = "${download.downloadedImages}/${pages.size}"
+        val reason = download.displayReasonText(view.context)
+        binding.downloadProgressText.text = if (reason.isNullOrBlank()) {
+            progressText
+        } else {
+            "$progressText · $reason"
+        }
     }
 
     override fun onItemReleased(position: Int) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/download/manga/MangaDownloadQueueScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/download/manga/MangaDownloadQueueScreenModel.kt
@@ -187,6 +187,7 @@ class MangaDownloadQueueScreenModel(
             MangaDownload.State.DOWNLOADING -> {
                 launchProgressJob(download)
                 // Initial update of the downloaded pages
+                onUpdateProgress(download)
                 onUpdateDownloadedPages(download)
             }
             MangaDownload.State.DOWNLOADED -> {
@@ -194,9 +195,14 @@ class MangaDownloadQueueScreenModel(
                 onUpdateProgress(download)
                 onUpdateDownloadedPages(download)
             }
-            MangaDownload.State.ERROR -> cancelProgressJob(download)
+            MangaDownload.State.ERROR -> {
+                cancelProgressJob(download)
+                onUpdateProgress(download)
+                onUpdateDownloadedPages(download)
+            }
             else -> {
-                /* unused */
+                onUpdateProgress(download)
+                onUpdateDownloadedPages(download)
             }
         }
     }
@@ -235,6 +241,7 @@ class MangaDownloadQueueScreenModel(
      */
     private fun onUpdateProgress(download: MangaDownload) {
         getHolder(download)?.notifyProgress()
+        getHolder(download)?.notifyDownloadedPages()
     }
 
     /**
@@ -244,6 +251,7 @@ class MangaDownloadQueueScreenModel(
      */
     fun onUpdateDownloadedPages(download: MangaDownload) {
         getHolder(download)?.notifyDownloadedPages()
+        getHolder(download)?.notifyProgress()
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/download/manga/MangaDownloadStatusText.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/download/manga/MangaDownloadStatusText.kt
@@ -1,0 +1,35 @@
+package eu.kanade.tachiyomi.ui.download.manga
+
+import android.content.Context
+import eu.kanade.tachiyomi.data.download.manga.model.MangaDownload
+import tachiyomi.core.common.i18n.stringResource
+import tachiyomi.i18n.MR
+
+fun MangaDownload.displayReasonText(context: Context): String? {
+    return when (displayStatus) {
+        MangaDownload.DisplayStatus.WAITING_FOR_SLOT -> context.stringResource(MR.strings.download_status_waiting_slot)
+        MangaDownload.DisplayStatus.WAITING_FOR_NETWORK -> context.stringResource(
+            MR.strings.download_notifier_no_network,
+        )
+        MangaDownload.DisplayStatus.WAITING_FOR_WIFI -> context.stringResource(
+            MR.strings.download_notifier_text_only_wifi,
+        )
+        MangaDownload.DisplayStatus.PREPARING -> context.stringResource(MR.strings.download_status_preparing)
+        MangaDownload.DisplayStatus.CONNECTING -> context.stringResource(MR.strings.download_status_connecting)
+        MangaDownload.DisplayStatus.DOWNLOADING -> null
+        MangaDownload.DisplayStatus.STALLED -> context.stringResource(MR.strings.download_status_stalled)
+        MangaDownload.DisplayStatus.RETRYING -> context.stringResource(
+            MR.strings.download_status_retrying_attempt,
+            retryAttempt,
+        )
+        MangaDownload.DisplayStatus.PAUSED_BY_USER -> context.stringResource(
+            MR.strings.download_notifier_download_paused,
+        )
+        MangaDownload.DisplayStatus.PAUSED_LOW_STORAGE -> context.stringResource(MR.strings.download_status_low_storage)
+        MangaDownload.DisplayStatus.VERIFYING -> context.stringResource(MR.strings.download_status_verifying)
+        MangaDownload.DisplayStatus.COMPLETED -> context.stringResource(MR.strings.download_status_completed)
+        MangaDownload.DisplayStatus.FAILED -> {
+            lastErrorReason ?: context.stringResource(MR.strings.download_notifier_unknown_error)
+        }
+    }
+}

--- a/app/src/test/java/eu/kanade/tachiyomi/data/download/manga/MangaDownloadStatusTrackerTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/data/download/manga/MangaDownloadStatusTrackerTest.kt
@@ -1,0 +1,66 @@
+package eu.kanade.tachiyomi.data.download.manga
+
+import eu.kanade.tachiyomi.data.download.manga.model.MangaDownload
+import eu.kanade.tachiyomi.data.download.manga.model.MangaDownloadStatusTracker
+import eu.kanade.tachiyomi.source.online.HttpSource
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import tachiyomi.domain.entries.manga.model.Manga
+import tachiyomi.domain.items.chapter.model.Chapter
+
+class MangaDownloadStatusTrackerTest {
+
+    @Test
+    fun `should mark stalled after threshold without retry`() {
+        val download = createDownload().apply {
+            status = MangaDownload.State.DOWNLOADING
+            displayStatus = MangaDownload.DisplayStatus.DOWNLOADING
+            lastProgressAt = 1_000L
+            retryAttempt = 0
+        }
+
+        MangaDownloadStatusTracker.shouldMarkStalled(download, 11_001L) shouldBe true
+    }
+
+    @Test
+    fun `should not mark stalled during retry`() {
+        val download = createDownload().apply {
+            status = MangaDownload.State.DOWNLOADING
+            displayStatus = MangaDownload.DisplayStatus.RETRYING
+            lastProgressAt = 1_000L
+            retryAttempt = 1
+        }
+
+        MangaDownloadStatusTracker.shouldMarkStalled(download, 20_000L) shouldBe false
+    }
+
+    @Test
+    fun `summarize should count downloading waiting and stalled statuses`() {
+        val downloads = listOf(
+            createDownload().apply { displayStatus = MangaDownload.DisplayStatus.DOWNLOADING },
+            createDownload().apply { displayStatus = MangaDownload.DisplayStatus.DOWNLOADING },
+            createDownload().apply { displayStatus = MangaDownload.DisplayStatus.WAITING_FOR_SLOT },
+            createDownload().apply { displayStatus = MangaDownload.DisplayStatus.STALLED },
+        )
+
+        val summary = MangaDownloadStatusTracker.summarize(downloads)
+
+        summary.downloading shouldBe 2
+        summary.waitingForSlot shouldBe 1
+        summary.stalled shouldBe 1
+    }
+
+    private fun createDownload(): MangaDownload {
+        val source = mockk<HttpSource>(relaxed = true)
+        val manga = mockk<Manga>(relaxed = true)
+        val chapter = mockk<Chapter>(relaxed = true)
+        every { chapter.id } returns 1L
+        return MangaDownload(
+            source = source,
+            manga = manga,
+            chapter = chapter,
+        )
+    }
+}


### PR DESCRIPTION
## Ticket
- ID: R381
- Priority: P1
- Risk Tier: T3
- GitHub Issue: Closes #397

## Objective
- Bring manga download engine behavior in line with anime v2 status transparency so users can see why downloads are waiting/retrying/stalled, and ensure low-storage is recoverable instead of terminal.

## Scope
- Added runtime display status model for manga downloads (`displayStatus`, `blockedReason`, `lastProgressAt`, retry/error metadata).
- Added manga stall tracker with 10s threshold and summary aggregation for notifier subtext.
- Upgraded manga downloader state transitions to explicit user-facing statuses.
- Converted manga low-storage behavior to `QUEUE + PAUSED_LOW_STORAGE` with warning notification.
- Added network policy blocked-state mapping (`WAITING_FOR_WIFI`, `WAITING_FOR_NETWORK`).
- Added queue row reason text + notifier reason/summarized status text.
- Extended manager status flow to emit on both status and display-status changes.
- Added unit tests for stalled detection and summary mapping.

## Non-goals
- Light novel plugin changes.
- Configurable stall threshold preference.
- Cross-engine abstraction refactor across anime and manga.

## Files Changed
- `app/src/main/java/eu/kanade/tachiyomi/data/download/manga/model/MangaDownload.kt`
- `app/src/main/java/eu/kanade/tachiyomi/data/download/manga/model/MangaDownloadStatusTracker.kt`
- `app/src/main/java/eu/kanade/tachiyomi/data/download/manga/MangaDownloader.kt`
- `app/src/main/java/eu/kanade/tachiyomi/data/download/manga/MangaDownloadManager.kt`
- `app/src/main/java/eu/kanade/tachiyomi/data/download/manga/MangaDownloadJob.kt`
- `app/src/main/java/eu/kanade/tachiyomi/data/download/manga/MangaDownloadNotifier.kt`
- `app/src/main/java/eu/kanade/tachiyomi/ui/download/manga/MangaDownloadStatusText.kt`
- `app/src/main/java/eu/kanade/tachiyomi/ui/download/manga/MangaDownloadHolder.kt`
- `app/src/main/java/eu/kanade/tachiyomi/ui/download/manga/MangaDownloadQueueScreenModel.kt`
- `app/src/test/java/eu/kanade/tachiyomi/data/download/manga/MangaDownloadStatusTrackerTest.kt`

## Verification
- Commands run:
  - `./gradlew spotlessCheck`
  - `./gradlew :app:compileDebugKotlin`
  - `./gradlew -Dkotlin.daemon.jvm.options=-Xmx4096m :app:testDebugUnitTest --tests "eu.kanade.tachiyomi.data.download.manga.MangaDownloadStatusTrackerTest"`
- Results:
  - All commands passed.
- Not tested:
  - Manual device/emulator interaction for queue screen messaging and notifications.

## Risk
- Runtime state-machine changes in downloader flow could affect queue progression under constrained storage/network conditions.
- Mitigations:
  - deterministic cleanup for per-download monitor/collector jobs (`cancel + join` ordering in `NonCancellable`)
  - explicit status transitions + blocked-reason assignment
  - unit tests for stall logic and summary mapping

## SLO Impact
- No expected latency regression in normal flow; additional 1s stall monitor coroutine per active manga download is lightweight and bounded by active download lifecycle.

## Rollback
- Revert this PR commit to restore prior manga download behavior (status-only model and previous low-storage handling). No schema/data migration is involved.

## Release Notes
- Manga download queue now surfaces clearer states (waiting/retrying/stalled/low-storage) and no longer fails terminally when storage is temporarily insufficient.

## Checklist
- [x] Naming conventions followed (use "Rayniyomi" in user-facing text, see [naming conventions](../docs/governance/naming-conventions.md))
- [x] Branch rebased on latest main and verification re-run (see [rebase policy](../docs/governance/agent-workflow.md#rebase-before-merge-policy-r45))
- [x] New coroutine scopes have documented owner and cancellation path
- [x] No new `runBlocking` on UI/main thread paths

## Definition of Done (DoD)
- [x] Acceptance criteria met and non-goals respected
- [x] Verification matrix completed (Risk Tier: T3)
- [x] Self-review completed
- [x] Rebased on latest `main` and revalidated (mandatory for merge)
- [ ] Sprint board updated (branch, commit, checks, PR link)
- [x] Release notes drafted (if applicable)
