### PR TITLE
chore: upgrade non-AGP/non-Kotlin Gradle plugins (R386)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,17 +1,17 @@
 [versions]
 aboutlib_version = "11.6.3"
 cast = "22.0.0"
-google_services = "4.4.2"
+google_services = "4.4.4"
 leakcanary = "2.14"
 mediarouter = "1.7.0"
-moko = "0.24.5"
+moko = "0.26.0"
 okhttp_version = "5.0.0-alpha.14"
 richtext = "0.20.0"
 shizuku_version = "13.1.0"
-sqldelight = "2.0.2"
+sqldelight = "2.2.1"
 sqlite = "2.4.0"
 voyager = "1.0.1"
-spotless = "7.0.2"
+spotless = "8.2.1"
 ktlint-core = "1.7.1"
 
 [libraries]

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -39,7 +39,7 @@ dependencyResolutionManagement {
 }
 
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.9.0"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")


### PR DESCRIPTION
## Ticket
- ID: R386
- Priority: P1
- Risk Tier: T2
- GitHub Issue: Closes #386

## Objective
- Upgrade non-AGP/non-Kotlin Gradle plugins to current stable releases while keeping existing AGP/Kotlin versions unchanged.

## Scope
- Updated plugin/tooling versions:
  - `com.google.gms.google-services` `4.4.2` -> `4.4.4`
  - `app.cash.sqldelight` `2.0.2` -> `2.2.1`
  - `dev.icerock.mobile.multiplatform-resources` `0.24.5` -> `0.26.0`
  - `com.diffplug.spotless` `7.0.2` -> `8.2.1`
  - `org.gradle.toolchains.foojay-resolver-convention` `0.9.0` -> `1.0.0`
- No Gradle script behavior changes were required beyond version bumps.

## Non-goals
- No AGP version changes.
- No Kotlin compiler/plugin version changes.
- No runtime feature or product behavior changes.

## Files Changed
- `gradle/libs.versions.toml`
- `settings.gradle.kts`

## Verification
- Commands run:
  - `./gradlew spotlessCheck`
  - `./gradlew :app:compileDebugKotlin`
  - `./gradlew :app:assembleDebug`
  - `./gradlew :app:testDebugUnitTest`
- Results:
  - All commands passed.
  - `assembleDebug` emitted AGP D8 Kotlin-metadata rewrite warnings for some classes, but build completed successfully.
- Not tested:
  - Manual reader/player UI smoke checks (not required by ticket acceptance criteria).

## Risk
- Low-to-moderate build-tooling risk from plugin upgrades.
- Mitigation: full ticket verification matrix passed; scope limited to version declarations only.

## SLO Impact
- No runtime SLO impact expected. Changes are build-time/tooling only.

## Rollback
- Revert this PR commit to restore previous plugin versions.

## Release Notes
- Internal maintenance: upgraded non-AGP/non-Kotlin Gradle plugins. No user-facing behavior changes.

## Checklist
- [x] Naming conventions followed (use "Rayniyomi" in user-facing text, see [naming conventions](../docs/governance/naming-conventions.md))
- [x] Branch rebased on latest main and verification re-run (see [rebase policy](../docs/governance/agent-workflow.md#rebase-before-merge-policy-r45))
- [x] New coroutine scopes have documented owner and cancellation path
- [x] No new `runBlocking` on UI/main thread paths

## Definition of Done (DoD)
- [x] Acceptance criteria met and non-goals respected
- [x] Verification matrix completed (Risk Tier: T2)
- [x] Self-review completed
- [x] Rebased on latest `main` and revalidated (mandatory for merge)
- [x] Sprint board updated (branch, commit, checks, PR link)
- [x] Release notes drafted (if applicable)

