### PR TITLE
refactor: extract shared source health check abstraction (R398)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 ### Changed
 
 - Migrated Kotlin context receivers to context parameters for Kotlin 2.2+ compatibility
+- **Source health check refactor** — shared health check state machine extracted into a reusable abstraction used by manga, anime, and light novel sources
 
 ### Other
 

--- a/app/src/main/java/eu/kanade/domain/DomainModule.kt
+++ b/app/src/main/java/eu/kanade/domain/DomainModule.kt
@@ -22,6 +22,7 @@ import eu.kanade.domain.items.chapter.interactor.SetReadStatus
 import eu.kanade.domain.items.chapter.interactor.SyncChaptersWithSource
 import eu.kanade.domain.items.episode.interactor.SetSeenStatus
 import eu.kanade.domain.items.episode.interactor.SyncEpisodesWithSource
+import eu.kanade.domain.source.anime.AnimeSourceHealthChecker
 import eu.kanade.domain.source.anime.interactor.GetAnimeIncognitoState
 import eu.kanade.domain.source.anime.interactor.GetAnimeSourcesWithFavoriteCount
 import eu.kanade.domain.source.anime.interactor.GetEnabledAnimeSources
@@ -31,6 +32,7 @@ import eu.kanade.domain.source.anime.interactor.ToggleAnimeSource
 import eu.kanade.domain.source.anime.interactor.ToggleAnimeSourcePin
 import eu.kanade.domain.source.interactor.SetMigrateSorting
 import eu.kanade.domain.source.interactor.ToggleLanguage
+import eu.kanade.domain.source.manga.MangaSourceHealthChecker
 import eu.kanade.domain.source.manga.interactor.GetEnabledMangaSources
 import eu.kanade.domain.source.manga.interactor.GetLanguagesWithMangaSources
 import eu.kanade.domain.source.manga.interactor.GetMangaIncognitoState
@@ -38,6 +40,7 @@ import eu.kanade.domain.source.manga.interactor.GetMangaSourcesWithFavoriteCount
 import eu.kanade.domain.source.manga.interactor.ToggleMangaIncognito
 import eu.kanade.domain.source.manga.interactor.ToggleMangaSource
 import eu.kanade.domain.source.manga.interactor.ToggleMangaSourcePin
+import eu.kanade.domain.source.novel.LightNovelPluginHealthChecker
 import eu.kanade.domain.track.anime.interactor.AddAnimeTracks
 import eu.kanade.domain.track.anime.interactor.RefreshAllAnimeTracks
 import eu.kanade.domain.track.anime.interactor.RefreshAnimeTracks
@@ -184,6 +187,7 @@ import tachiyomi.domain.source.anime.interactor.GetAnimeSourcesWithNonLibraryAni
 import tachiyomi.domain.source.anime.interactor.GetRemoteAnime
 import tachiyomi.domain.source.anime.repository.AnimeSourceRepository
 import tachiyomi.domain.source.anime.repository.AnimeStubSourceRepository
+import tachiyomi.domain.source.health.RunSourceHealthCheck
 import tachiyomi.domain.source.manga.interactor.CheckSourceHealth
 import tachiyomi.domain.source.manga.interactor.GetMangaSourcesWithNonLibraryManga
 import tachiyomi.domain.source.manga.interactor.GetRemoteManga
@@ -370,7 +374,7 @@ class DomainModule : InjektModule {
         addSingletonFactory<AnimeSourceRepository> { AnimeSourceRepositoryImpl(get(), get()) }
         addSingletonFactory<AnimeStubSourceRepository> { AnimeStubSourceRepositoryImpl(get()) }
         addFactory { GetEnabledAnimeSources(get(), get(), get()) }
-        addFactory { CheckAnimeSourceHealth(get(), get()) }
+        addFactory { CheckAnimeSourceHealth(get(), get<AnimeSourceHealthChecker>()) }
         addFactory { GetLanguagesWithAnimeSources(get(), get()) }
         addFactory { GetRemoteAnime(get()) }
         addFactory { GetAnimeSourcesWithFavoriteCount(get(), get()) }
@@ -381,8 +385,12 @@ class DomainModule : InjektModule {
         addSingletonFactory<MangaSourceRepository> { MangaSourceRepositoryImpl(get(), get()) }
         addSingletonFactory<MangaStubSourceRepository> { MangaStubSourceRepositoryImpl(get()) }
         addSingletonFactory<SourceHealthRepository> { SourceHealthRepositoryImpl(get()) }
+        addSingletonFactory { RunSourceHealthCheck(get()) }
+        addSingletonFactory { MangaSourceHealthChecker(get()) }
+        addSingletonFactory { AnimeSourceHealthChecker(get()) }
+        addSingletonFactory { LightNovelPluginHealthChecker(get()) }
         addFactory { GetEnabledMangaSources(get(), get(), get()) }
-        addFactory { CheckSourceHealth(get(), get()) }
+        addFactory { CheckSourceHealth(get(), get<MangaSourceHealthChecker>()) }
         addFactory { GetLanguagesWithMangaSources(get(), get()) }
         addFactory { GetRemoteManga(get()) }
         addFactory { GetMangaSourcesWithFavoriteCount(get(), get()) }

--- a/app/src/main/java/eu/kanade/domain/source/anime/AnimeSourceHealthChecker.kt
+++ b/app/src/main/java/eu/kanade/domain/source/anime/AnimeSourceHealthChecker.kt
@@ -1,0 +1,20 @@
+package eu.kanade.domain.source.anime
+
+import eu.kanade.tachiyomi.animesource.AnimeCatalogueSource
+import tachiyomi.domain.source.anime.service.AnimeSourceManager
+import tachiyomi.domain.source.health.SourceHealthChecker
+import tachiyomi.source.local.entries.anime.LocalAnimeSource
+
+class AnimeSourceHealthChecker(
+    private val sourceManager: AnimeSourceManager,
+) : SourceHealthChecker {
+    override suspend fun probe(sourceId: Long) {
+        val source = sourceManager.get(sourceId) as? AnimeCatalogueSource
+            ?: throw IllegalStateException("Source $sourceId not available")
+        source.getPopularAnime(1)
+    }
+
+    override fun shouldSkip(sourceId: Long): Boolean =
+        sourceId == LocalAnimeSource.ID ||
+            sourceManager.get(sourceId) !is AnimeCatalogueSource
+}

--- a/app/src/main/java/eu/kanade/domain/source/manga/MangaSourceHealthChecker.kt
+++ b/app/src/main/java/eu/kanade/domain/source/manga/MangaSourceHealthChecker.kt
@@ -1,0 +1,20 @@
+package eu.kanade.domain.source.manga
+
+import eu.kanade.tachiyomi.source.CatalogueSource
+import tachiyomi.domain.source.health.SourceHealthChecker
+import tachiyomi.domain.source.manga.service.MangaSourceManager
+import tachiyomi.source.local.entries.manga.LocalMangaSource
+
+class MangaSourceHealthChecker(
+    private val sourceManager: MangaSourceManager,
+) : SourceHealthChecker {
+    override suspend fun probe(sourceId: Long) {
+        val source = sourceManager.get(sourceId) as? CatalogueSource
+            ?: throw IllegalStateException("Source $sourceId not available")
+        source.getPopularManga(1)
+    }
+
+    override fun shouldSkip(sourceId: Long): Boolean =
+        sourceId == LocalMangaSource.ID ||
+            sourceManager.get(sourceId) !is CatalogueSource
+}

--- a/app/src/main/java/eu/kanade/domain/source/novel/LightNovelPluginHealthChecker.kt
+++ b/app/src/main/java/eu/kanade/domain/source/novel/LightNovelPluginHealthChecker.kt
@@ -1,0 +1,16 @@
+package eu.kanade.domain.source.novel
+
+import eu.kanade.tachiyomi.feature.novel.LightNovelPluginManager
+import tachiyomi.domain.source.health.SourceHealthChecker
+
+class LightNovelPluginHealthChecker(
+    private val pluginManager: LightNovelPluginManager,
+) : SourceHealthChecker {
+    override suspend fun probe(sourceId: Long) {
+        if (!pluginManager.isPluginReady()) {
+            throw IllegalStateException("LN plugin not ready")
+        }
+    }
+
+    override fun shouldSkip(sourceId: Long): Boolean = false
+}

--- a/app/src/test/java/eu/kanade/domain/source/anime/AnimeSourceHealthCheckerTest.kt
+++ b/app/src/test/java/eu/kanade/domain/source/anime/AnimeSourceHealthCheckerTest.kt
@@ -1,0 +1,88 @@
+package eu.kanade.domain.source.anime
+
+import eu.kanade.tachiyomi.animesource.AnimeCatalogueSource
+import eu.kanade.tachiyomi.animesource.AnimeSource
+import eu.kanade.tachiyomi.animesource.model.AnimesPage
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
+import tachiyomi.domain.source.anime.service.AnimeSourceManager
+
+@Execution(ExecutionMode.CONCURRENT)
+class AnimeSourceHealthCheckerTest {
+
+    private val sourceManager: AnimeSourceManager = mockk()
+    private val checker = AnimeSourceHealthChecker(sourceManager)
+
+    private val testSourceId = 42L
+    private val localSourceId = 0L // LocalAnimeSource.ID
+
+    // --- shouldSkip ---
+
+    @Test
+    fun `shouldSkip returns true for local source ID without calling sourceManager`() {
+        // No stubbing needed — short-circuit prevents sourceManager.get(0L)
+        val result = checker.shouldSkip(localSourceId)
+
+        result shouldBe true
+    }
+
+    @Test
+    fun `shouldSkip returns true when source is null`() {
+        every { sourceManager.get(testSourceId) } returns null
+
+        val result = checker.shouldSkip(testSourceId)
+
+        result shouldBe true
+    }
+
+    @Test
+    fun `shouldSkip returns true when source is not AnimeCatalogueSource`() {
+        val plainSource: AnimeSource = mockk()
+        every { sourceManager.get(testSourceId) } returns plainSource
+
+        val result = checker.shouldSkip(testSourceId)
+
+        result shouldBe true
+    }
+
+    @Test
+    fun `shouldSkip returns false for AnimeCatalogueSource`() {
+        val catalogueSource: AnimeCatalogueSource = mockk()
+        every { sourceManager.get(testSourceId) } returns catalogueSource
+
+        val result = checker.shouldSkip(testSourceId)
+
+        result shouldBe false
+    }
+
+    // --- probe ---
+
+    @Test
+    fun `probe throws IllegalStateException when source is not available`() = runTest {
+        every { sourceManager.get(testSourceId) } returns null
+
+        var threw = false
+        try {
+            checker.probe(testSourceId)
+        } catch (e: IllegalStateException) {
+            threw = true
+        }
+
+        threw shouldBe true
+    }
+
+    @Test
+    fun `probe completes without throwing when AnimeCatalogueSource returns page`() = runTest {
+        val catalogueSource: AnimeCatalogueSource = mockk()
+        every { sourceManager.get(testSourceId) } returns catalogueSource
+        coEvery { catalogueSource.getPopularAnime(1) } returns AnimesPage(emptyList(), false)
+
+        checker.probe(testSourceId) // should not throw
+    }
+}

--- a/app/src/test/java/eu/kanade/domain/source/manga/MangaSourceHealthCheckerTest.kt
+++ b/app/src/test/java/eu/kanade/domain/source/manga/MangaSourceHealthCheckerTest.kt
@@ -1,0 +1,88 @@
+package eu.kanade.domain.source.manga
+
+import eu.kanade.tachiyomi.source.CatalogueSource
+import eu.kanade.tachiyomi.source.MangaSource
+import eu.kanade.tachiyomi.source.model.MangasPage
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
+import tachiyomi.domain.source.manga.service.MangaSourceManager
+
+@Execution(ExecutionMode.CONCURRENT)
+class MangaSourceHealthCheckerTest {
+
+    private val sourceManager: MangaSourceManager = mockk()
+    private val checker = MangaSourceHealthChecker(sourceManager)
+
+    private val testSourceId = 42L
+    private val localSourceId = 0L // LocalMangaSource.ID
+
+    // --- shouldSkip ---
+
+    @Test
+    fun `shouldSkip returns true for local source ID without calling sourceManager`() {
+        // No stubbing needed — short-circuit prevents sourceManager.get(0L)
+        val result = checker.shouldSkip(localSourceId)
+
+        result shouldBe true
+    }
+
+    @Test
+    fun `shouldSkip returns true when source is null`() {
+        every { sourceManager.get(testSourceId) } returns null
+
+        val result = checker.shouldSkip(testSourceId)
+
+        result shouldBe true
+    }
+
+    @Test
+    fun `shouldSkip returns true when source is not CatalogueSource`() {
+        val plainSource: MangaSource = mockk()
+        every { sourceManager.get(testSourceId) } returns plainSource
+
+        val result = checker.shouldSkip(testSourceId)
+
+        result shouldBe true
+    }
+
+    @Test
+    fun `shouldSkip returns false for CatalogueSource`() {
+        val catalogueSource: CatalogueSource = mockk()
+        every { sourceManager.get(testSourceId) } returns catalogueSource
+
+        val result = checker.shouldSkip(testSourceId)
+
+        result shouldBe false
+    }
+
+    // --- probe ---
+
+    @Test
+    fun `probe throws IllegalStateException when source is not available`() = runTest {
+        every { sourceManager.get(testSourceId) } returns null
+
+        var threw = false
+        try {
+            checker.probe(testSourceId)
+        } catch (e: IllegalStateException) {
+            threw = true
+        }
+
+        threw shouldBe true
+    }
+
+    @Test
+    fun `probe completes without throwing when CatalogueSource returns page`() = runTest {
+        val catalogueSource: CatalogueSource = mockk()
+        every { sourceManager.get(testSourceId) } returns catalogueSource
+        coEvery { catalogueSource.getPopularManga(1) } returns MangasPage(emptyList(), false)
+
+        checker.probe(testSourceId) // should not throw
+    }
+}

--- a/app/src/test/java/eu/kanade/domain/source/novel/LightNovelPluginHealthCheckerTest.kt
+++ b/app/src/test/java/eu/kanade/domain/source/novel/LightNovelPluginHealthCheckerTest.kt
@@ -1,0 +1,58 @@
+package eu.kanade.domain.source.novel
+
+import eu.kanade.tachiyomi.feature.novel.LightNovelPluginManager
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
+
+@Execution(ExecutionMode.CONCURRENT)
+class LightNovelPluginHealthCheckerTest {
+
+    private val pluginManager: LightNovelPluginManager = mockk()
+    private val checker = LightNovelPluginHealthChecker(pluginManager)
+
+    private val testSourceId = 1L
+
+    // --- shouldSkip ---
+
+    @Test
+    fun `shouldSkip always returns false`() {
+        val result = checker.shouldSkip(testSourceId)
+
+        result shouldBe false
+    }
+
+    @Test
+    fun `shouldSkip returns false for any source ID`() {
+        listOf(0L, 1L, Long.MAX_VALUE).forEach { id ->
+            checker.shouldSkip(id) shouldBe false
+        }
+    }
+
+    // --- probe ---
+
+    @Test
+    fun `probe completes without throwing when plugin is ready`() = runTest {
+        every { pluginManager.isPluginReady() } returns true
+
+        checker.probe(testSourceId) // should not throw
+    }
+
+    @Test
+    fun `probe throws IllegalStateException when plugin is not ready`() = runTest {
+        every { pluginManager.isPluginReady() } returns false
+
+        var threw = false
+        try {
+            checker.probe(testSourceId)
+        } catch (e: IllegalStateException) {
+            threw = true
+        }
+
+        threw shouldBe true
+    }
+}

--- a/domain/src/main/java/tachiyomi/domain/source/anime/interactor/CheckAnimeSourceHealth.kt
+++ b/domain/src/main/java/tachiyomi/domain/source/anime/interactor/CheckAnimeSourceHealth.kt
@@ -1,93 +1,12 @@
 package tachiyomi.domain.source.anime.interactor
 
-import eu.kanade.tachiyomi.animesource.AnimeCatalogueSource
-import kotlinx.coroutines.TimeoutCancellationException
-import kotlinx.coroutines.withTimeout
-import tachiyomi.domain.source.anime.service.AnimeSourceManager
+import tachiyomi.domain.source.health.RunSourceHealthCheck
+import tachiyomi.domain.source.health.SourceHealthChecker
 import tachiyomi.domain.source.manga.model.SourceHealth
-import tachiyomi.domain.source.manga.model.SourceHealthStatus
-import tachiyomi.domain.source.manga.repository.SourceHealthRepository
-import kotlin.coroutines.cancellation.CancellationException
 
 class CheckAnimeSourceHealth(
-    private val sourceManager: AnimeSourceManager,
-    private val healthRepository: SourceHealthRepository,
+    private val runner: RunSourceHealthCheck,
+    private val checker: SourceHealthChecker,
 ) {
-
-    suspend fun check(sourceId: Long): SourceHealth {
-        val source = sourceManager.get(sourceId)
-
-        // Source not available — skip, leave as UNKNOWN
-        if (source == null) {
-            return SourceHealth(
-                sourceId = sourceId,
-                status = SourceHealthStatus.UNKNOWN,
-                lastCheckedAt = System.currentTimeMillis(),
-                failureCount = 0,
-                lastError = null,
-            )
-        }
-
-        // Not a catalogue source (e.g. stub) — skip
-        val catalogueSource = source as? AnimeCatalogueSource ?: return SourceHealth(
-            sourceId = sourceId,
-            status = SourceHealthStatus.UNKNOWN,
-            lastCheckedAt = System.currentTimeMillis(),
-            failureCount = 0,
-            lastError = null,
-        )
-
-        val existing = healthRepository.get(sourceId)
-        val now = System.currentTimeMillis()
-
-        return try {
-            withTimeout(HEALTH_CHECK_TIMEOUT_MS) {
-                catalogueSource.getPopularAnime(1)
-            }
-            // Any successful response (even empty) means the source is reachable
-            val health = SourceHealth(
-                sourceId = sourceId,
-                status = SourceHealthStatus.HEALTHY,
-                lastCheckedAt = now,
-                failureCount = 0,
-                lastError = null,
-            )
-            healthRepository.upsert(health)
-            health
-        } catch (e: TimeoutCancellationException) {
-            onFailure(sourceId, existing, now, "Check timed out (10s)")
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            onFailure(sourceId, existing, now, e.message ?: e::class.simpleName ?: "Unknown error")
-        }
-    }
-
-    private suspend fun onFailure(
-        sourceId: Long,
-        existing: SourceHealth?,
-        now: Long,
-        error: String,
-    ): SourceHealth {
-        val newFailureCount = (existing?.failureCount ?: 0) + 1
-        val status = if (newFailureCount >= BROKEN_THRESHOLD) {
-            SourceHealthStatus.BROKEN
-        } else {
-            SourceHealthStatus.DEGRADED
-        }
-        val health = SourceHealth(
-            sourceId = sourceId,
-            status = status,
-            lastCheckedAt = now,
-            failureCount = newFailureCount,
-            lastError = error,
-        )
-        healthRepository.upsert(health)
-        return health
-    }
-
-    companion object {
-        private const val HEALTH_CHECK_TIMEOUT_MS = 10_000L
-        private const val BROKEN_THRESHOLD = 3
-    }
+    suspend fun check(sourceId: Long): SourceHealth = runner.check(sourceId, checker)
 }

--- a/domain/src/main/java/tachiyomi/domain/source/health/RunSourceHealthCheck.kt
+++ b/domain/src/main/java/tachiyomi/domain/source/health/RunSourceHealthCheck.kt
@@ -1,0 +1,76 @@
+package tachiyomi.domain.source.health
+
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.withTimeout
+import tachiyomi.domain.source.manga.model.SourceHealth
+import tachiyomi.domain.source.manga.model.SourceHealthStatus
+import tachiyomi.domain.source.manga.repository.SourceHealthRepository
+import kotlin.coroutines.cancellation.CancellationException
+
+class RunSourceHealthCheck(
+    private val healthRepository: SourceHealthRepository,
+) {
+    companion object {
+        const val HEALTH_CHECK_TIMEOUT_MS = 10_000L
+        const val BROKEN_THRESHOLD = 3
+    }
+
+    suspend fun check(sourceId: Long, checker: SourceHealthChecker): SourceHealth {
+        if (checker.shouldSkip(sourceId)) {
+            return SourceHealth(
+                sourceId = sourceId,
+                status = SourceHealthStatus.UNKNOWN,
+                lastCheckedAt = System.currentTimeMillis(),
+                failureCount = 0,
+                lastError = null,
+            )
+        }
+
+        val existing = healthRepository.get(sourceId)
+        val now = System.currentTimeMillis()
+
+        return try {
+            withTimeout(HEALTH_CHECK_TIMEOUT_MS) {
+                checker.probe(sourceId)
+            }
+            val health = SourceHealth(
+                sourceId = sourceId,
+                status = SourceHealthStatus.HEALTHY,
+                lastCheckedAt = now,
+                failureCount = 0,
+                lastError = null,
+            )
+            healthRepository.upsert(health)
+            health
+        } catch (e: TimeoutCancellationException) {
+            onFailure(sourceId, existing, now, "Check timed out (10s)")
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            onFailure(sourceId, existing, now, e.message ?: e::class.simpleName ?: "Unknown error")
+        }
+    }
+
+    private suspend fun onFailure(
+        sourceId: Long,
+        existing: SourceHealth?,
+        now: Long,
+        error: String,
+    ): SourceHealth {
+        val newFailureCount = (existing?.failureCount ?: 0) + 1
+        val status = if (newFailureCount >= BROKEN_THRESHOLD) {
+            SourceHealthStatus.BROKEN
+        } else {
+            SourceHealthStatus.DEGRADED
+        }
+        val health = SourceHealth(
+            sourceId = sourceId,
+            status = status,
+            lastCheckedAt = now,
+            failureCount = newFailureCount,
+            lastError = error,
+        )
+        healthRepository.upsert(health)
+        return health
+    }
+}

--- a/domain/src/main/java/tachiyomi/domain/source/health/SourceHealthChecker.kt
+++ b/domain/src/main/java/tachiyomi/domain/source/health/SourceHealthChecker.kt
@@ -1,0 +1,9 @@
+package tachiyomi.domain.source.health
+
+interface SourceHealthChecker {
+    /** Perform the health probe. Throws on failure. */
+    suspend fun probe(sourceId: Long)
+
+    /** Return true to skip the health check (e.g. local/stub sources). */
+    fun shouldSkip(sourceId: Long): Boolean
+}

--- a/domain/src/main/java/tachiyomi/domain/source/manga/interactor/CheckSourceHealth.kt
+++ b/domain/src/main/java/tachiyomi/domain/source/manga/interactor/CheckSourceHealth.kt
@@ -1,93 +1,12 @@
 package tachiyomi.domain.source.manga.interactor
 
-import eu.kanade.tachiyomi.source.CatalogueSource
-import kotlinx.coroutines.TimeoutCancellationException
-import kotlinx.coroutines.withTimeout
+import tachiyomi.domain.source.health.RunSourceHealthCheck
+import tachiyomi.domain.source.health.SourceHealthChecker
 import tachiyomi.domain.source.manga.model.SourceHealth
-import tachiyomi.domain.source.manga.model.SourceHealthStatus
-import tachiyomi.domain.source.manga.repository.SourceHealthRepository
-import tachiyomi.domain.source.manga.service.MangaSourceManager
-import kotlin.coroutines.cancellation.CancellationException
 
 class CheckSourceHealth(
-    private val sourceManager: MangaSourceManager,
-    private val healthRepository: SourceHealthRepository,
+    private val runner: RunSourceHealthCheck,
+    private val checker: SourceHealthChecker,
 ) {
-
-    suspend fun check(sourceId: Long): SourceHealth {
-        val source = sourceManager.get(sourceId)
-
-        // Source not available — skip, leave as UNKNOWN
-        if (source == null) {
-            return SourceHealth(
-                sourceId = sourceId,
-                status = SourceHealthStatus.UNKNOWN,
-                lastCheckedAt = System.currentTimeMillis(),
-                failureCount = 0,
-                lastError = null,
-            )
-        }
-
-        // Not a catalogue source (e.g. stub) — skip
-        val catalogueSource = source as? CatalogueSource ?: return SourceHealth(
-            sourceId = sourceId,
-            status = SourceHealthStatus.UNKNOWN,
-            lastCheckedAt = System.currentTimeMillis(),
-            failureCount = 0,
-            lastError = null,
-        )
-
-        val existing = healthRepository.get(sourceId)
-        val now = System.currentTimeMillis()
-
-        return try {
-            withTimeout(HEALTH_CHECK_TIMEOUT_MS) {
-                catalogueSource.getPopularManga(1)
-            }
-            // Any successful response (even empty) means the source is reachable
-            val health = SourceHealth(
-                sourceId = sourceId,
-                status = SourceHealthStatus.HEALTHY,
-                lastCheckedAt = now,
-                failureCount = 0,
-                lastError = null,
-            )
-            healthRepository.upsert(health)
-            health
-        } catch (e: TimeoutCancellationException) {
-            onFailure(sourceId, existing, now, "Check timed out (10s)")
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            onFailure(sourceId, existing, now, e.message ?: e::class.simpleName ?: "Unknown error")
-        }
-    }
-
-    private suspend fun onFailure(
-        sourceId: Long,
-        existing: SourceHealth?,
-        now: Long,
-        error: String,
-    ): SourceHealth {
-        val newFailureCount = (existing?.failureCount ?: 0) + 1
-        val status = if (newFailureCount >= BROKEN_THRESHOLD) {
-            SourceHealthStatus.BROKEN
-        } else {
-            SourceHealthStatus.DEGRADED
-        }
-        val health = SourceHealth(
-            sourceId = sourceId,
-            status = status,
-            lastCheckedAt = now,
-            failureCount = newFailureCount,
-            lastError = error,
-        )
-        healthRepository.upsert(health)
-        return health
-    }
-
-    companion object {
-        private const val HEALTH_CHECK_TIMEOUT_MS = 10_000L
-        private const val BROKEN_THRESHOLD = 3
-    }
+    suspend fun check(sourceId: Long): SourceHealth = runner.check(sourceId, checker)
 }

--- a/domain/src/test/java/tachiyomi/domain/source/anime/interactor/CheckAnimeSourceHealthTest.kt
+++ b/domain/src/test/java/tachiyomi/domain/source/anime/interactor/CheckAnimeSourceHealthTest.kt
@@ -1,236 +1,41 @@
 package tachiyomi.domain.source.anime.interactor
 
-import eu.kanade.tachiyomi.animesource.AnimeCatalogueSource
-import eu.kanade.tachiyomi.animesource.AnimeSource
-import eu.kanade.tachiyomi.animesource.model.AnimesPage
-import eu.kanade.tachiyomi.animesource.model.SAnimeImpl
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.coVerify
-import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.parallel.Execution
 import org.junit.jupiter.api.parallel.ExecutionMode
-import tachiyomi.domain.source.anime.service.AnimeSourceManager
+import tachiyomi.domain.source.health.RunSourceHealthCheck
+import tachiyomi.domain.source.health.SourceHealthChecker
 import tachiyomi.domain.source.manga.model.SourceHealth
 import tachiyomi.domain.source.manga.model.SourceHealthStatus
-import tachiyomi.domain.source.manga.repository.SourceHealthRepository
 
 @Execution(ExecutionMode.CONCURRENT)
 class CheckAnimeSourceHealthTest {
 
-    private val sourceManager: AnimeSourceManager = mockk()
-    private val healthRepository: SourceHealthRepository = mockk(relaxUnitFun = true)
-    private val interactor = CheckAnimeSourceHealth(sourceManager, healthRepository)
+    private val runner: RunSourceHealthCheck = mockk()
+    private val checker: SourceHealthChecker = mockk()
+    private val interactor = CheckAnimeSourceHealth(runner, checker)
 
     private val testSourceId = 42L
 
-    private fun createAnimesPage(count: Int = 1): AnimesPage {
-        val animes = List(count) {
-            SAnimeImpl().apply {
-                url = "/anime/$it"
-                title = "Anime $it"
-            }
-        }
-        return AnimesPage(animes, hasNextPage = false)
-    }
-
-    // --- Source not available ---
-
     @Test
-    fun `check returns UNKNOWN when source is null`() = runTest {
-        every { sourceManager.get(testSourceId) } returns null
-
-        val result = interactor.check(testSourceId)
-
-        result.sourceId shouldBe testSourceId
-        result.status shouldBe SourceHealthStatus.UNKNOWN
-        result.failureCount shouldBe 0
-    }
-
-    // --- Source is not AnimeCatalogueSource ---
-
-    @Test
-    fun `check returns UNKNOWN when source is not AnimeCatalogueSource`() = runTest {
-        val plainSource: AnimeSource = mockk()
-        every { sourceManager.get(testSourceId) } returns plainSource
-
-        val result = interactor.check(testSourceId)
-
-        result.sourceId shouldBe testSourceId
-        result.status shouldBe SourceHealthStatus.UNKNOWN
-    }
-
-    // --- Successful checks ---
-
-    @Test
-    fun `check returns HEALTHY on successful getPopularAnime with results`() = runTest {
-        val catalogueSource: AnimeCatalogueSource = mockk()
-        every { sourceManager.get(testSourceId) } returns catalogueSource
-        coEvery { catalogueSource.getPopularAnime(1) } returns createAnimesPage(3)
-        coEvery { healthRepository.get(testSourceId) } returns null
-
-        val result = interactor.check(testSourceId)
-
-        result.status shouldBe SourceHealthStatus.HEALTHY
-        result.failureCount shouldBe 0
-        result.lastError shouldBe null
-        coVerify { healthRepository.upsert(match { it.status == SourceHealthStatus.HEALTHY }) }
-    }
-
-    @Test
-    fun `check resets to HEALTHY after previous failures`() = runTest {
-        val catalogueSource: AnimeCatalogueSource = mockk()
-        every { sourceManager.get(testSourceId) } returns catalogueSource
-        coEvery { catalogueSource.getPopularAnime(1) } returns createAnimesPage(1)
-        coEvery { healthRepository.get(testSourceId) } returns SourceHealth(
+    fun `check delegates to runner with correct arguments`() = runTest {
+        val expectedHealth = SourceHealth(
             sourceId = testSourceId,
-            status = SourceHealthStatus.BROKEN,
+            status = SourceHealthStatus.HEALTHY,
             lastCheckedAt = 0L,
-            failureCount = 5,
-            lastError = "Previous error",
+            failureCount = 0,
+            lastError = null,
         )
+        coEvery { runner.check(testSourceId, checker) } returns expectedHealth
 
         val result = interactor.check(testSourceId)
 
-        result.status shouldBe SourceHealthStatus.HEALTHY
-        result.failureCount shouldBe 0
-        result.lastError shouldBe null
-    }
-
-    // --- Failure states ---
-
-    @Test
-    fun `check returns DEGRADED on first failure`() = runTest {
-        val catalogueSource: AnimeCatalogueSource = mockk()
-        every { sourceManager.get(testSourceId) } returns catalogueSource
-        coEvery { catalogueSource.getPopularAnime(1) } throws RuntimeException("Network error")
-        coEvery { healthRepository.get(testSourceId) } returns null
-
-        val result = interactor.check(testSourceId)
-
-        result.status shouldBe SourceHealthStatus.DEGRADED
-        result.failureCount shouldBe 1
-        result.lastError shouldBe "Network error"
-    }
-
-    @Test
-    fun `check returns DEGRADED on second consecutive failure`() = runTest {
-        val catalogueSource: AnimeCatalogueSource = mockk()
-        every { sourceManager.get(testSourceId) } returns catalogueSource
-        coEvery { catalogueSource.getPopularAnime(1) } throws RuntimeException("Timeout")
-        coEvery { healthRepository.get(testSourceId) } returns SourceHealth(
-            sourceId = testSourceId,
-            status = SourceHealthStatus.DEGRADED,
-            lastCheckedAt = 0L,
-            failureCount = 1,
-            lastError = "Previous error",
-        )
-
-        val result = interactor.check(testSourceId)
-
-        result.status shouldBe SourceHealthStatus.DEGRADED
-        result.failureCount shouldBe 2
-        result.lastError shouldBe "Timeout"
-    }
-
-    @Test
-    fun `check transitions to BROKEN after three consecutive failures`() = runTest {
-        val catalogueSource: AnimeCatalogueSource = mockk()
-        every { sourceManager.get(testSourceId) } returns catalogueSource
-        coEvery { catalogueSource.getPopularAnime(1) } throws RuntimeException("Still broken")
-        coEvery { healthRepository.get(testSourceId) } returns SourceHealth(
-            sourceId = testSourceId,
-            status = SourceHealthStatus.DEGRADED,
-            lastCheckedAt = 0L,
-            failureCount = 2,
-            lastError = "Previous error",
-        )
-
-        val result = interactor.check(testSourceId)
-
-        result.status shouldBe SourceHealthStatus.BROKEN
-        result.failureCount shouldBe 3
-        result.lastError shouldBe "Still broken"
-    }
-
-    @Test
-    fun `check stays BROKEN after more than three failures`() = runTest {
-        val catalogueSource: AnimeCatalogueSource = mockk()
-        every { sourceManager.get(testSourceId) } returns catalogueSource
-        coEvery { catalogueSource.getPopularAnime(1) } throws RuntimeException("Down")
-        coEvery { healthRepository.get(testSourceId) } returns SourceHealth(
-            sourceId = testSourceId,
-            status = SourceHealthStatus.BROKEN,
-            lastCheckedAt = 0L,
-            failureCount = 5,
-            lastError = "Previous error",
-        )
-
-        val result = interactor.check(testSourceId)
-
-        result.status shouldBe SourceHealthStatus.BROKEN
-        result.failureCount shouldBe 6
-    }
-
-    // --- Empty results page ---
-
-    @Test
-    fun `check treats empty results page as healthy`() = runTest {
-        val catalogueSource: AnimeCatalogueSource = mockk()
-        every { sourceManager.get(testSourceId) } returns catalogueSource
-        coEvery { catalogueSource.getPopularAnime(1) } returns AnimesPage(emptyList(), false)
-        coEvery { healthRepository.get(testSourceId) } returns null
-
-        val result = interactor.check(testSourceId)
-
-        result.status shouldBe SourceHealthStatus.HEALTHY
-        result.failureCount shouldBe 0
-        result.lastError shouldBe null
-    }
-
-    @Test
-    fun `check treats empty results page as healthy even with prior failures`() = runTest {
-        val catalogueSource: AnimeCatalogueSource = mockk()
-        every { sourceManager.get(testSourceId) } returns catalogueSource
-        coEvery { catalogueSource.getPopularAnime(1) } returns AnimesPage(emptyList(), false)
-        coEvery { healthRepository.get(testSourceId) } returns SourceHealth(
-            sourceId = testSourceId,
-            status = SourceHealthStatus.DEGRADED,
-            lastCheckedAt = 0L,
-            failureCount = 2,
-            lastError = "Previous error",
-        )
-
-        val result = interactor.check(testSourceId)
-
-        result.status shouldBe SourceHealthStatus.HEALTHY
-        result.failureCount shouldBe 0
-        result.lastError shouldBe null
-    }
-
-    // --- Repository interactions ---
-
-    @Test
-    fun `check upserts health record on failure`() = runTest {
-        val catalogueSource: AnimeCatalogueSource = mockk()
-        every { sourceManager.get(testSourceId) } returns catalogueSource
-        coEvery { catalogueSource.getPopularAnime(1) } throws RuntimeException("Error")
-        coEvery { healthRepository.get(testSourceId) } returns null
-
-        interactor.check(testSourceId)
-
-        coVerify { healthRepository.upsert(match { it.status == SourceHealthStatus.DEGRADED && it.failureCount == 1 }) }
-    }
-
-    @Test
-    fun `check does not upsert when source is null`() = runTest {
-        every { sourceManager.get(testSourceId) } returns null
-
-        interactor.check(testSourceId)
-
-        coVerify(exactly = 0) { healthRepository.upsert(any()) }
+        result shouldBe expectedHealth
+        coVerify(exactly = 1) { runner.check(testSourceId, checker) }
     }
 }

--- a/domain/src/test/java/tachiyomi/domain/source/health/RunSourceHealthCheckTest.kt
+++ b/domain/src/test/java/tachiyomi/domain/source/health/RunSourceHealthCheckTest.kt
@@ -1,0 +1,201 @@
+package tachiyomi.domain.source.health
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
+import tachiyomi.domain.source.manga.model.SourceHealth
+import tachiyomi.domain.source.manga.model.SourceHealthStatus
+import tachiyomi.domain.source.manga.repository.SourceHealthRepository
+import kotlin.coroutines.cancellation.CancellationException
+
+@Execution(ExecutionMode.CONCURRENT)
+class RunSourceHealthCheckTest {
+
+    private val healthRepository: SourceHealthRepository = mockk(relaxUnitFun = true)
+    private val checker: SourceHealthChecker = mockk()
+    private val runner = RunSourceHealthCheck(healthRepository)
+
+    private val testSourceId = 42L
+
+    // --- shouldSkip ---
+
+    @Test
+    fun `check returns UNKNOWN and skips probe when shouldSkip is true`() = runTest {
+        every { checker.shouldSkip(testSourceId) } returns true
+
+        val result = runner.check(testSourceId, checker)
+
+        result.sourceId shouldBe testSourceId
+        result.status shouldBe SourceHealthStatus.UNKNOWN
+        result.failureCount shouldBe 0
+        result.lastError shouldBe null
+        coVerify(exactly = 0) { checker.probe(any()) }
+        coVerify(exactly = 0) { healthRepository.upsert(any()) }
+    }
+
+    // --- Successful checks ---
+
+    @Test
+    fun `check returns HEALTHY on successful probe`() = runTest {
+        every { checker.shouldSkip(testSourceId) } returns false
+        coEvery { checker.probe(testSourceId) } returns Unit
+        coEvery { healthRepository.get(testSourceId) } returns null
+
+        val result = runner.check(testSourceId, checker)
+
+        result.sourceId shouldBe testSourceId
+        result.status shouldBe SourceHealthStatus.HEALTHY
+        result.failureCount shouldBe 0
+        result.lastError shouldBe null
+        coVerify { healthRepository.upsert(match { it.status == SourceHealthStatus.HEALTHY && it.failureCount == 0 }) }
+    }
+
+    @Test
+    fun `check resets to HEALTHY with zero failures after previous failures`() = runTest {
+        every { checker.shouldSkip(testSourceId) } returns false
+        coEvery { checker.probe(testSourceId) } returns Unit
+        coEvery { healthRepository.get(testSourceId) } returns SourceHealth(
+            sourceId = testSourceId,
+            status = SourceHealthStatus.BROKEN,
+            lastCheckedAt = 0L,
+            failureCount = 5,
+            lastError = "Previous error",
+        )
+
+        val result = runner.check(testSourceId, checker)
+
+        result.status shouldBe SourceHealthStatus.HEALTHY
+        result.failureCount shouldBe 0
+        result.lastError shouldBe null
+    }
+
+    // --- Failure states ---
+
+    @Test
+    fun `check returns DEGRADED on first failure`() = runTest {
+        every { checker.shouldSkip(testSourceId) } returns false
+        coEvery { checker.probe(testSourceId) } throws RuntimeException("Network error")
+        coEvery { healthRepository.get(testSourceId) } returns null
+
+        val result = runner.check(testSourceId, checker)
+
+        result.status shouldBe SourceHealthStatus.DEGRADED
+        result.failureCount shouldBe 1
+        result.lastError shouldBe "Network error"
+    }
+
+    @Test
+    fun `check returns DEGRADED on second consecutive failure`() = runTest {
+        every { checker.shouldSkip(testSourceId) } returns false
+        coEvery { checker.probe(testSourceId) } throws RuntimeException("Still down")
+        coEvery { healthRepository.get(testSourceId) } returns SourceHealth(
+            sourceId = testSourceId,
+            status = SourceHealthStatus.DEGRADED,
+            lastCheckedAt = 0L,
+            failureCount = 1,
+            lastError = "Previous error",
+        )
+
+        val result = runner.check(testSourceId, checker)
+
+        result.status shouldBe SourceHealthStatus.DEGRADED
+        result.failureCount shouldBe 2
+        result.lastError shouldBe "Still down"
+    }
+
+    @Test
+    fun `check transitions to BROKEN at failure threshold`() = runTest {
+        every { checker.shouldSkip(testSourceId) } returns false
+        coEvery { checker.probe(testSourceId) } throws RuntimeException("Broken")
+        coEvery { healthRepository.get(testSourceId) } returns SourceHealth(
+            sourceId = testSourceId,
+            status = SourceHealthStatus.DEGRADED,
+            lastCheckedAt = 0L,
+            failureCount = 2,
+            lastError = "Previous error",
+        )
+
+        val result = runner.check(testSourceId, checker)
+
+        result.status shouldBe SourceHealthStatus.BROKEN
+        result.failureCount shouldBe 3
+        result.lastError shouldBe "Broken"
+    }
+
+    @Test
+    fun `check stays BROKEN after exceeding failure threshold`() = runTest {
+        every { checker.shouldSkip(testSourceId) } returns false
+        coEvery { checker.probe(testSourceId) } throws RuntimeException("Still broken")
+        coEvery { healthRepository.get(testSourceId) } returns SourceHealth(
+            sourceId = testSourceId,
+            status = SourceHealthStatus.BROKEN,
+            lastCheckedAt = 0L,
+            failureCount = 5,
+            lastError = "Previous error",
+        )
+
+        val result = runner.check(testSourceId, checker)
+
+        result.status shouldBe SourceHealthStatus.BROKEN
+        result.failureCount shouldBe 6
+    }
+
+    // --- Timeout ---
+
+    @Test
+    fun `check returns DEGRADED when probe exceeds timeout`() = runTest {
+        every { checker.shouldSkip(testSourceId) } returns false
+        coEvery { checker.probe(testSourceId) } coAnswers { delay(15_000L) }
+        coEvery { healthRepository.get(testSourceId) } returns null
+
+        val result = runner.check(testSourceId, checker)
+
+        result.status shouldBe SourceHealthStatus.DEGRADED
+        result.failureCount shouldBe 1
+        result.lastError shouldBe "Check timed out (10s)"
+    }
+
+    // --- CancellationException propagation ---
+
+    @Test
+    fun `CancellationException propagates and is not treated as failure`() = runTest {
+        every { checker.shouldSkip(testSourceId) } returns false
+        coEvery { checker.probe(testSourceId) } throws CancellationException("Job cancelled")
+        coEvery { healthRepository.get(testSourceId) } returns null
+
+        var propagated = false
+        try {
+            runner.check(testSourceId, checker)
+        } catch (e: CancellationException) {
+            propagated = true
+        }
+
+        propagated shouldBe true
+        coVerify(exactly = 0) { healthRepository.upsert(any()) }
+    }
+
+    // --- Repository interactions ---
+
+    @Test
+    fun `check upserts DEGRADED health record on failure`() = runTest {
+        every { checker.shouldSkip(testSourceId) } returns false
+        coEvery { checker.probe(testSourceId) } throws RuntimeException("Error")
+        coEvery { healthRepository.get(testSourceId) } returns null
+
+        runner.check(testSourceId, checker)
+
+        coVerify {
+            healthRepository.upsert(
+                match { it.status == SourceHealthStatus.DEGRADED && it.failureCount == 1 },
+            )
+        }
+    }
+}

--- a/domain/src/test/java/tachiyomi/domain/source/manga/interactor/CheckSourceHealthTest.kt
+++ b/domain/src/test/java/tachiyomi/domain/source/manga/interactor/CheckSourceHealthTest.kt
@@ -1,237 +1,41 @@
 package tachiyomi.domain.source.manga.interactor
 
-import eu.kanade.tachiyomi.source.CatalogueSource
-import eu.kanade.tachiyomi.source.MangaSource
-import eu.kanade.tachiyomi.source.model.MangasPage
-import eu.kanade.tachiyomi.source.model.SManga
-import eu.kanade.tachiyomi.source.model.SMangaImpl
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.coVerify
-import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.parallel.Execution
 import org.junit.jupiter.api.parallel.ExecutionMode
+import tachiyomi.domain.source.health.RunSourceHealthCheck
+import tachiyomi.domain.source.health.SourceHealthChecker
 import tachiyomi.domain.source.manga.model.SourceHealth
 import tachiyomi.domain.source.manga.model.SourceHealthStatus
-import tachiyomi.domain.source.manga.repository.SourceHealthRepository
-import tachiyomi.domain.source.manga.service.MangaSourceManager
 
 @Execution(ExecutionMode.CONCURRENT)
 class CheckSourceHealthTest {
 
-    private val sourceManager: MangaSourceManager = mockk()
-    private val healthRepository: SourceHealthRepository = mockk(relaxUnitFun = true)
-    private val interactor = CheckSourceHealth(sourceManager, healthRepository)
+    private val runner: RunSourceHealthCheck = mockk()
+    private val checker: SourceHealthChecker = mockk()
+    private val interactor = CheckSourceHealth(runner, checker)
 
     private val testSourceId = 42L
 
-    private fun createMangasPage(count: Int = 1): MangasPage {
-        val mangas = List(count) {
-            SMangaImpl().apply {
-                url = "/manga/$it"
-                title = "Manga $it"
-            }
-        }
-        return MangasPage(mangas, hasNextPage = false)
-    }
-
-    // --- Source not available ---
-
     @Test
-    fun `check returns UNKNOWN when source is null`() = runTest {
-        every { sourceManager.get(testSourceId) } returns null
-
-        val result = interactor.check(testSourceId)
-
-        result.sourceId shouldBe testSourceId
-        result.status shouldBe SourceHealthStatus.UNKNOWN
-        result.failureCount shouldBe 0
-    }
-
-    // --- Source is not CatalogueSource ---
-
-    @Test
-    fun `check returns UNKNOWN when source is not CatalogueSource`() = runTest {
-        val plainSource: MangaSource = mockk()
-        every { sourceManager.get(testSourceId) } returns plainSource
-
-        val result = interactor.check(testSourceId)
-
-        result.sourceId shouldBe testSourceId
-        result.status shouldBe SourceHealthStatus.UNKNOWN
-    }
-
-    // --- Successful checks ---
-
-    @Test
-    fun `check returns HEALTHY on successful getPopularManga with results`() = runTest {
-        val catalogueSource: CatalogueSource = mockk()
-        every { sourceManager.get(testSourceId) } returns catalogueSource
-        coEvery { catalogueSource.getPopularManga(1) } returns createMangasPage(3)
-        coEvery { healthRepository.get(testSourceId) } returns null
-
-        val result = interactor.check(testSourceId)
-
-        result.status shouldBe SourceHealthStatus.HEALTHY
-        result.failureCount shouldBe 0
-        result.lastError shouldBe null
-        coVerify { healthRepository.upsert(match { it.status == SourceHealthStatus.HEALTHY }) }
-    }
-
-    @Test
-    fun `check resets to HEALTHY after previous failures`() = runTest {
-        val catalogueSource: CatalogueSource = mockk()
-        every { sourceManager.get(testSourceId) } returns catalogueSource
-        coEvery { catalogueSource.getPopularManga(1) } returns createMangasPage(1)
-        coEvery { healthRepository.get(testSourceId) } returns SourceHealth(
+    fun `check delegates to runner with correct arguments`() = runTest {
+        val expectedHealth = SourceHealth(
             sourceId = testSourceId,
-            status = SourceHealthStatus.BROKEN,
+            status = SourceHealthStatus.HEALTHY,
             lastCheckedAt = 0L,
-            failureCount = 5,
-            lastError = "Previous error",
+            failureCount = 0,
+            lastError = null,
         )
+        coEvery { runner.check(testSourceId, checker) } returns expectedHealth
 
         val result = interactor.check(testSourceId)
 
-        result.status shouldBe SourceHealthStatus.HEALTHY
-        result.failureCount shouldBe 0
-        result.lastError shouldBe null
-    }
-
-    // --- Failure states ---
-
-    @Test
-    fun `check returns DEGRADED on first failure`() = runTest {
-        val catalogueSource: CatalogueSource = mockk()
-        every { sourceManager.get(testSourceId) } returns catalogueSource
-        coEvery { catalogueSource.getPopularManga(1) } throws RuntimeException("Network error")
-        coEvery { healthRepository.get(testSourceId) } returns null
-
-        val result = interactor.check(testSourceId)
-
-        result.status shouldBe SourceHealthStatus.DEGRADED
-        result.failureCount shouldBe 1
-        result.lastError shouldBe "Network error"
-    }
-
-    @Test
-    fun `check returns DEGRADED on second consecutive failure`() = runTest {
-        val catalogueSource: CatalogueSource = mockk()
-        every { sourceManager.get(testSourceId) } returns catalogueSource
-        coEvery { catalogueSource.getPopularManga(1) } throws RuntimeException("Timeout")
-        coEvery { healthRepository.get(testSourceId) } returns SourceHealth(
-            sourceId = testSourceId,
-            status = SourceHealthStatus.DEGRADED,
-            lastCheckedAt = 0L,
-            failureCount = 1,
-            lastError = "Previous error",
-        )
-
-        val result = interactor.check(testSourceId)
-
-        result.status shouldBe SourceHealthStatus.DEGRADED
-        result.failureCount shouldBe 2
-        result.lastError shouldBe "Timeout"
-    }
-
-    @Test
-    fun `check transitions to BROKEN after three consecutive failures`() = runTest {
-        val catalogueSource: CatalogueSource = mockk()
-        every { sourceManager.get(testSourceId) } returns catalogueSource
-        coEvery { catalogueSource.getPopularManga(1) } throws RuntimeException("Still broken")
-        coEvery { healthRepository.get(testSourceId) } returns SourceHealth(
-            sourceId = testSourceId,
-            status = SourceHealthStatus.DEGRADED,
-            lastCheckedAt = 0L,
-            failureCount = 2,
-            lastError = "Previous error",
-        )
-
-        val result = interactor.check(testSourceId)
-
-        result.status shouldBe SourceHealthStatus.BROKEN
-        result.failureCount shouldBe 3
-        result.lastError shouldBe "Still broken"
-    }
-
-    @Test
-    fun `check stays BROKEN after more than three failures`() = runTest {
-        val catalogueSource: CatalogueSource = mockk()
-        every { sourceManager.get(testSourceId) } returns catalogueSource
-        coEvery { catalogueSource.getPopularManga(1) } throws RuntimeException("Down")
-        coEvery { healthRepository.get(testSourceId) } returns SourceHealth(
-            sourceId = testSourceId,
-            status = SourceHealthStatus.BROKEN,
-            lastCheckedAt = 0L,
-            failureCount = 5,
-            lastError = "Previous error",
-        )
-
-        val result = interactor.check(testSourceId)
-
-        result.status shouldBe SourceHealthStatus.BROKEN
-        result.failureCount shouldBe 6
-    }
-
-    // --- Empty results page ---
-
-    @Test
-    fun `check treats empty results page as healthy`() = runTest {
-        val catalogueSource: CatalogueSource = mockk()
-        every { sourceManager.get(testSourceId) } returns catalogueSource
-        coEvery { catalogueSource.getPopularManga(1) } returns MangasPage(emptyList(), false)
-        coEvery { healthRepository.get(testSourceId) } returns null
-
-        val result = interactor.check(testSourceId)
-
-        result.status shouldBe SourceHealthStatus.HEALTHY
-        result.failureCount shouldBe 0
-        result.lastError shouldBe null
-    }
-
-    @Test
-    fun `check treats empty results page as healthy even with prior failures`() = runTest {
-        val catalogueSource: CatalogueSource = mockk()
-        every { sourceManager.get(testSourceId) } returns catalogueSource
-        coEvery { catalogueSource.getPopularManga(1) } returns MangasPage(emptyList(), false)
-        coEvery { healthRepository.get(testSourceId) } returns SourceHealth(
-            sourceId = testSourceId,
-            status = SourceHealthStatus.DEGRADED,
-            lastCheckedAt = 0L,
-            failureCount = 2,
-            lastError = "Previous error",
-        )
-
-        val result = interactor.check(testSourceId)
-
-        result.status shouldBe SourceHealthStatus.HEALTHY
-        result.failureCount shouldBe 0
-        result.lastError shouldBe null
-    }
-
-    // --- Repository interactions ---
-
-    @Test
-    fun `check upserts health record on failure`() = runTest {
-        val catalogueSource: CatalogueSource = mockk()
-        every { sourceManager.get(testSourceId) } returns catalogueSource
-        coEvery { catalogueSource.getPopularManga(1) } throws RuntimeException("Error")
-        coEvery { healthRepository.get(testSourceId) } returns null
-
-        interactor.check(testSourceId)
-
-        coVerify { healthRepository.upsert(match { it.status == SourceHealthStatus.DEGRADED && it.failureCount == 1 }) }
-    }
-
-    @Test
-    fun `check does not upsert when source is null`() = runTest {
-        every { sourceManager.get(testSourceId) } returns null
-
-        interactor.check(testSourceId)
-
-        coVerify(exactly = 0) { healthRepository.upsert(any()) }
+        result shouldBe expectedHealth
+        coVerify(exactly = 1) { runner.check(testSourceId, checker) }
     }
 }


### PR DESCRIPTION
## Objective

Extract the duplicated health check state machine shared by `CheckSourceHealth` (manga) and `CheckAnimeSourceHealth` (anime) into a reusable domain-layer abstraction used by all three content types.

## Scope

**New files:**
- `domain/.../source/health/SourceHealthChecker.kt` — interface (`probe` + `shouldSkip`)
- `domain/.../source/health/RunSourceHealthCheck.kt` — shared state machine executor (timeout, failure counting, BROKEN threshold)
- `app/.../domain/source/manga/MangaSourceHealthChecker.kt` — manga probe implementation
- `app/.../domain/source/anime/AnimeSourceHealthChecker.kt` — anime probe implementation
- `app/.../domain/source/novel/LightNovelPluginHealthChecker.kt` — LN plugin readiness probe

**Modified files:**
- `CheckSourceHealth.kt` — now a thin wrapper delegating to `RunSourceHealthCheck`
- `CheckAnimeSourceHealth.kt` — same
- `DomainModule.kt` — registers `RunSourceHealthCheck` + three checker singletons
- `CHANGELOG.md` — records the refactor under Unreleased

**Test files (28 tests total, all passing):**
- `RunSourceHealthCheckTest.kt` — 10 tests covering state machine (success, degraded, broken, skip, timeout, cancellation)
- `CheckSourceHealthTest.kt` / `CheckAnimeSourceHealthTest.kt` — 1 delegation test each
- `MangaSourceHealthCheckerTest.kt` / `AnimeSourceHealthCheckerTest.kt` — 6 tests each
- `LightNovelPluginHealthCheckerTest.kt` — 4 tests

## Verification

```
./gradlew :domain:testDebugUnitTest --tests "*HealthCheck*"   # 10 passing
./gradlew :domain:testDebugUnitTest --tests "*CheckSourceHealthTest*" --tests "*CheckAnimeSourceHealthTest*"  # 2 passing
./gradlew :app:testDebugUnitTest --tests "*HealthChecker*"    # 16 passing
./gradlew spotlessCheck                                        # PASSED
./gradlew assembleDebug                                        # BUILD SUCCESSFUL
```

## Risk

**T2 — Medium.** Pure logic extraction with no new behaviour introduced. All existing health check flows (manga, anime) continue to work identically through the thin wrappers. LN health checker is new but only active when `LightNovelPluginManager` is injected into the future LN source health use case.

Closes #423