### PR TITLE
ci: speed up workflows without reducing checks (R474)

### DIFF
--- a/.github/workflows/build_pull_request.yml
+++ b/.github/workflows/build_pull_request.yml
@@ -30,6 +30,13 @@ jobs:
     runs-on: 'ubuntu-24.04'
 
     steps:
+      - name: Restore SqlDelight local Maven cache
+        id: sqldelight-cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.2.3
+        with:
+          path: ~/.m2/repository/app/cash
+          key: sqldelight-m2-${{ env.SQLDELIGHT_AGP9_FIX_SHA }}
+
       - name: Set up JDK
         uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
@@ -37,6 +44,7 @@ jobs:
           distribution: temurin
 
       - name: Build SqlDelight AGP 9 fix
+        if: steps.sqldelight-cache.outputs.cache-hit != 'true'
         run: |
           set -euxo pipefail
 
@@ -68,8 +76,6 @@ jobs:
 
       - name: Set up gradle
         uses: gradle/actions/setup-gradle@94baf225fe0a508e581a564467443d0e2379123b # v4.3.0
-        with:
-          cache-disabled: true
 
       - name: Download SqlDelight local Maven artifacts
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
@@ -78,7 +84,7 @@ jobs:
           path: ~/.m2/repository/app/cash
 
       - name: Check code format
-        run: ./gradlew spotlessCheck --no-build-cache --no-configuration-cache --refresh-dependencies -Dorg.gradle.workers.max=1
+        run: ./gradlew spotlessCheck
 
   build:
     name: Build app

--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -27,6 +27,13 @@ jobs:
       - name: Clone repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      - name: Restore SqlDelight local Maven cache
+        id: sqldelight-cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.2.3
+        with:
+          path: ~/.m2/repository/app/cash
+          key: sqldelight-m2-${{ env.SQLDELIGHT_AGP9_FIX_SHA }}
+
       - name: Set up JDK
         uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
@@ -37,6 +44,7 @@ jobs:
         uses: gradle/actions/setup-gradle@94baf225fe0a508e581a564467443d0e2379123b # v4.3.0
 
       - name: Build SqlDelight AGP 9 fix
+        if: steps.sqldelight-cache.outputs.cache-hit != 'true'
         run: |
           set -euxo pipefail
 
@@ -46,14 +54,11 @@ jobs:
 
           ./gradlew publishToMavenLocal -x test --no-daemon
 
-      - name: Check code format
-        run: ./gradlew spotlessCheck
+      - name: Check format and run unit tests
+        run: ./gradlew spotlessCheck :app:testDebugUnitTest
 
       - name: Build app
         run: ./gradlew assembleRelease -Penable-updater
-
-      - name: Run unit tests
-        run: ./gradlew :app:testDebugUnitTest
 
       - name: Upload APK
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2


### PR DESCRIPTION
## Objective
Improve CI efficiency while preserving existing quality gates and validation behavior.

## Scope
- Add SQLDelight Maven-local cache keyed by `SQLDELIGHT_AGP9_FIX_SHA` in PR and push workflows.
- Skip SQLDelight bootstrap build when cache is hit.
- Keep `spotlessCheck` enforcement but remove forced cold-cache flags.
- Keep push workflow checks intact (`spotlessCheck`, `:app:testDebugUnitTest`, and `assembleRelease -Penable-updater`) while reducing redundant overhead.

## Verification
- Workflow YAML parses successfully for:
  - `.github/workflows/build_pull_request.yml`
  - `.github/workflows/build_push.yml`
- Local pre-push hooks passed:
  - `./gradlew spotlessCheck`
  - `./gradlew :app:compileDebugKotlin`

## Risk
Low. Changes are limited to CI workflow configuration. No application/runtime code changes. Quality gates are preserved.

Closes #489
