### PR TITLE
fix: preserve Crashlytics build ID in release artifacts (R500)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -109,6 +109,12 @@ android {
     }
 
     sourceSets {
+        // AGP 9 + Crashlytics plugin can generate release mapping-file resources without wiring
+        // them into mergeResources; include the release-generated folder explicitly so release
+        // APKs always contain the Crashlytics build ID metadata required at runtime.
+        getByName("release") {
+            res.srcDir("build/generated/res/injectCrashlyticsMappingFileIdRelease")
+        }
         getByName("preview") { res.srcDir("src/debug/res") }
         getByName("benchmark") { res.srcDir("src/debug/res") }
     }
@@ -187,6 +193,15 @@ android {
     lint {
         abortOnError = false
         checkReleaseBuilds = false
+    }
+}
+
+tasks.configureEach {
+    if (
+        name.contains("Release") &&
+        (name.contains("Resource") || name.contains("Navigation"))
+    ) {
+        dependsOn("injectCrashlyticsMappingFileIdRelease")
     }
 }
 

--- a/app/src/main/res/raw/firebase_crashlytics_keep.xml
+++ b/app/src/main/res/raw/firebase_crashlytics_keep.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools"
+    tools:keep="@string/com_google_firebase_crashlytics_mapping_file_id" />


### PR DESCRIPTION
## Ticket
- ID: R500
- Priority: P1
- Risk Tier: T1
- GitHub Issue: Closes #500

## Objective
- Prevent startup crash in release builds caused by missing Crashlytics build ID metadata at runtime.

## Scope
- Wire release sourceSet to include Crashlytics generated mapping-id resources.
- Ensure release resource/navigation pipeline tasks depend on `injectCrashlyticsMappingFileIdRelease`.
- Add a shrinker keep file so `com_google_firebase_crashlytics_mapping_file_id` is not removed as unreachable.

## Non-goals
- No runtime code changes in app startup logic.
- No Firebase feature/SDK version changes.

## Files Changed
- `app/build.gradle.kts`
- `app/src/main/res/raw/firebase_crashlytics_keep.xml`

## Verification
- Commands run:
  - `./gradlew spotlessCheck`
  - `./gradlew :app:compileDebugKotlin`
  - `./gradlew spotlessCheck :app:testDebugUnitTest`
  - `./gradlew :app:assembleRelease -Penable-updater`
  - `aapt2 dump resources app/build/outputs/apk/release/app-arm64-v8a-release-unsigned.apk | rg com.google.firebase.crashlytics.mapping_file_id`
  - `rg com_google_firebase_crashlytics_mapping_file_id app/build/outputs/mapping/release/resources.txt`
- Results:
  - All Gradle verification commands pass.
  - Release APK now contains `string/com.google.firebase.crashlytics.mapping_file_id`.
  - Shrinker report now marks mapping id resource as reachable via keep xml.
- Not tested:
  - Manual device install/launch smoke for this branch artifact.

## Risk
- Build-logic only change in app module; risk is limited to release resource task graph/wiring.
- Mitigation: validated full release assembly and resource table output.

## SLO Impact
- Improves crash-free startup SLO by preventing a deterministic startup crash in release builds.

## Rollback
- Revert this PR to restore previous build wiring and keep-resource behavior.

## Release Notes
- Fixed a release-only startup crash where Firebase Crashlytics build ID metadata could be stripped from APK resources.

## Checklist
- [x] Naming conventions followed (use "Rayniyomi" in user-facing text, see [naming conventions](../docs/governance/naming-conventions.md))
- [x] Branch rebased on latest main and verification re-run (see [rebase policy](../docs/governance/agent-workflow.md#rebase-before-merge-policy-r45))
- [x] New coroutine scopes have documented owner and cancellation path
- [x] No new `runBlocking` on UI/main thread paths

## Definition of Done (DoD)
- [x] Acceptance criteria met and non-goals respected
- [x] Verification matrix completed (Risk Tier: T1)
- [x] Self-review completed
- [x] Rebased on latest `main` and revalidated (mandatory for merge)
- [ ] Sprint board updated (branch, commit, checks, PR link)
- [x] Release notes drafted (if applicable)

## Fork Compliance Checklist (for new forks only)
- [x] Not applicable (existing fork)
