### PR TITLE
feat: light novel transfer status + a11y hardening (R383)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -200,6 +200,8 @@ kotlin {
 }
 
 dependencies {
+    implementation(project(":lightnovel-contract"))
+
     implementation(projects.i18n)
     implementation(projects.i18nAniyomi)
     implementation(projects.core.archive)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloadNotifier.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloadNotifier.kt
@@ -102,7 +102,7 @@ internal class AnimeDownloadNotifier(private val context: Context) {
             }
             val reasonText = download.displayReasonText(context)
             val contentText = listOfNotNull(downloadingProgressText, reasonText)
-                .joinToString(" · ")
+                .joinToString(", ")
 
             if (preferences.hideNotificationContent().get()) {
                 setContentTitle(downloadingProgressText)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/manga/MangaDownloadNotifier.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/manga/MangaDownloadNotifier.kt
@@ -100,7 +100,7 @@ internal class MangaDownloadNotifier(private val context: Context) {
             )
             val reasonText = download.displayReasonText(context)
             val contentText = listOfNotNull(downloadingProgressText, reasonText)
-                .joinToString(" · ")
+                .joinToString(", ")
 
             if (preferences.hideNotificationContent().get()) {
                 setContentTitle(downloadingProgressText)

--- a/app/src/main/java/eu/kanade/tachiyomi/feature/novel/HostLightNovelTransferSnapshot.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/feature/novel/HostLightNovelTransferSnapshot.kt
@@ -1,0 +1,17 @@
+package eu.kanade.tachiyomi.feature.novel
+
+import xyz.rayniyomi.lightnovel.contract.LightNovelTransferDisplayStatus
+import xyz.rayniyomi.lightnovel.contract.LightNovelTransferSnapshot
+
+/**
+ * Host-side bridge point for future plugin import status projection.
+ *
+ * This keeps host/install state and plugin/import state intentionally decoupled.
+ */
+data class HostLightNovelTransferSnapshot(
+    override val displayStatus: LightNovelTransferDisplayStatus,
+    override val lastProgressAt: Long = 0L,
+    override val retryAttempt: Int = 0,
+    override val lastErrorReason: String? = null,
+    override val progressPercent: Int? = null,
+) : LightNovelTransferSnapshot

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/download/anime/AnimeDownloadHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/download/anime/AnimeDownloadHolder.kt
@@ -102,8 +102,12 @@ class AnimeDownloadHolder(private val view: View, val adapter: AnimeDownloadAdap
         binding.downloadProgressText.text = if (reason.isNullOrBlank()) {
             progressText
         } else {
-            "$progressText · $reason"
+            "$progressText, $reason"
         }
+        val a11yText = "${download.anime.title} ${download.episode.name} ${binding.downloadProgressText.text}"
+        binding.downloadProgressText.contentDescription = a11yText
+        binding.downloadProgress.contentDescription = a11yText
+        binding.downloadProgressText.accessibilityLiveRegion = View.ACCESSIBILITY_LIVE_REGION_POLITE
     }
 
     override fun onItemReleased(position: Int) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/download/manga/MangaDownloadHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/download/manga/MangaDownloadHolder.kt
@@ -92,8 +92,12 @@ class MangaDownloadHolder(private val view: View, val adapter: MangaDownloadAdap
         binding.downloadProgressText.text = if (reason.isNullOrBlank()) {
             progressText
         } else {
-            "$progressText · $reason"
+            "$progressText, $reason"
         }
+        val a11yText = "${download.manga.title} ${download.chapter.name} ${binding.downloadProgressText.text}"
+        binding.downloadProgressText.contentDescription = a11yText
+        binding.downloadProgress.contentDescription = a11yText
+        binding.downloadProgressText.accessibilityLiveRegion = View.ACCESSIBILITY_LIVE_REGION_POLITE
     }
 
     override fun onItemReleased(position: Int) {

--- a/lightnovel-contract/build.gradle.kts
+++ b/lightnovel-contract/build.gradle.kts
@@ -1,0 +1,12 @@
+plugins {
+    id("mihon.library")
+    kotlin("android")
+}
+
+android {
+    namespace = "xyz.rayniyomi.lightnovel.contract"
+}
+
+dependencies {
+    testImplementation(libs.bundles.test)
+}

--- a/lightnovel-contract/src/main/java/xyz/rayniyomi/lightnovel/contract/LightNovelTransferStatus.kt
+++ b/lightnovel-contract/src/main/java/xyz/rayniyomi/lightnovel/contract/LightNovelTransferStatus.kt
@@ -1,0 +1,26 @@
+package xyz.rayniyomi.lightnovel.contract
+
+enum class LightNovelTransferDisplayStatus {
+    PREPARING,
+    IMPORTING,
+    VERIFYING,
+    STALLED,
+    COMPLETED,
+    FAILED,
+    PAUSED_LOW_STORAGE,
+}
+
+enum class LightNovelTransferBlockedReason {
+    STORAGE,
+    SOURCE_UNAVAILABLE,
+    CORRUPT_FILE,
+    UNKNOWN,
+}
+
+interface LightNovelTransferSnapshot {
+    val displayStatus: LightNovelTransferDisplayStatus
+    val lastProgressAt: Long
+    val retryAttempt: Int
+    val lastErrorReason: String?
+    val progressPercent: Int?
+}

--- a/lightnovel-plugin/build.gradle.kts
+++ b/lightnovel-plugin/build.gradle.kts
@@ -46,11 +46,14 @@ android {
 }
 
 dependencies {
+    implementation(project(":lightnovel-contract"))
+
     implementation(androidx.appcompat)
     implementation(androidx.corektx)
     implementation(androidx.bundles.lifecycle)
 
     implementation(libs.jsoup)
+    implementation(libs.material)
     implementation(kotlinx.serialization.json)
     implementation(kotlinx.coroutines.android)
 

--- a/lightnovel-plugin/src/main/java/xyz/rayniyomi/plugin/lightnovel/MainViewModel.kt
+++ b/lightnovel-plugin/src/main/java/xyz/rayniyomi/plugin/lightnovel/MainViewModel.kt
@@ -1,0 +1,100 @@
+package xyz.rayniyomi.plugin.lightnovel
+
+import android.app.Application
+import android.net.Uri
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import xyz.rayniyomi.plugin.lightnovel.data.ImportTooLargeException
+import xyz.rayniyomi.plugin.lightnovel.data.InvalidEpubException
+import xyz.rayniyomi.plugin.lightnovel.data.LowStorageException
+import xyz.rayniyomi.plugin.lightnovel.data.NovelBook
+import xyz.rayniyomi.plugin.lightnovel.data.NovelImportStatusTracker
+import xyz.rayniyomi.plugin.lightnovel.data.NovelStorage
+import xyz.rayniyomi.plugin.lightnovel.data.SourceUnavailableException
+
+class MainViewModel(application: Application) : AndroidViewModel(application) {
+
+    private val storage = NovelStorage(application)
+    private val tracker = NovelImportStatusTracker()
+    private val importMutex = Mutex()
+
+    private val mutableBooks = MutableStateFlow<List<NovelBook>>(emptyList())
+    val books: StateFlow<List<NovelBook>> = mutableBooks.asStateFlow()
+    val importStatus = tracker.status
+
+    private var importJob: Job? = null
+    private var lastImportUri: Uri? = null
+
+    init {
+        refreshBooks()
+    }
+
+    fun isImportRunning(): Boolean = importJob?.isActive == true
+
+    fun retryLastImport(): Boolean {
+        val uri = lastImportUri ?: return false
+        return importEpub(uri)
+    }
+
+    fun importEpub(uri: Uri): Boolean {
+        if (isImportRunning()) return false
+        lastImportUri = uri
+        importJob = viewModelScope.launch(Dispatchers.IO) {
+            importMutex.withLock {
+                tracker.onPreparing()
+                val stallJob = launch {
+                    while (isActive) {
+                        delay(1_000L)
+                        tracker.updateStalledIfNeeded()
+                    }
+                }
+                try {
+                    storage.importEpub(
+                        uri = uri,
+                        onVerifying = { tracker.onVerifying() },
+                        onProgress = { bytesRead, totalBytes ->
+                            tracker.onImportProgress(bytesRead, totalBytes)
+                        },
+                    )
+                    tracker.onCompleted()
+                    refreshBooks()
+                } catch (e: Throwable) {
+                    when (e) {
+                        is LowStorageException -> tracker.onPausedLowStorage(mapImportError(e))
+                        else -> tracker.onFailed(mapImportError(e))
+                    }
+                } finally {
+                    stallJob.cancel()
+                }
+            }
+        }
+        return true
+    }
+
+    fun refreshBooks() {
+        viewModelScope.launch(Dispatchers.IO) {
+            mutableBooks.value = storage.listBooks()
+        }
+    }
+
+    private fun mapImportError(cause: Throwable): String {
+        val context = getApplication<Application>()
+        return when (cause) {
+            is ImportTooLargeException -> context.getString(R.string.import_too_large)
+            is InvalidEpubException -> context.getString(R.string.import_invalid_epub)
+            is SourceUnavailableException -> context.getString(R.string.import_source_unavailable)
+            is LowStorageException -> context.getString(R.string.import_low_storage)
+            else -> context.getString(R.string.import_failed)
+        }
+    }
+}

--- a/lightnovel-plugin/src/main/java/xyz/rayniyomi/plugin/lightnovel/data/NovelImportStatusTracker.kt
+++ b/lightnovel-plugin/src/main/java/xyz/rayniyomi/plugin/lightnovel/data/NovelImportStatusTracker.kt
@@ -1,0 +1,97 @@
+package xyz.rayniyomi.plugin.lightnovel.data
+
+import android.os.SystemClock
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import xyz.rayniyomi.lightnovel.contract.LightNovelTransferDisplayStatus
+import xyz.rayniyomi.lightnovel.contract.LightNovelTransferSnapshot
+
+data class NovelImportStatus(
+    override val displayStatus: LightNovelTransferDisplayStatus =
+        LightNovelTransferDisplayStatus.PREPARING,
+    override val lastProgressAt: Long = 0L,
+    override val retryAttempt: Int = 0,
+    override val lastErrorReason: String? = null,
+    override val progressPercent: Int? = null,
+) : LightNovelTransferSnapshot
+
+class NovelImportStatusTracker(
+    private val nowMs: () -> Long = { SystemClock.elapsedRealtime() },
+) {
+    private val mutableStatus = MutableStateFlow(
+        NovelImportStatus(
+            displayStatus = LightNovelTransferDisplayStatus.COMPLETED,
+            progressPercent = 100,
+        ),
+    )
+    val status = mutableStatus.asStateFlow()
+
+    fun onPreparing() {
+        mutableStatus.value = NovelImportStatus(
+            displayStatus = LightNovelTransferDisplayStatus.PREPARING,
+            progressPercent = 0,
+        )
+    }
+
+    fun onImportProgress(bytesRead: Long, contentLength: Long?) {
+        val current = mutableStatus.value
+        val percent = contentLength
+            ?.takeIf { it > 0L }
+            ?.let { ((bytesRead.coerceAtLeast(0L) * 100L) / it).toInt().coerceIn(0, 100) }
+        mutableStatus.value = current.copy(
+            displayStatus = LightNovelTransferDisplayStatus.IMPORTING,
+            lastProgressAt = nowMs(),
+            progressPercent = percent,
+            lastErrorReason = null,
+        )
+    }
+
+    fun onVerifying() {
+        val current = mutableStatus.value
+        mutableStatus.value = current.copy(
+            displayStatus = LightNovelTransferDisplayStatus.VERIFYING,
+        )
+    }
+
+    fun onCompleted() {
+        mutableStatus.value = NovelImportStatus(
+            displayStatus = LightNovelTransferDisplayStatus.COMPLETED,
+            progressPercent = 100,
+        )
+    }
+
+    fun onFailed(reason: String) {
+        val current = mutableStatus.value
+        mutableStatus.value = current.copy(
+            displayStatus = LightNovelTransferDisplayStatus.FAILED,
+            lastErrorReason = reason,
+        )
+    }
+
+    fun onPausedLowStorage(reason: String) {
+        val current = mutableStatus.value
+        mutableStatus.value = current.copy(
+            displayStatus = LightNovelTransferDisplayStatus.PAUSED_LOW_STORAGE,
+            lastErrorReason = reason,
+        )
+    }
+
+    fun updateStalledIfNeeded() {
+        val current = mutableStatus.value
+        if (shouldMarkStalled(current, nowMs())) {
+            mutableStatus.value = current.copy(
+                displayStatus = LightNovelTransferDisplayStatus.STALLED,
+            )
+        }
+    }
+
+    companion object {
+        const val STALL_THRESHOLD_MS = 10_000L
+
+        fun shouldMarkStalled(snapshot: LightNovelTransferSnapshot, nowMs: Long): Boolean {
+            if (snapshot.displayStatus != LightNovelTransferDisplayStatus.IMPORTING) return false
+            if (snapshot.lastProgressAt <= 0L) return false
+            return nowMs - snapshot.lastProgressAt >= STALL_THRESHOLD_MS
+        }
+    }
+}

--- a/lightnovel-plugin/src/main/java/xyz/rayniyomi/plugin/lightnovel/ui/LightNovelStatusTextMapper.kt
+++ b/lightnovel-plugin/src/main/java/xyz/rayniyomi/plugin/lightnovel/ui/LightNovelStatusTextMapper.kt
@@ -1,0 +1,28 @@
+package xyz.rayniyomi.plugin.lightnovel.ui
+
+import android.content.Context
+import xyz.rayniyomi.lightnovel.contract.LightNovelTransferDisplayStatus
+import xyz.rayniyomi.lightnovel.contract.LightNovelTransferSnapshot
+import xyz.rayniyomi.plugin.lightnovel.R
+
+fun LightNovelTransferSnapshot.displayReasonText(context: Context): String {
+    return when (displayStatus) {
+        LightNovelTransferDisplayStatus.PREPARING -> context.getString(R.string.import_preparing)
+        LightNovelTransferDisplayStatus.IMPORTING -> {
+            val percent = progressPercent
+            if (percent == null) {
+                context.getString(R.string.import_progress_unknown)
+            } else {
+                context.getString(R.string.import_progress_percent, percent)
+            }
+        }
+        LightNovelTransferDisplayStatus.VERIFYING -> context.getString(R.string.import_verifying)
+        LightNovelTransferDisplayStatus.STALLED -> context.getString(R.string.import_stalled)
+        LightNovelTransferDisplayStatus.COMPLETED -> context.getString(R.string.import_completed)
+        LightNovelTransferDisplayStatus.FAILED -> {
+            val reason = lastErrorReason?.takeIf { it.isNotBlank() } ?: context.getString(R.string.import_failed)
+            context.getString(R.string.import_failed_reason, reason)
+        }
+        LightNovelTransferDisplayStatus.PAUSED_LOW_STORAGE -> context.getString(R.string.import_low_storage)
+    }
+}

--- a/lightnovel-plugin/src/main/res/layout/activity_main.xml
+++ b/lightnovel-plugin/src/main/res/layout/activity_main.xml
@@ -9,7 +9,36 @@
         android:id="@+id/importEpubButton"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:minHeight="48dp"
+        android:contentDescription="@string/import_epub"
         android:text="@string/import_epub" />
+
+    <Button
+        android:id="@+id/retryImportButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:minHeight="48dp"
+        android:contentDescription="@string/retry_import_epub"
+        android:text="@string/retry_import_epub"
+        android:visibility="gone" />
+
+    <com.google.android.material.progressindicator.LinearProgressIndicator
+        android:id="@+id/importProgressBar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:visibility="gone" />
+
+    <TextView
+        android:id="@+id/importStatusText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:accessibilityLiveRegion="polite"
+        android:textAppearance="?android:attr/textAppearanceMedium"
+        android:textColor="?android:attr/textColorSecondary"
+        android:visibility="gone" />
 
     <ListView
         android:id="@+id/booksList"

--- a/lightnovel-plugin/src/main/res/values/strings.xml
+++ b/lightnovel-plugin/src/main/res/values/strings.xml
@@ -1,8 +1,21 @@
 <resources>
     <string name="app_name">Light Novel Plugin</string>
     <string name="import_epub">Import EPUB</string>
+    <string name="retry_import_epub">Retry import</string>
     <string name="import_failed">Failed to import EPUB</string>
     <string name="import_too_large">EPUB is too large. Max size is 100MB.</string>
+    <string name="import_in_progress">Import in progress</string>
+    <string name="import_preparing">Preparing import…</string>
+    <string name="import_verifying">Verifying EPUB…</string>
+    <string name="import_stalled">Import stalled, still retrying…</string>
+    <string name="import_completed">Import completed.</string>
+    <string name="import_progress_percent">Importing: %1$d%%</string>
+    <string name="import_progress_unknown">Importing (size unknown)…</string>
+    <string name="import_low_storage">Not enough storage to import this EPUB.</string>
+    <string name="import_source_unavailable">Source unavailable or permission removed.</string>
+    <string name="import_invalid_epub">File appears invalid or corrupted.</string>
+    <string name="import_already_running">Import already in progress.</string>
+    <string name="import_failed_reason">Import failed: %1$s</string>
     <string name="no_books">No imported light novels yet.</string>
     <string name="chapter_format">Chapter %1$d / %2$d</string>
     <string name="previous_chapter">Previous</string>

--- a/lightnovel-plugin/src/test/java/xyz/rayniyomi/plugin/lightnovel/data/NovelImportStatusTrackerTest.kt
+++ b/lightnovel-plugin/src/test/java/xyz/rayniyomi/plugin/lightnovel/data/NovelImportStatusTrackerTest.kt
@@ -1,0 +1,33 @@
+package xyz.rayniyomi.plugin.lightnovel.data
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import xyz.rayniyomi.lightnovel.contract.LightNovelTransferDisplayStatus
+
+class NovelImportStatusTrackerTest {
+
+    @Test
+    fun `marks stalled after threshold and resumes on next progress`() {
+        var now = 1_000L
+        val tracker = NovelImportStatusTracker(nowMs = { now })
+
+        tracker.onImportProgress(bytesRead = 10, contentLength = 100)
+        now = 11_100L
+        tracker.updateStalledIfNeeded()
+        tracker.status.value.displayStatus shouldBe LightNovelTransferDisplayStatus.STALLED
+
+        now = 11_200L
+        tracker.onImportProgress(bytesRead = 20, contentLength = 100)
+        tracker.status.value.displayStatus shouldBe LightNovelTransferDisplayStatus.IMPORTING
+    }
+
+    @Test
+    fun `keeps unknown-size progress indeterminate`() {
+        val tracker = NovelImportStatusTracker(nowMs = { 10_000L })
+
+        tracker.onImportProgress(bytesRead = 256, contentLength = null)
+
+        tracker.status.value.displayStatus shouldBe LightNovelTransferDisplayStatus.IMPORTING
+        tracker.status.value.progressPercent shouldBe null
+    }
+}

--- a/lightnovel-plugin/src/test/java/xyz/rayniyomi/plugin/lightnovel/ui/LightNovelStatusTextMapperTest.kt
+++ b/lightnovel-plugin/src/test/java/xyz/rayniyomi/plugin/lightnovel/ui/LightNovelStatusTextMapperTest.kt
@@ -1,0 +1,35 @@
+package xyz.rayniyomi.plugin.lightnovel.ui
+
+import android.content.Context
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import xyz.rayniyomi.lightnovel.contract.LightNovelTransferDisplayStatus
+import xyz.rayniyomi.plugin.lightnovel.R
+import xyz.rayniyomi.plugin.lightnovel.data.NovelImportStatus
+
+class LightNovelStatusTextMapperTest {
+    private val context = mockk<Context>(relaxed = true)
+
+    @Test
+    fun `maps importing unknown size to unknown text`() {
+        every { context.getString(R.string.import_progress_unknown) } returns "unknown"
+
+        NovelImportStatus(
+            displayStatus = LightNovelTransferDisplayStatus.IMPORTING,
+            progressPercent = null,
+        ).displayReasonText(context) shouldBe "unknown"
+    }
+
+    @Test
+    fun `maps failed reason with fallback`() {
+        every { context.getString(R.string.import_failed) } returns "failed"
+        every { context.getString(R.string.import_failed_reason, "failed") } returns "Import failed: failed"
+
+        NovelImportStatus(
+            displayStatus = LightNovelTransferDisplayStatus.FAILED,
+            lastErrorReason = null,
+        ).displayReasonText(context) shouldBe "Import failed: failed"
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -59,4 +59,5 @@ include(":presentation-widget")
 include(":source-api")
 include(":source-local")
 
+include(":lightnovel-contract")
 include(":lightnovel-plugin")


### PR DESCRIPTION
## Ticket
- ID: R383
- Priority: P1
- Risk Tier: T2
- GitHub Issue: Closes #401

## Objective
- Add a shared light novel transfer-status contract and harden plugin import transparency (status/reasons/stall handling), while improving accessibility wording/semantics on recently added anime/manga download status surfaces.

## Scope
- Added new :lightnovel-contract module with shared transfer status enums + snapshot interface.
- Wired contract dependency into app and lightnovel-plugin.
- Added plugin import runtime status tracking (NovelImportStatusTracker) with 10s stall detection.
- Refactored plugin import flow into a MainViewModel with lifecycle-safe state collection in MainActivity.
- Extended NovelStorage.importEpub(...) with progress + verification callbacks, temp-file safety, and explicit exception mapping (source unavailable, invalid EPUB, low storage).
- Added plugin UI status row/progress/retry affordance and accessibility live-region + content descriptions.
- Applied minimal behavior-preserving a11y wording/semantics updates to anime/manga queue row status text and download notifications.
- Added plugin unit tests for status tracker and status text mapping.

## Non-goals
- No host-side IPC projection of live plugin import status.
- No download engine threshold/policy changes for anime/manga beyond a11y-oriented text/semantics.
- No redesign of host plugin install/update flow.

## Files Changed
- settings.gradle.kts
- app/build.gradle.kts
- app/src/main/java/eu/kanade/tachiyomi/feature/novel/HostLightNovelTransferSnapshot.kt
- app/src/main/java/eu/kanade/tachiyomi/ui/download/anime/AnimeDownloadHolder.kt
- app/src/main/java/eu/kanade/tachiyomi/ui/download/manga/MangaDownloadHolder.kt
- app/src/main/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloadNotifier.kt
- app/src/main/java/eu/kanade/tachiyomi/data/download/manga/MangaDownloadNotifier.kt
- lightnovel-contract/build.gradle.kts
- lightnovel-contract/src/main/java/xyz/rayniyomi/lightnovel/contract/LightNovelTransferStatus.kt
- lightnovel-plugin/build.gradle.kts
- lightnovel-plugin/src/main/java/xyz/rayniyomi/plugin/lightnovel/MainActivity.kt
- lightnovel-plugin/src/main/java/xyz/rayniyomi/plugin/lightnovel/MainViewModel.kt
- lightnovel-plugin/src/main/java/xyz/rayniyomi/plugin/lightnovel/data/NovelStorage.kt
- lightnovel-plugin/src/main/java/xyz/rayniyomi/plugin/lightnovel/data/NovelImportStatusTracker.kt
- lightnovel-plugin/src/main/java/xyz/rayniyomi/plugin/lightnovel/ui/LightNovelStatusTextMapper.kt
- lightnovel-plugin/src/main/res/layout/activity_main.xml
- lightnovel-plugin/src/main/res/values/strings.xml
- lightnovel-plugin/src/test/java/xyz/rayniyomi/plugin/lightnovel/data/NovelImportStatusTrackerTest.kt
- lightnovel-plugin/src/test/java/xyz/rayniyomi/plugin/lightnovel/ui/LightNovelStatusTextMapperTest.kt

## Verification
- Commands run:
  - ./gradlew spotlessCheck
  - ./gradlew :app:compileDebugKotlin
  - ./gradlew :lightnovel-contract:compileDebugKotlin
  - ./gradlew :lightnovel-plugin:compileDebugKotlin
  - ./gradlew :lightnovel-plugin:testDebugUnitTest --tests "*NovelImportStatusTrackerTest*" --tests "*LightNovelStatusTextMapperTest*"
- Results:
  - All commands passed locally.
- Not tested:
  - Instrumentation/device UI tests (plugin and app).

## Risk
- Primary risks are import-state regressions in plugin UI and text/semantics regressions in download row/notifier copy.
- Mitigation:
  - Status logic isolated in tracker + unit tests.
  - Storage import changes keep default callback parameters backward-compatible.
  - App-side changes are minimal and behavior-preserving.

## SLO Impact
- No expected backend/network SLO impact.
- Minor UX improvement for perceived download/import responsiveness and status clarity.

## Rollback
- Revert this PR to restore previous plugin import flow and app download status text behavior.
- No schema migration or persisted contract versioning changes are required for rollback.

## Release Notes
- Improved light novel plugin import transparency with explicit status reasons, stall detection, and retry visibility.
- Improved accessibility/readability of download status messaging in anime/manga queue + notifications.

## Checklist
- [x] Naming conventions followed (use "Rayniyomi" in user-facing text, see [naming conventions](../docs/governance/naming-conventions.md))
- [x] Branch rebased on latest main and verification re-run (see [rebase policy](../docs/governance/agent-workflow.md#rebase-before-merge-policy-r45))
- [x] New coroutine scopes have documented owner and cancellation path
- [x] No new runBlocking on UI/main thread paths

## Definition of Done (DoD)
- [x] Acceptance criteria met and non-goals respected
- [x] Verification matrix completed (Risk Tier: T2)
- [x] Self-review completed
- [x] Rebased on latest main and revalidated (mandatory for merge)
- [x] Sprint board updated (branch, commit, checks, PR link)
- [x] Release notes drafted (if applicable)
