### PR TITLE
fix: prevent CrashActivity crash in :error_handler process (R442)

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/crash/CrashActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/crash/CrashActivity.kt
@@ -2,13 +2,14 @@ package eu.kanade.tachiyomi.crash
 
 import android.content.Intent
 import android.os.Bundle
+import androidx.activity.compose.setContent
+import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.material3.MaterialTheme
 import androidx.core.view.WindowCompat
 import eu.kanade.presentation.crash.CrashScreen
-import eu.kanade.tachiyomi.ui.base.activity.BaseActivity
 import eu.kanade.tachiyomi.ui.main.MainActivity
-import eu.kanade.tachiyomi.util.view.setComposeContent
 
-class CrashActivity : BaseActivity() {
+class CrashActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -16,14 +17,16 @@ class CrashActivity : BaseActivity() {
         WindowCompat.setDecorFitsSystemWindows(window, false)
 
         val exception = GlobalExceptionHandler.getThrowableFromIntent(intent)
-        setComposeContent {
-            CrashScreen(
-                exception = exception,
-                onRestartClick = {
-                    finishAffinity()
-                    startActivity(Intent(this@CrashActivity, MainActivity::class.java))
-                },
-            )
+        setContent {
+            MaterialTheme {
+                CrashScreen(
+                    exception = exception,
+                    onRestartClick = {
+                        finishAffinity()
+                        startActivity(Intent(this@CrashActivity, MainActivity::class.java))
+                    },
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/util/CrashLogUtil.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/CrashLogUtil.kt
@@ -17,19 +17,14 @@ import uy.kohesive.injekt.api.get
 import java.time.OffsetDateTime
 import java.time.ZoneId
 
-class CrashLogUtil(
-    private val context: Context,
-    private val mangaExtensionManager: MangaExtensionManager = Injekt.get(),
-    private val animeExtensionManager: AnimeExtensionManager = Injekt.get(),
-) {
+class CrashLogUtil(private val context: Context) {
 
     suspend fun dumpLogs(exception: Throwable? = null) = withNonCancellableContext {
         try {
             val file = context.createFileInCacheDir("aniyomi_crash_logs.txt")
 
             file.appendText(getDebugInfo() + "\n\n")
-            getMangaExtensionsInfo()?.let { file.appendText("$it\n\n") }
-            getAnimeExtensionsInfo()?.let { file.appendText("$it\n\n") }
+            getExtensionsInfo()?.let { file.appendText("$it\n\n") }
             exception?.let { file.appendText("$it\n\n") }
 
             Runtime.getRuntime().exec("logcat *:E -d -v year -v zone -f ${file.absolutePath}").waitFor()
@@ -64,10 +59,22 @@ class CrashLogUtil(
         //    FFmpeg version: ${Utils.VERSIONS.ffmpeg}
     }
 
-    private fun getMangaExtensionsInfo(): String? {
-        val availableExtensions = mangaExtensionManager.availableExtensionsFlow.value.associateBy { it.pkgName }
+    /**
+     * Best-effort: DI is unavailable in the :error_handler process,
+     * so we silently skip extension info when Injekt has not been initialised.
+     */
+    private fun getExtensionsInfo(): String? = runCatching {
+        val sections = listOfNotNull(
+            getMangaExtensionsInfo(Injekt.get()),
+            getAnimeExtensionsInfo(Injekt.get()),
+        )
+        sections.joinToString("\n\n").ifEmpty { null }
+    }.getOrNull()
 
-        val extensionInfoList = mangaExtensionManager.installedExtensionsFlow.value
+    private fun getMangaExtensionsInfo(manager: MangaExtensionManager): String? {
+        val availableExtensions = manager.availableExtensionsFlow.value.associateBy { it.pkgName }
+
+        val extensionInfoList = manager.installedExtensionsFlow.value
             .sortedBy { it.name }
             .mapNotNull {
                 val availableExtension = availableExtensions[it.pkgName]
@@ -90,10 +97,10 @@ class CrashLogUtil(
         }
     }
 
-    private fun getAnimeExtensionsInfo(): String? {
-        val availableExtensions = animeExtensionManager.availableExtensionsFlow.value.associateBy { it.pkgName }
+    private fun getAnimeExtensionsInfo(manager: AnimeExtensionManager): String? {
+        val availableExtensions = manager.availableExtensionsFlow.value.associateBy { it.pkgName }
 
-        val extensionInfoList = animeExtensionManager.installedExtensionsFlow.value
+        val extensionInfoList = manager.installedExtensionsFlow.value
             .sortedBy { it.name }
             .mapNotNull {
                 val availableExtension = availableExtensions[it.pkgName]


### PR DESCRIPTION
## Objective

Fix `CrashActivity` crashing on launch due to `InjektionException` — Injekt DI is never initialised in the separate `:error_handler` process.

## Scope

**CrashActivity.kt**
- Switch from `BaseActivity` to `AppCompatActivity` (removes `attachBaseContext` → `Injekt.get<UiPreferences>()` crash path)
- Replace `setComposeContent` with `setContent` + bare `MaterialTheme` (removes `TachiyomiTheme` → `Injekt.get<UiPreferences>()` crash path)

**CrashLogUtil.kt**
- Remove extension manager constructor parameters that eagerly called `Injekt.get()`
- Add `getExtensionsInfo()` wrapper that lazily resolves DI as best-effort — silently skips extension info when DI is unavailable, preserving device info + exception + logcat in the crash log

## Verification

- CrashActivity no longer crashes in `:error_handler` process
- Crash log dump still works from main process (Settings → Advanced → Dump crash logs)
- Extension info included when DI is available, gracefully omitted when not

## Risk

Low — changes are confined to crash handling. No impact on normal app flow.

Closes #442

🤖 Generated with [Claude Code](https://claude.com/claude-code)