### PR TITLE
fix: update SQLDelight snapshot repository URL (R485)

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,14 +9,14 @@ pluginManagement {
     }
     repositories {
         // Temporary for SqlDelight 2.3.0-SNAPSHOT AGP 9 support.
-        // Remove this mavenLocal/snapshot wiring once stable SqlDelight ships AGP 9 support.
-        // Tracking: cashapp/sqldelight#6139.
+        // Snapshot moved from s01.oss.sonatype.org to central.sonatype.com (see SqlDelight 2.2.1 release notes).
+        // Remove once stable SqlDelight ships AGP 9 support. Tracking: cashapp/sqldelight#6139.
         mavenLocal {
             content {
                 includeGroup("app.cash.sqldelight")
             }
         }
-        maven(url = "https://s01.oss.sonatype.org/content/repositories/snapshots/") {
+        maven(url = "https://central.sonatype.com/repository/maven-snapshots/") {
             content {
                 includeGroup("app.cash.sqldelight")
             }
@@ -46,14 +46,14 @@ dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
         // Temporary for SqlDelight 2.3.0-SNAPSHOT AGP 9 support.
-        // Remove this mavenLocal/snapshot wiring once stable SqlDelight ships AGP 9 support.
-        // Tracking: cashapp/sqldelight#6139.
+        // Snapshot moved from s01.oss.sonatype.org to central.sonatype.com (see SqlDelight 2.2.1 release notes).
+        // Remove once stable SqlDelight ships AGP 9 support. Tracking: cashapp/sqldelight#6139.
         mavenLocal {
             content {
                 includeGroup("app.cash.sqldelight")
             }
         }
-        maven(url = "https://s01.oss.sonatype.org/content/repositories/snapshots/") {
+        maven(url = "https://central.sonatype.com/repository/maven-snapshots/") {
             content {
                 includeGroup("app.cash.sqldelight")
             }


### PR DESCRIPTION
## Objective

Fix CI build failures caused by the SQLDelight 2.3.0-SNAPSHOT repository URL being unreachable. The `s01.oss.sonatype.org` snapshot endpoint is dead; SQLDelight migrated snapshots to `central.sonatype.com` as of their 2.2.1 release.

## Scope

- `settings.gradle.kts`: Update both `pluginManagement` and `dependencyResolutionManagement` snapshot URLs to the new endpoint

No version changes — `2.3.0-SNAPSHOT` is retained (required for AGP 9 support, tracking cashapp/sqldelight#6139).

## Verification

- `spotlessCheck` passes locally (confirmed via pre-push hook)
- 2.3.0-SNAPSHOT confirmed available at new URL (last updated 2026-03-11)

## Risk

Low — URL-only change, no logic or version changes.

## Rollback

Revert `settings.gradle.kts`. Note: old URLs are 404 so rolling back restores broken builds until a stable SQLDelight ships AGP 9 support.

Closes #485