### PR TITLE
ci: auto-extract changelog and publish release directly on tag (R472)

### DIFF
--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -113,31 +113,43 @@ jobs:
           sha=`sha256sum rayniyomi-x86_64-${{ env.VERSION_TAG }}.apk | awk '{ print $1 }'`
           echo "APK_X86_64_SHA=$sha" >> $GITHUB_ENV
 
+      - name: Extract changelog for release
+        if: startsWith(github.ref, 'refs/tags/') && github.repository == 'ryacub/rayniyomi'
+        run: |
+          set -ex
+          version="${VERSION_TAG#v}"
+          # Extract the section for this version from CHANGELOG.md
+          awk "/^## \[${version}\]/{found=1; next} found && /^## /{exit} found{print}" CHANGELOG.md > /tmp/changelog_section.md
+          # Append checksums table
+          cat >> /tmp/changelog_section.md << EOF
+
+          ---
+
+          ### Checksums
+
+          | Variant | SHA-256 |
+          | ------- | ------- |
+          | Universal | ${APK_UNIVERSAL_SHA}
+          | arm64-v8a | ${APK_ARM64_V8A_SHA}
+          | armeabi-v7a | ${APK_ARMEABI_V7A_SHA}
+          | x86 | ${APK_X86_SHA}
+          | x86_64 | ${APK_X86_64_SHA} |
+          EOF
+
       - name: Create Release
         if: startsWith(github.ref, 'refs/tags/') && github.repository == 'ryacub/rayniyomi'
         uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2.2.1
         with:
           tag_name: ${{ env.VERSION_TAG }}
           name: Rayniyomi ${{ env.VERSION_TAG }}
-          body: |
-            ---
-
-            ### Checksums
-
-            | Variant | SHA-256 |
-            | ------- | ------- |
-            | Universal | ${{ env.APK_UNIVERSAL_SHA }}
-            | arm64-v8a | ${{ env.APK_ARM64_V8A_SHA }}
-            | armeabi-v7a | ${{ env.APK_ARMEABI_V7A_SHA }}
-            | x86 | ${{ env.APK_X86_SHA }}
-            | x86_64 | ${{ env.APK_X86_64_SHA }} |
+          body_path: /tmp/changelog_section.md
           files: |
             rayniyomi-${{ env.VERSION_TAG }}.apk
             rayniyomi-arm64-v8a-${{ env.VERSION_TAG }}.apk
             rayniyomi-armeabi-v7a-${{ env.VERSION_TAG }}.apk
             rayniyomi-x86-${{ env.VERSION_TAG }}.apk
             rayniyomi-x86_64-${{ env.VERSION_TAG }}.apk
-          draft: true
+          draft: false
           prerelease: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Objective
Eliminate the manual release creation step by having CI own the full release lifecycle when a tag is pushed.

## Scope
- `.github/workflows/build_push.yml` — adds changelog extraction step; changes `draft: true` → `draft: false`; switches from inline `body:` to `body_path:` pointing to generated file

## Changes
- New step **Extract changelog for release**: uses `awk` to extract the `## [version]` section from `CHANGELOG.md` matching the pushed tag, then appends the checksums table
- **Create Release** step: uses `body_path` instead of static `body`; publishes directly (`draft: false`)

## New release workflow
```bash
# Version CHANGELOG (## Unreleased → ## [x.x.x.x] - date), commit, PR, merge
# Then just push the tag:
git tag v0.18.1.67 <sha>
git push ryacub v0.18.1.67
# CI builds APKs, signs, extracts changelog, publishes — done
```

## Verification
- [ ] Tag a test release and confirm the published release body contains the changelog section + checksums
- [ ] Confirm no manual editing step needed after CI completes

## Risk
Low — only affects the tag-triggered release creation path; no impact on branch push builds or PR checks.

Closes #472