### PR TITLE
fix: move Crashlytics plugin application before android block (R495)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,6 +19,15 @@ plugins {
 val appVersionCode = 205
 val lightNovelExpectedPluginApiVersion = 1
 
+// Apply Google Services and Crashlytics plugins conditionally for non-debug builds
+// This allows debug builds to work without xyz.rayniyomi.dev in Firebase
+// R495: Must be before android block so Crashlytics can register onVariants callbacks
+// early enough in AGP's configuration pipeline to embed the build UUID
+if (gradle.startParameter.taskNames.none { it.contains("Debug", ignoreCase = true) }) {
+    apply(plugin = "com.google.gms.google-services")
+    apply(plugin = "com.google.firebase.crashlytics")
+}
+
 android {
     namespace = "eu.kanade.tachiyomi"
 
@@ -373,13 +382,6 @@ tasks.register("printLightNovelCompatibilitySnapshot") {
             """.trimIndent(),
         )
     }
-}
-
-// Apply Google Services and Crashlytics plugins conditionally for non-debug builds
-// This allows debug builds to work without xyz.rayniyomi.dev in Firebase
-if (gradle.startParameter.taskNames.none { it.contains("Debug", ignoreCase = true) }) {
-    apply(plugin = "com.google.gms.google-services")
-    apply(plugin = "com.google.firebase.crashlytics")
 }
 
 buildscript {


### PR DESCRIPTION
## Objective

Fix the Firebase Crashlytics plugin ordering issue that causes missing build IDs and startup crashes on release builds.

## Scope

- Moved the conditional Firebase Crashlytics and Google Services plugin application block from the end of `app/build.gradle.kts` (after `android {}` block) to before the `android {}` block
- Updated the comment to explain why early plugin registration is critical for AGP's configuration pipeline
- No functional changes to the build logic — purely reordering the plugin application timing

## Verification

The Crashlytics plugin will now register its `onVariants` callbacks early enough in AGP's configuration pipeline to properly embed the build UUID, preventing the `IllegalStateException: The Crashlytics build ID is missing` startup crash that was occurring on non-debug builds.

Testing:
- Spotless formatting applied and verified
- No fully qualified class names introduced
- Commit follows project conventions

## Risk

Low — this is purely a reordering of existing code with no logic changes. The conditional that decides whether to apply the plugins remains identical. This fixes a plugin timing issue, not a functional behavior issue.

Closes #495