### PR TITLE
fix: remove unused sqldelight-android-paging dep (R470)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -180,30 +180,6 @@ android {
     }
 }
 
-// R470: Pin androidx.paging to 3.3.6 to prevent Compose version mismatch.
-// SQLDelight 2.3.0-SNAPSHOT transitively pulls paging-common:3.4.0-beta01, which triggers
-// the paging atomic group and forces paging-compose:3.4.0-beta01. That artifact's POM
-// explicitly declares ui-android:1.10.0 / runtime-android:1.10.0, causing the Compose
-// runtime classpath to jump from BOM 2025.03.00 (1.7.8) → 1.10.0 at the ABI level.
-// presentation-core is compiled against 1.7.8 and AnchoredDraggableState's constructor
-// signature changed between 1.7.x and 1.10.0 → NoSuchMethodError on fresh install.
-// 3.3.6 is safe: SQLDelight only uses stable PagingSource/PagingData APIs that are
-// compatible across 3.3.x/3.4.x. Remove once SQLDelight ships a stable release that
-// aligns its paging transitive to a Compose BOM we compile against.
-configurations.all {
-    resolutionStrategy.eachDependency {
-        if (requested.group == "androidx.paging") {
-            useVersion("3.3.6")
-            because(
-                "Pin paging to 3.3.6 — SQLDelight 2.3.0-SNAPSHOT pulls 3.4.0-beta01, " +
-                    "which forces paging-compose:3.4.0-beta01 (atomic group). That POM declares " +
-                    "ui:1.10.0/runtime:1.10.0, causing a Compose compile-runtime mismatch with " +
-                    "BOM 2025.03.00 (1.7.8) → NoSuchMethodError on AnchoredDraggableState (R470).",
-            )
-        }
-    }
-}
-
 kotlin {
     compilerOptions {
         freeCompilerArgs.addAll(
@@ -223,37 +199,6 @@ kotlin {
 }
 
 dependencies {
-    // R469: Enforce Foundation 1.7+ floor — AnchoredDraggableState snapAnimationSpec/decayAnimationSpec
-    // constructor requires 1.7+. Transitive deps (e.g. Voyager) may pull older versions via strictly
-    // constraints, causing NoSuchMethodError at runtime. `require` sets a minimum floor; conflict
-    // resolution can still select a higher version (e.g. 1.10.0 from the BOM).
-    constraints {
-        implementation("androidx.compose.foundation:foundation") {
-            version { require("1.7.0") }
-            because(
-                "Foundation 1.7+ required for AnchoredDraggableState snapAnimationSpec/decayAnimationSpec API (R469)",
-            )
-        }
-        implementation("androidx.compose.foundation:foundation-android") {
-            version { require("1.7.0") }
-            because(
-                "Foundation 1.7+ required for AnchoredDraggableState snapAnimationSpec/decayAnimationSpec API (R469)",
-            )
-        }
-        implementation("androidx.compose.foundation:foundation-layout") {
-            version { require("1.7.0") }
-            because(
-                "Foundation 1.7+ required for AnchoredDraggableState snapAnimationSpec/decayAnimationSpec API (R469)",
-            )
-        }
-        implementation("androidx.compose.foundation:foundation-layout-android") {
-            version { require("1.7.0") }
-            because(
-                "Foundation 1.7+ required for AnchoredDraggableState snapAnimationSpec/decayAnimationSpec API (R469)",
-            )
-        }
-    }
-
     implementation(project(":lightnovel-contract"))
 
     implementation(projects.i18n)

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -28,7 +28,7 @@ dependencies {
 
     implementation(libs.unifile)
 
-    api(libs.sqldelight.android.paging)
+    api(androidx.paging.common)
 
     compileOnly(libs.compose.stablemarker)
 

--- a/gradle/androidx.versions.toml
+++ b/gradle/androidx.versions.toml
@@ -23,6 +23,7 @@ lifecycle-runtimektx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", ve
 
 workmanager = "androidx.work:work-runtime:2.10.0"
 
+paging-common = { module = "androidx.paging:paging-common", version.ref = "paging_version" }
 paging-runtime = { module = "androidx.paging:paging-runtime", version.ref = "paging_version" }
 paging-compose = { module = "androidx.paging:paging-compose", version.ref = "paging_version" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -87,7 +87,6 @@ leakcanary-plumber = { module = "com.squareup.leakcanary:plumber-android", versi
 
 sqldelight-android-driver = { module = "app.cash.sqldelight:android-driver", version.ref = "sqldelight" }
 sqldelight-coroutines = { module = "app.cash.sqldelight:coroutines-extensions-jvm", version.ref = "sqldelight" }
-sqldelight-android-paging = { module = "app.cash.sqldelight:androidx-paging3-extensions", version.ref = "sqldelight" }
 sqldelight-dialects-sql = { module = "app.cash.sqldelight:sqlite-3-38-dialect", version.ref = "sqldelight" }
 
 junit = "org.junit.jupiter:junit-jupiter:5.11.4"
@@ -116,7 +115,7 @@ js-engine = ["quickjs-android"]
 sqlite = ["sqlite-framework", "sqlite-ktx", "sqlite-android"]
 coil = ["coil-core", "coil-gif", "coil-compose", "coil-network-okhttp"]
 shizuku = ["shizuku-api", "shizuku-provider"]
-sqldelight = ["sqldelight-android-driver", "sqldelight-coroutines", "sqldelight-android-paging"]
+sqldelight = ["sqldelight-android-driver", "sqldelight-coroutines"]
 voyager = ["voyager-navigator", "voyager-screenmodel", "voyager-tab-navigator", "voyager-transitions"]
 richtext = ["richtext-commonmark", "richtext-m3"]
 test = ["junit", "kotest-assertions", "mockk"]


### PR DESCRIPTION
## Objective

Fix `NoSuchMethodError` crash on `AnchoredDraggableState` caused by unused `sqldelight-android-paging` dependency dragging Compose Foundation from 1.7.8 to 1.10.0 at runtime via two atomic group hops.

Closes #470

## Scope

- Remove unused `sqldelight-android-paging` from `:app` bundle and `:domain` direct `api()` — `QueryPagingSource` was never imported anywhere
- Replace `:domain`'s dependency with `androidx.paging:paging-common:3.3.6` (what it actually needs for the `PagingSource` type alias)
- Remove PR #470's `require("1.7.0")` constraints (no longer needed — source of 1.10.0 eliminated)
- Supersedes `resolutionStrategy.eachDependency` bandaid (commit `623054af9`)

## Risk

**Tier:** T1 (low)
**Rationale:** Removing a dependency that was never imported. No code changes — only build config. `compileDebugKotlin` and `spotlessCheck` pass. Foundation resolves to 1.7.8 via `dependencyInsight`.

## Verification

- `./gradlew :app:dependencyInsight --dependency "androidx.compose.foundation:foundation" --configuration debugRuntimeClasspath` → resolves to 1.7.8
- `./gradlew :app:compileDebugKotlin` → BUILD SUCCESSFUL
- `./gradlew spotlessCheck` → BUILD SUCCESSFUL

## Root Cause

```
SQLDelight 2.3.0-SNAPSHOT
  └─ sqldelight-android-paging (UNUSED — QueryPagingSource never imported)
       └─ paging-common:3.4.0-beta01
            └─ atomic group: ALL androidx.paging modules → 3.4.0-beta01
                 └─ paging-compose:3.4.0-beta01
                      └─ POM declares ui:1.10.0 / runtime:1.10.0
                           └─ atomic group: ALL compose modules → 1.10.0
                                └─ Foundation jumps from BOM 1.7.8 → 1.10.0
                                     └─ AnchoredDraggableState constructor changed
                                          └─ NoSuchMethodError at runtime
```

## Test plan

- [x] `dependencyInsight` confirms Foundation resolves to 1.7.8
- [x] `compileDebugKotlin` passes
- [x] `spotlessCheck` passes
- [ ] Fresh install — bottom sheets render without crash
- [ ] Existing install — no regression in paging (manga/anime library lists)

🤖 Generated with [Claude Code](https://claude.com/claude-code)