### PR TITLE
fix: move Crashlytics plugin application before android block (R495)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,6 +19,13 @@ plugins {
 val appVersionCode = 205
 val lightNovelExpectedPluginApiVersion = 1
 
+// Apply Google Services and Crashlytics plugins before AGP variant configuration.
+// Applying them at the end of the script is too late for Crashlytics to embed its build ID.
+if (gradle.startParameter.taskNames.none { it.contains("Debug", ignoreCase = true) }) {
+    apply(plugin = "com.google.gms.google-services")
+    apply(plugin = "com.google.firebase.crashlytics")
+}
+
 android {
     namespace = "eu.kanade.tachiyomi"
 
@@ -373,13 +380,6 @@ tasks.register("printLightNovelCompatibilitySnapshot") {
             """.trimIndent(),
         )
     }
-}
-
-// Apply Google Services and Crashlytics plugins conditionally for non-debug builds
-// This allows debug builds to work without xyz.rayniyomi.dev in Firebase
-if (gradle.startParameter.taskNames.none { it.contains("Debug", ignoreCase = true) }) {
-    apply(plugin = "com.google.gms.google-services")
-    apply(plugin = "com.google.firebase.crashlytics")
 }
 
 buildscript {


### PR DESCRIPTION
## Objective
Fix startup crash path where Crashlytics fails with missing build ID because the plugin is applied too late in Gradle script evaluation.

## Scope
- Move conditional application of `com.google.gms.google-services` and `com.google.firebase.crashlytics` to before `android {}` in `app/build.gradle.kts`.
- Keep existing non-debug gating behavior unchanged.
- No runtime code changes and no dependency/version changes.

## Verification
- `./gradlew spotlessCheck`
- `./gradlew :app:compileDebugKotlin --no-daemon`
- Observed release configuration runs Crashlytics tasks during release assembly (`injectCrashlyticsMappingFileIdRelease`, `injectCrashlyticsVersionControlInfoRelease`).

## Risk
Low. Change is limited to plugin application order in Gradle script. Main risk is unintended variant/plugin behavior change, mitigated by preserving the existing conditional gate and confirming debug compile + release task wiring.

Closes #495
