### PR TITLE
fix: make error-log write outcomes explicit with sealed result types (R387)

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupNotifier.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupNotifier.kt
@@ -6,18 +6,20 @@ import androidx.core.app.NotificationCompat
 import com.hippo.unifile.UniFile
 import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.core.security.SecurityPreferences
+import eu.kanade.tachiyomi.data.notification.ErrorLogWriteOutcome
 import eu.kanade.tachiyomi.data.notification.NotificationReceiver
 import eu.kanade.tachiyomi.data.notification.Notifications
-import eu.kanade.tachiyomi.data.notification.shouldAttachRestoreErrorLogAction
+import eu.kanade.tachiyomi.data.notification.resolveRestoreErrorLogFileForAction
 import eu.kanade.tachiyomi.util.storage.getUriCompat
 import eu.kanade.tachiyomi.util.system.cancelNotification
 import eu.kanade.tachiyomi.util.system.notificationBuilder
 import eu.kanade.tachiyomi.util.system.notify
+import logcat.LogPriority
 import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.core.common.storage.displayablePath
+import tachiyomi.core.common.util.system.logcat
 import tachiyomi.i18n.MR
 import uy.kohesive.injekt.injectLazy
-import java.io.File
 import java.util.concurrent.TimeUnit
 
 class BackupNotifier(private val context: Context) {
@@ -138,7 +140,7 @@ class BackupNotifier(private val context: Context) {
     fun showRestoreComplete(
         time: Long,
         errorCount: Int,
-        errorLogFile: File?,
+        errorLogWriteOutcome: ErrorLogWriteOutcome,
         sync: Boolean,
     ) {
         val contentTitle = if (sync) {
@@ -169,9 +171,7 @@ class BackupNotifier(private val context: Context) {
             )
 
             clearActions()
-            val shareableErrorLogFile = errorLogFile?.takeIf {
-                shouldAttachRestoreErrorLogAction(errorCount, it)
-            }
+            val shareableErrorLogFile = resolveRestoreErrorLogFileForAction(errorCount, errorLogWriteOutcome)
             if (shareableErrorLogFile != null) {
                 val uri = shareableErrorLogFile.getUriCompat(context)
 
@@ -182,6 +182,11 @@ class BackupNotifier(private val context: Context) {
                     context.stringResource(MR.strings.action_show_errors),
                     errorLogIntent,
                 )
+            }
+            if (errorLogWriteOutcome is ErrorLogWriteOutcome.Failed) {
+                logcat(LogPriority.WARN, errorLogWriteOutcome.cause) {
+                    "Failed to write backup restore error log file; skipping error log notification action"
+                }
             }
 
             show(Notifications.ID_RESTORE_COMPLETE)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/BackupRestorer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/BackupRestorer.kt
@@ -22,6 +22,8 @@ import eu.kanade.tachiyomi.data.backup.restore.restorers.MangaCategoriesRestorer
 import eu.kanade.tachiyomi.data.backup.restore.restorers.MangaExtensionRepoRestorer
 import eu.kanade.tachiyomi.data.backup.restore.restorers.MangaRestorer
 import eu.kanade.tachiyomi.data.backup.restore.restorers.PreferenceRestorer
+import eu.kanade.tachiyomi.data.notification.ErrorLogWriteOutcome
+import eu.kanade.tachiyomi.data.notification.writeErrorLogOutcome
 import eu.kanade.tachiyomi.util.system.createFileInCacheDir
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.coroutineScope
@@ -32,7 +34,6 @@ import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.i18n.MR
 import tachiyomi.i18n.aniyomi.AYMR
-import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -341,22 +342,17 @@ class BackupRestorer(
         return lightNovelBackupDataSource.isPluginInstalled()
     }
 
-    private fun writeErrorLog(): File? {
-        try {
-            if (errors.isNotEmpty()) {
-                val file = context.createFileInCacheDir("aniyomi_restore_error.txt")
-                val sdf = SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS", Locale.getDefault())
+    private fun writeErrorLog(): ErrorLogWriteOutcome {
+        return writeErrorLogOutcome(hasErrors = errors.isNotEmpty()) {
+            val file = context.createFileInCacheDir("aniyomi_restore_error.txt")
+            val sdf = SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS", Locale.getDefault())
 
-                file.bufferedWriter().use { out ->
-                    errors.forEach { (date, message) ->
-                        out.write("[${sdf.format(date)}] $message\n")
-                    }
+            file.bufferedWriter().use { out ->
+                errors.forEach { (date, message) ->
+                    out.write("[${sdf.format(date)}] $message\n")
                 }
-                return file
             }
-        } catch (e: Exception) {
-            logcat(LogPriority.WARN, e) { "Failed to create backup restore error log file" }
+            file
         }
-        return null
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/anime/AnimeLibraryUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/anime/AnimeLibraryUpdateJob.kt
@@ -30,8 +30,10 @@ import eu.kanade.tachiyomi.data.download.anime.AnimeDownloadManager
 import eu.kanade.tachiyomi.data.library.AutoUpdateCandidate
 import eu.kanade.tachiyomi.data.library.AutoUpdateSkipReason
 import eu.kanade.tachiyomi.data.library.evaluateAutoUpdateCandidate
+import eu.kanade.tachiyomi.data.notification.ErrorLogWriteOutcome
 import eu.kanade.tachiyomi.data.notification.Notifications
 import eu.kanade.tachiyomi.data.notification.hasShareableErrorLogFile
+import eu.kanade.tachiyomi.data.notification.writeErrorLogOutcome
 import eu.kanade.tachiyomi.util.storage.getUriCompat
 import eu.kanade.tachiyomi.util.system.createFileInCacheDir
 import eu.kanade.tachiyomi.util.system.isConnectedToWifi
@@ -69,7 +71,6 @@ import tachiyomi.i18n.MR
 import tachiyomi.i18n.aniyomi.AYMR
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
-import java.io.File
 import java.time.Instant
 import java.time.ZonedDateTime
 import java.util.concurrent.CopyOnWriteArrayList
@@ -343,16 +344,25 @@ class AnimeLibraryUpdateJob(private val context: Context, workerParams: WorkerPa
         }
 
         if (failedUpdates.isNotEmpty()) {
-            val errorFile = writeErrorFile(failedUpdates)
-            val shareableErrorFile = errorFile?.takeIf { hasShareableErrorLogFile(it) }
-            if (shareableErrorFile != null) {
-                notifier.showUpdateErrorNotification(
-                    failedUpdates.size,
-                    shareableErrorFile.getUriCompat(context),
-                )
-            } else {
-                logcat(LogPriority.WARN) {
-                    "Failed to write anime library update error file; skipping error log notification action"
+            when (val errorLogOutcome = writeErrorFile(failedUpdates)) {
+                is ErrorLogWriteOutcome.Created -> {
+                    val shareableErrorFile = errorLogOutcome.file.takeIf(::hasShareableErrorLogFile)
+                    if (shareableErrorFile != null) {
+                        notifier.showUpdateErrorNotification(
+                            failedUpdates.size,
+                            shareableErrorFile.getUriCompat(context),
+                        )
+                    } else {
+                        logcat(LogPriority.WARN) {
+                            "Anime library update error log file missing; skipping error log notification action"
+                        }
+                    }
+                }
+                ErrorLogWriteOutcome.NoErrors -> Unit
+                is ErrorLogWriteOutcome.Failed -> {
+                    logcat(LogPriority.WARN, errorLogOutcome.cause) {
+                        "Failed to write anime library update error file; skipping error log notification action"
+                    }
                 }
             }
         }
@@ -419,35 +429,30 @@ class AnimeLibraryUpdateJob(private val context: Context, workerParams: WorkerPa
     /**
      * Writes basic file of update errors to cache dir.
      */
-    private fun writeErrorFile(errors: List<Pair<Anime, String?>>): File? {
-        try {
-            if (errors.isNotEmpty()) {
-                val file = context.createFileInCacheDir("aniyomi_update_errors.txt")
-                file.bufferedWriter().use { out ->
-                    out.write(
-                        context.stringResource(MR.strings.library_errors_help, ERROR_LOG_HELP_URL) + "\n\n",
-                    )
-                    // Error file format:
-                    // ! Error
-                    //   # Source
-                    //     - Anime
-                    errors.groupBy({ it.second }, { it.first }).forEach { (error, animes) ->
-                        out.write("\n! ${error}\n")
-                        animes.groupBy { it.source }.forEach { (srcId, animes) ->
-                            val source = sourceManager.getOrStub(srcId)
-                            out.write("  # $source\n")
-                            animes.forEach {
-                                out.write("    - ${it.title}\n")
-                            }
+    private fun writeErrorFile(errors: List<Pair<Anime, String?>>): ErrorLogWriteOutcome {
+        return writeErrorLogOutcome(hasErrors = errors.isNotEmpty()) {
+            val file = context.createFileInCacheDir("aniyomi_update_errors.txt")
+            file.bufferedWriter().use { out ->
+                out.write(
+                    context.stringResource(MR.strings.library_errors_help, ERROR_LOG_HELP_URL) + "\n\n",
+                )
+                // Error file format:
+                // ! Error
+                //   # Source
+                //     - Anime
+                errors.groupBy({ it.second }, { it.first }).forEach { (error, animes) ->
+                    out.write("\n! ${error}\n")
+                    animes.groupBy { it.source }.forEach { (srcId, animes) ->
+                        val source = sourceManager.getOrStub(srcId)
+                        out.write("  # $source\n")
+                        animes.forEach {
+                            out.write("    - ${it.title}\n")
                         }
                     }
                 }
-                return file
             }
-        } catch (e: Exception) {
-            logcat(LogPriority.WARN, e) { "Failed to create anime library update error file" }
+            file
         }
-        return null
     }
 
     companion object {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/manga/MangaLibraryUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/manga/MangaLibraryUpdateJob.kt
@@ -26,8 +26,10 @@ import eu.kanade.tachiyomi.data.download.manga.MangaDownloadManager
 import eu.kanade.tachiyomi.data.library.AutoUpdateCandidate
 import eu.kanade.tachiyomi.data.library.AutoUpdateSkipReason
 import eu.kanade.tachiyomi.data.library.evaluateAutoUpdateCandidate
+import eu.kanade.tachiyomi.data.notification.ErrorLogWriteOutcome
 import eu.kanade.tachiyomi.data.notification.Notifications
 import eu.kanade.tachiyomi.data.notification.hasShareableErrorLogFile
+import eu.kanade.tachiyomi.data.notification.writeErrorLogOutcome
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.model.UpdateStrategy
 import eu.kanade.tachiyomi.util.storage.getUriCompat
@@ -65,7 +67,6 @@ import tachiyomi.domain.source.manga.service.MangaSourceManager
 import tachiyomi.i18n.MR
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
-import java.io.File
 import java.time.Instant
 import java.time.ZonedDateTime
 import java.util.concurrent.CopyOnWriteArrayList
@@ -315,16 +316,25 @@ class MangaLibraryUpdateJob(private val context: Context, workerParams: WorkerPa
         }
 
         if (failedUpdates.isNotEmpty()) {
-            val errorFile = writeErrorFile(failedUpdates)
-            val shareableErrorFile = errorFile?.takeIf { hasShareableErrorLogFile(it) }
-            if (shareableErrorFile != null) {
-                notifier.showUpdateErrorNotification(
-                    failedUpdates.size,
-                    shareableErrorFile.getUriCompat(context),
-                )
-            } else {
-                logcat(LogPriority.WARN) {
-                    "Failed to write manga library update error file; skipping error log notification action"
+            when (val errorLogOutcome = writeErrorFile(failedUpdates)) {
+                is ErrorLogWriteOutcome.Created -> {
+                    val shareableErrorFile = errorLogOutcome.file.takeIf(::hasShareableErrorLogFile)
+                    if (shareableErrorFile != null) {
+                        notifier.showUpdateErrorNotification(
+                            failedUpdates.size,
+                            shareableErrorFile.getUriCompat(context),
+                        )
+                    } else {
+                        logcat(LogPriority.WARN) {
+                            "Manga library update error log file missing; skipping error log notification action"
+                        }
+                    }
+                }
+                ErrorLogWriteOutcome.NoErrors -> Unit
+                is ErrorLogWriteOutcome.Failed -> {
+                    logcat(LogPriority.WARN, errorLogOutcome.cause) {
+                        "Failed to write manga library update error file; skipping error log notification action"
+                    }
                 }
             }
         }
@@ -391,35 +401,30 @@ class MangaLibraryUpdateJob(private val context: Context, workerParams: WorkerPa
     /**
      * Writes basic file of update errors to cache dir.
      */
-    private fun writeErrorFile(errors: List<Pair<Manga, String?>>): File? {
-        try {
-            if (errors.isNotEmpty()) {
-                val file = context.createFileInCacheDir("aniyomi_update_errors.txt")
-                file.bufferedWriter().use { out ->
-                    out.write(
-                        context.stringResource(MR.strings.library_errors_help, ERROR_LOG_HELP_URL) + "\n\n",
-                    )
-                    // Error file format:
-                    // ! Error
-                    //   # Source
-                    //     - Manga
-                    errors.groupBy({ it.second }, { it.first }).forEach { (error, mangas) ->
-                        out.write("\n! ${error}\n")
-                        mangas.groupBy { it.source }.forEach { (srcId, mangas) ->
-                            val source = sourceManager.getOrStub(srcId)
-                            out.write("  # $source\n")
-                            mangas.forEach {
-                                out.write("    - ${it.title}\n")
-                            }
+    private fun writeErrorFile(errors: List<Pair<Manga, String?>>): ErrorLogWriteOutcome {
+        return writeErrorLogOutcome(hasErrors = errors.isNotEmpty()) {
+            val file = context.createFileInCacheDir("aniyomi_update_errors.txt")
+            file.bufferedWriter().use { out ->
+                out.write(
+                    context.stringResource(MR.strings.library_errors_help, ERROR_LOG_HELP_URL) + "\n\n",
+                )
+                // Error file format:
+                // ! Error
+                //   # Source
+                //     - Manga
+                errors.groupBy({ it.second }, { it.first }).forEach { (error, mangas) ->
+                    out.write("\n! ${error}\n")
+                    mangas.groupBy { it.source }.forEach { (srcId, mangas) ->
+                        val source = sourceManager.getOrStub(srcId)
+                        out.write("  # $source\n")
+                        mangas.forEach {
+                            out.write("    - ${it.title}\n")
                         }
                     }
                 }
-                return file
             }
-        } catch (e: Exception) {
-            logcat(LogPriority.WARN, e) { "Failed to create manga library update error file" }
+            file
         }
-        return null
     }
 
     companion object {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/notification/ErrorLogGuards.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/notification/ErrorLogGuards.kt
@@ -2,10 +2,40 @@ package eu.kanade.tachiyomi.data.notification
 
 import java.io.File
 
-internal fun hasShareableErrorLogFile(errorLogFile: File?): Boolean {
-    return errorLogFile?.exists() == true
+sealed interface ErrorLogWriteOutcome {
+    data class Created(val file: File) : ErrorLogWriteOutcome
+    data object NoErrors : ErrorLogWriteOutcome
+    data class Failed(val cause: Throwable? = null) : ErrorLogWriteOutcome
 }
 
-internal fun shouldAttachRestoreErrorLogAction(errorCount: Int, errorLogFile: File?): Boolean {
-    return errorCount > 0 && hasShareableErrorLogFile(errorLogFile)
+internal inline fun writeErrorLogOutcome(
+    hasErrors: Boolean,
+    writeFile: () -> File,
+): ErrorLogWriteOutcome {
+    if (!hasErrors) return ErrorLogWriteOutcome.NoErrors
+    return runCatching { writeFile() }
+        .fold(
+            onSuccess = { ErrorLogWriteOutcome.Created(it) },
+            onFailure = { ErrorLogWriteOutcome.Failed(it) },
+        )
+}
+
+internal fun hasShareableErrorLogFile(errorLogFile: File): Boolean {
+    return errorLogFile.exists()
+}
+
+internal fun resolveRestoreErrorLogFileForAction(
+    errorCount: Int,
+    errorLogWriteOutcome: ErrorLogWriteOutcome,
+): File? {
+    if (errorCount <= 0) return null
+    val errorLogFile = (errorLogWriteOutcome as? ErrorLogWriteOutcome.Created)?.file ?: return null
+    return errorLogFile.takeIf(::hasShareableErrorLogFile)
+}
+
+internal fun shouldAttachRestoreErrorLogAction(
+    errorCount: Int,
+    errorLogWriteOutcome: ErrorLogWriteOutcome,
+): Boolean {
+    return resolveRestoreErrorLogFileForAction(errorCount, errorLogWriteOutcome) != null
 }

--- a/app/src/test/java/eu/kanade/tachiyomi/data/notification/ErrorLogGuardsTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/data/notification/ErrorLogGuardsTest.kt
@@ -1,20 +1,19 @@
 package eu.kanade.tachiyomi.data.notification
 
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
+import java.io.IOException
 import java.nio.file.Path
 
 class ErrorLogGuardsTest {
 
     @TempDir
     lateinit var tempDir: Path
-
-    @Test
-    fun `hasShareableErrorLogFile returns false for null file`() {
-        assertFalse(hasShareableErrorLogFile(null))
-    }
 
     @Test
     fun `hasShareableErrorLogFile returns false for missing file`() {
@@ -33,27 +32,96 @@ class ErrorLogGuardsTest {
     }
 
     @Test
-    fun `shouldAttachRestoreErrorLogAction returns false when no errors`() {
-        val existingFile = tempDir.resolve("errors.txt").toFile().apply {
-            writeText("error")
+    fun `writeErrorLogOutcome returns NoErrors when no errors exist`() {
+        val outcome = writeErrorLogOutcome(hasErrors = false) {
+            tempDir.resolve("errors.txt").toFile()
         }
 
-        assertFalse(shouldAttachRestoreErrorLogAction(0, existingFile))
+        assertTrue(outcome is ErrorLogWriteOutcome.NoErrors)
     }
 
     @Test
-    fun `shouldAttachRestoreErrorLogAction returns false when file missing`() {
+    fun `writeErrorLogOutcome returns Created when file write succeeds`() {
+        val expected = tempDir.resolve("errors.txt").toFile().apply { writeText("error") }
+        val outcome = writeErrorLogOutcome(hasErrors = true) { expected }
+
+        assertTrue(outcome is ErrorLogWriteOutcome.Created)
+        assertEquals(expected, (outcome as ErrorLogWriteOutcome.Created).file)
+    }
+
+    @Test
+    fun `writeErrorLogOutcome returns Failed when file write throws`() {
+        val outcome = writeErrorLogOutcome(hasErrors = true) {
+            throw IOException("boom")
+        }
+
+        assertTrue(outcome is ErrorLogWriteOutcome.Failed)
+        assertEquals("boom", (outcome as ErrorLogWriteOutcome.Failed).cause?.message)
+    }
+
+    @Test
+    fun `resolveRestoreErrorLogFileForAction returns null when no errors`() {
+        val created = ErrorLogWriteOutcome.Created(tempDir.resolve("errors.txt").toFile().apply { writeText("error") })
+
+        assertNull(resolveRestoreErrorLogFileForAction(errorCount = 0, errorLogWriteOutcome = created))
+    }
+
+    @Test
+    fun `resolveRestoreErrorLogFileForAction returns null when outcome is NoErrors`() {
+        assertNull(
+            resolveRestoreErrorLogFileForAction(
+                errorCount = 1,
+                errorLogWriteOutcome = ErrorLogWriteOutcome.NoErrors,
+            ),
+        )
+    }
+
+    @Test
+    fun `resolveRestoreErrorLogFileForAction returns null when outcome is Failed`() {
+        assertNull(
+            resolveRestoreErrorLogFileForAction(
+                errorCount = 1,
+                errorLogWriteOutcome = ErrorLogWriteOutcome.Failed(IOException("write failed")),
+            ),
+        )
+    }
+
+    @Test
+    fun `resolveRestoreErrorLogFileForAction returns null when created file does not exist`() {
         val missingFile = tempDir.resolve("missing.txt").toFile()
 
-        assertFalse(shouldAttachRestoreErrorLogAction(1, missingFile))
+        assertNull(
+            resolveRestoreErrorLogFileForAction(
+                errorCount = 1,
+                errorLogWriteOutcome = ErrorLogWriteOutcome.Created(missingFile),
+            ),
+        )
     }
 
     @Test
-    fun `shouldAttachRestoreErrorLogAction returns true when errors exist and file exists`() {
+    fun `resolveRestoreErrorLogFileForAction returns file when errors exist and file exists`() {
         val existingFile = tempDir.resolve("errors.txt").toFile().apply {
             writeText("error")
         }
+        val resolved = resolveRestoreErrorLogFileForAction(
+            errorCount = 1,
+            errorLogWriteOutcome = ErrorLogWriteOutcome.Created(existingFile),
+        )
 
-        assertTrue(shouldAttachRestoreErrorLogAction(1, existingFile))
+        assertNotNull(resolved)
+        assertEquals(existingFile, resolved)
+    }
+
+    @Test
+    fun `shouldAttachRestoreErrorLogAction returns true only for action-eligible outcome`() {
+        val existingFile = tempDir.resolve("errors.txt").toFile().apply { writeText("error") }
+        val created = ErrorLogWriteOutcome.Created(existingFile)
+        val noErrors = ErrorLogWriteOutcome.NoErrors
+        val failed = ErrorLogWriteOutcome.Failed(IOException("write failed"))
+
+        assertTrue(shouldAttachRestoreErrorLogAction(1, created))
+        assertFalse(shouldAttachRestoreErrorLogAction(0, created))
+        assertFalse(shouldAttachRestoreErrorLogAction(1, noErrors))
+        assertFalse(shouldAttachRestoreErrorLogAction(1, failed))
     }
 }


### PR DESCRIPTION
## Ticket
- ID: R387
- Priority: P1
- Risk Tier: T2
- GitHub Issue: Closes #387

## Objective
- Replace ambiguous nullable error-log write outcomes with explicit, exhaustive result states so notification/action behavior is deterministic and failure modes are observable.

## Scope
- Added shared sealed outcome model for error-log writes in host app paths.
- Refactored manga/anime library update error-log writers and backup restore error-log writer from `File?` to sealed outcomes.
- Refactored host call sites and restore notifier boundary to branch exhaustively on `Created`/`NoErrors`/`Failed`.
- Added/updated tests in `ErrorLogGuardsTest` for mapping and action-attachment behavior.
- Audited light novel plugin paths requested for #387.

## Non-goals
- No AGP/Kotlin/plugin version upgrades.
- No behavior changes outside host error-log write/action paths.
- No light novel plugin implementation changes (audit-only unless nullable/sentinel ambiguity found).

## Files Changed
- `app/src/main/java/eu/kanade/tachiyomi/data/notification/ErrorLogGuards.kt`
- `app/src/main/java/eu/kanade/tachiyomi/data/library/manga/MangaLibraryUpdateJob.kt`
- `app/src/main/java/eu/kanade/tachiyomi/data/library/anime/AnimeLibraryUpdateJob.kt`
- `app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/BackupRestorer.kt`
- `app/src/main/java/eu/kanade/tachiyomi/data/backup/BackupNotifier.kt`
- `app/src/test/java/eu/kanade/tachiyomi/data/notification/ErrorLogGuardsTest.kt`

## Plugin Audit Results
- Audited (no code changes):
  - `lightnovel-plugin/src/main/java/xyz/rayniyomi/plugin/lightnovel/backup/BackupLightNovelRestorer.kt`
  - `lightnovel-plugin/src/main/java/xyz/rayniyomi/plugin/lightnovel/backup/LightNovelBackupContentProvider.kt`
  - `lightnovel-plugin/src/main/java/xyz/rayniyomi/plugin/lightnovel/data/NovelStorage.kt`
- Result: no nullable `File?` error-log write outcomes and no sentinel-file pattern on plugin error-log notification paths.
- Plugin restore success/failure remains boolean-driven and not wired to host error-log notification action attachment; outside #387 scope.

## Verification
- Commands run:
  - `./gradlew spotlessCheck`
  - `./gradlew :app:compileDebugKotlin`
  - `./gradlew :app:testDebugUnitTest --tests "eu.kanade.tachiyomi.data.notification.ErrorLogGuardsTest"`
  - `./gradlew :app:testDebugUnitTest`
- Results:
  - All commands passed locally.
  - Pre-push hooks reran `spotlessCheck` and `:app:compileDebugKotlin` successfully during `git push`.
- Not tested:
  - Full app runtime/manual device flows (notification tap path) not manually exercised in this ticket.

## Risk
- Primary regression risk is restore/update notification action attachment logic.
- Mitigations:
  - Single shared guard/mapping helpers in `ErrorLogGuards.kt`.
  - Exhaustive branching at call sites.
  - Added targeted tests for `NoErrors`, `Created`, and `Failed` outcomes plus action-eligibility checks.

## SLO Impact
- No runtime performance/SLO target changes expected.
- Minor logging on explicit write failures only.

## Rollback
- Revert this PR commit to restore prior nullable `File?` flow.
- No schema/data migration is involved.

## Release Notes
- Internal reliability improvement: backup/library update error-log handling now uses explicit result states to avoid ambiguous notification-action behavior.

## Checklist
- [x] Naming conventions followed (use "Rayniyomi" in user-facing text, see [naming conventions](../docs/governance/naming-conventions.md))
- [x] Branch rebased on latest main and verification re-run (see [rebase policy](../docs/governance/agent-workflow.md#rebase-before-merge-policy-r45))
- [x] New coroutine scopes have documented owner and cancellation path
- [x] No new `runBlocking` on UI/main thread paths

## Definition of Done (DoD)
- [x] Acceptance criteria met and non-goals respected
- [x] Verification matrix completed (Risk Tier: T2)
- [x] Self-review completed
- [x] Rebased on latest `main` and revalidated (mandatory for merge)
- [ ] Sprint board updated (branch, commit, checks, PR link)
- [x] Release notes drafted (if applicable)
