### PR TITLE
fix: throttle light novel progress updates and improve a11y announcements (R403)

### DIFF
--- a/lightnovel-contract/src/main/java/xyz/rayniyomi/lightnovel/contract/LightNovelTransferStatus.kt
+++ b/lightnovel-contract/src/main/java/xyz/rayniyomi/lightnovel/contract/LightNovelTransferStatus.kt
@@ -1,22 +1,51 @@
 package xyz.rayniyomi.lightnovel.contract
 
+/**
+ * User-visible lifecycle states for light novel transfer/import operations.
+ */
 enum class LightNovelTransferDisplayStatus {
+    /** Import request accepted and setup/validation is in progress. */
     PREPARING,
+
+    /** Bytes are currently being copied from source to destination. */
     IMPORTING,
+
+    /** Byte copy finished and EPUB contents are being validated/parsed. */
     VERIFYING,
+
+    /** Transfer has an active request but no byte progress in the stall window. */
     STALLED,
+
+    /** Import finished successfully and the book was persisted. */
     COMPLETED,
+
+    /** Import failed and requires user intervention or retry. */
     FAILED,
+
+    /** Import cannot continue because device storage is insufficient. */
     PAUSED_LOW_STORAGE,
 }
 
+/**
+ * Normalized blocker/failure categories for light novel transfer reporting.
+ */
 enum class LightNovelTransferBlockedReason {
+    /** Local storage is insufficient for current transfer step. */
     STORAGE,
+
+    /** Source URI or permission is unavailable. */
     SOURCE_UNAVAILABLE,
+
+    /** Source content is malformed or unreadable as EPUB. */
     CORRUPT_FILE,
+
+    /** Fallback category when a specific blocker is unavailable. */
     UNKNOWN,
 }
 
+/**
+ * Read-only snapshot consumed by UI and notifier layers.
+ */
 interface LightNovelTransferSnapshot {
     val displayStatus: LightNovelTransferDisplayStatus
     val lastProgressAt: Long

--- a/lightnovel-plugin/src/main/java/xyz/rayniyomi/plugin/lightnovel/MainActivity.kt
+++ b/lightnovel-plugin/src/main/java/xyz/rayniyomi/plugin/lightnovel/MainActivity.kt
@@ -2,10 +2,12 @@ package xyz.rayniyomi.plugin.lightnovel
 
 import android.content.Intent
 import android.os.Bundle
+import android.view.View
 import android.widget.ArrayAdapter
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
 import androidx.core.view.isVisible
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
@@ -103,11 +105,22 @@ class MainActivity : AppCompatActivity() {
                 binding.importProgressBar.isVisible = inProgress
                 if (status.progressPercent == null || status.displayStatus == LightNovelTransferDisplayStatus.STALLED) {
                     binding.importProgressBar.isIndeterminate = true
+                    val unknownProgressText = getString(R.string.import_progress_unknown)
+                    binding.importProgressBar.contentDescription = unknownProgressText
+                    ViewCompat.setStateDescription(binding.importProgressBar, unknownProgressText)
                 } else {
                     binding.importProgressBar.isIndeterminate = false
                     binding.importProgressBar.progress = status.progressPercent
+                    val percentProgressText = getString(R.string.import_progress_percent, status.progressPercent)
+                    binding.importProgressBar.contentDescription = percentProgressText
+                    ViewCompat.setStateDescription(binding.importProgressBar, percentProgressText)
                 }
-                binding.importProgressBar.contentDescription = statusText
+                binding.importStatusText.accessibilityLiveRegion =
+                    if (status.displayStatus == LightNovelTransferDisplayStatus.IMPORTING) {
+                        View.ACCESSIBILITY_LIVE_REGION_NONE
+                    } else {
+                        View.ACCESSIBILITY_LIVE_REGION_POLITE
+                    }
                 binding.importEpubButton.isEnabled = !viewModel.isImportRunning()
                 binding.retryImportButton.isVisible = status.displayStatus in setOf(
                     LightNovelTransferDisplayStatus.FAILED,

--- a/lightnovel-plugin/src/test/java/xyz/rayniyomi/plugin/lightnovel/data/NovelImportStatusTrackerTest.kt
+++ b/lightnovel-plugin/src/test/java/xyz/rayniyomi/plugin/lightnovel/data/NovelImportStatusTrackerTest.kt
@@ -30,4 +30,36 @@ class NovelImportStatusTrackerTest {
         tracker.status.value.displayStatus shouldBe LightNovelTransferDisplayStatus.IMPORTING
         tracker.status.value.progressPercent shouldBe null
     }
+
+    @Test
+    fun `coalesces determinate progress updates when percent is unchanged`() {
+        var now = 1_000L
+        val tracker = NovelImportStatusTracker(nowMs = { now })
+
+        tracker.onImportProgress(bytesRead = 10, contentLength = 1_000)
+        val firstProgressAt = tracker.status.value.lastProgressAt
+
+        now = 1_050L
+        tracker.onImportProgress(bytesRead = 11, contentLength = 1_000)
+
+        tracker.status.value.progressPercent shouldBe 1
+        tracker.status.value.lastProgressAt shouldBe firstProgressAt
+    }
+
+    @Test
+    fun `throttles unknown-size progress emissions`() {
+        var now = 1_000L
+        val tracker = NovelImportStatusTracker(nowMs = { now })
+
+        tracker.onImportProgress(bytesRead = 10, contentLength = null)
+        val firstProgressAt = tracker.status.value.lastProgressAt
+
+        now = 1_100L
+        tracker.onImportProgress(bytesRead = 40, contentLength = null)
+        tracker.status.value.lastProgressAt shouldBe firstProgressAt
+
+        now = 1_400L
+        tracker.onImportProgress(bytesRead = 100, contentLength = null)
+        tracker.status.value.lastProgressAt shouldBe 1_400L
+    }
 }


### PR DESCRIPTION
## Objective
Address follow-up review feedback from R383 by reducing noisy import progress updates and making plugin progress accessibility output explicit and screen-reader friendly.

## Scope
- lightnovel-plugin import status tracker coalescing logic
- lightnovel-plugin progress bar accessibility descriptions/live-region behavior
- lightnovel-contract KDoc for transfer status semantics
- tracker unit tests covering new coalescing behavior

## Verification
- ./gradlew :lightnovel-plugin:testDebugUnitTest --tests "*NovelImportStatusTrackerTest*"
- ./gradlew :lightnovel-contract:compileDebugKotlin
- ./gradlew spotlessCheck
- ./gradlew :app:compileDebugKotlin

## Risk
- T2: localized behavior updates in plugin status emission cadence and accessibility announcements

## Rollback
Revert this PR to restore previous per-buffer status emission behavior and prior progress bar accessibility text handling.

Closes #403
