### PR TITLE
chore: bump target sdk to 35 (R384)

### DIFF
--- a/buildSrc/src/main/kotlin/mihon/buildlogic/AndroidConfig.kt
+++ b/buildSrc/src/main/kotlin/mihon/buildlogic/AndroidConfig.kt
@@ -5,7 +5,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget as KotlinJvmTarget
 
 object AndroidConfig {
     const val COMPILE_SDK = 35
-    const val TARGET_SDK = 34
+    const val TARGET_SDK = 35
     const val MIN_SDK = 26
     const val NDK = "27.1.12297006"
     const val BUILD_TOOLS = "35.0.1"


### PR DESCRIPTION
## Ticket
- ID: R384
- Priority: P1
- Risk Tier: T2
- GitHub Issue: Closes #384

## Objective
- Raise Play compliance target by updating app target SDK from 34 to 35 while keeping scope limited to ticket #384.

## Scope
- Updated `TARGET_SDK` in build logic from 34 to 35.
- Verified formatting, Kotlin compilation, and debug assembly with the new target SDK.

## Non-goals
- No AGP/Gradle/Kotlin toolchain upgrades.
- No `compileSdk` bump.
- No `minSdk` bump.

## Files Changed
- `buildSrc/src/main/kotlin/mihon/buildlogic/AndroidConfig.kt`

## Verification
- Commands run:
  - `./gradlew spotlessCheck`
  - `./gradlew :app:compileDebugKotlin`
  - `./gradlew :app:assembleDebug`
- Results:
  - All commands passed locally.
- Not tested:
  - Manual smoke scenarios (startup, library update, downloads, reader, player, notifications).
  - API 35/API 26 device runs (no connected emulator/device in this environment).

## Risk
- Main risk is runtime behavior changes gated by `targetSdk=35` (edge-to-edge/FGS behavior) that require device-level smoke validation.
- Mitigation: change is isolated to one build constant and can be reverted cleanly.

## SLO Impact
- No expected direct SLO impact from this configuration-only change.

## Rollback
- Revert this PR to restore `TARGET_SDK` to 34.

## Release Notes
- Internal build configuration update for Play target SDK compliance; no direct user-facing feature change.

## Checklist
- [x] Naming conventions followed (use "Rayniyomi" in user-facing text, see [naming conventions](../docs/governance/naming-conventions.md))
- [x] Branch rebased on latest main and verification re-run (see [rebase policy](../docs/governance/agent-workflow.md#rebase-before-merge-policy-r45))
- [x] New coroutine scopes have documented owner and cancellation path
- [x] No new `runBlocking` on UI/main thread paths

## Definition of Done (DoD)
- [x] Acceptance criteria met and non-goals respected
- [x] Verification matrix completed (Risk Tier: T2)
- [x] Self-review completed
- [x] Rebased on latest `main` and revalidated (mandatory for merge)
- [ ] Sprint board updated (branch, commit, checks, PR link)
- [x] Release notes drafted (if applicable)
