### PR TITLE
fix: add Crashlytics Gradle plugin to resolve startup crash (R493)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,6 +13,7 @@ plugins {
     // Only apply Google Services plugin for release builds (Firebase Analytics/Crashlytics)
     // Debug builds don't need it and google-services.json only contains release package
     alias(libs.plugins.google.services) apply false
+    alias(libs.plugins.firebase.crashlytics) apply false
 }
 
 val appVersionCode = 203
@@ -374,10 +375,11 @@ tasks.register("printLightNovelCompatibilitySnapshot") {
     }
 }
 
-// Apply Google Services plugin conditionally for non-debug builds
+// Apply Google Services and Crashlytics plugins conditionally for non-debug builds
 // This allows debug builds to work without xyz.rayniyomi.dev in Firebase
 if (gradle.startParameter.taskNames.none { it.contains("Debug", ignoreCase = true) }) {
     apply(plugin = "com.google.gms.google-services")
+    apply(plugin = "com.google.firebase.crashlytics")
 }
 
 buildscript {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 aboutlib_version = "11.6.3"
 cast = "22.0.0"
 google_services = "4.4.4"
+firebase_crashlytics_gradle = "3.0.6"
 leakcanary = "2.14"
 mediarouter = "1.7.0"
 moko = "0.26.0"
@@ -105,6 +106,7 @@ ktlint-core = { module = "com.pinterest.ktlint:ktlint-cli", version.ref = "ktlin
 [plugins]
 aboutLibraries = { id = "com.mikepenz.aboutlibraries.plugin", version.ref = "aboutlib_version" }
 google-services = { id = "com.google.gms.google-services", version.ref = "google_services" }
+firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "firebase_crashlytics_gradle" }
 sqldelight = { id = "app.cash.sqldelight", version.ref = "sqldelight" }
 moko = { id = "dev.icerock.mobile.multiplatform-resources", version.ref = "moko" }
 


### PR DESCRIPTION
## Objective

Fix app crash on startup caused by missing Crashlytics build ID.

## Scope

**Root cause:** `firebase-crashlytics-ktx` was included as a runtime dependency but the `com.google.firebase.crashlytics` Gradle plugin was never applied. The plugin is responsible for embedding a build ID UUID in the APK at compile time. Without it, `CrashlyticsCore.onPreExecute()` throws `IllegalStateException` before any app code runs.

**Changes:**
- `gradle/libs.versions.toml` — add `firebase_crashlytics_gradle = "3.0.6"` to `[versions]` and `firebase-crashlytics` plugin entry to `[plugins]`
- `app/build.gradle.kts` — declare plugin with `apply false`, apply it conditionally alongside `google-services` for non-debug builds

## Verification

- `./gradlew :app:assembleRelease` — build completes successfully with plugin applied
- No changes to debug build path (plugin still excluded for debug builds)

## Risk

**T1** — Build configuration only. No runtime logic changed. If the plugin fails to apply, the build fails fast (compile time) rather than crashing at runtime.

Closes #493