### PR TITLE
fix: keep RoomDatabase subclass constructors to prevent WorkManager crash (R502)

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -99,6 +99,13 @@
 
 # XmlUtil
 -keep public enum nl.adaptivity.xmlutil.EventType { *; }
+##---------------Begin: proguard configuration for WorkManager / Room  ----------
+# WorkManager's generated RoomDatabase subclass (WorkDatabase_Impl) is instantiated via
+# reflection (getDeclaredConstructor). R8 strips the no-arg constructor without this rule,
+# causing a NoSuchMethodException crash at startup during AppInitializer.
+-keep class * extends androidx.room.RoomDatabase { <init>(); }
+##---------------End: proguard configuration for WorkManager / Room  ----------
+
 ##---------------Begin: proguard configuration for Firebase Crashlytics  ----------
 # Keep Firebase Crashlytics classes and methods
 -keep class com.google.firebase.crashlytics.** { *; }


### PR DESCRIPTION
## Objective

Fix a release-build startup crash where R8 strips the no-arg constructor of WorkManager's generated `WorkDatabase_Impl` class.

## Scope

Single ProGuard rule added to `app/proguard-rules.pro`:
```
-keep class * extends androidx.room.RoomDatabase { <init>(); }
```

WorkManager instantiates `WorkDatabase_Impl` via `getDeclaredConstructor()` (reflection). R8's optimizer removes constructors it cannot see a direct call to. The keep rule prevents this.

The `coil.network.HttpException` wrapping seen in the crash trace is a secondary symptom — R8's `allowoptimization` was merging `androidx.startup.StartupException` with another class; once WorkManager initializes correctly this goes away.

## Verification

- Build release APK and confirm app starts without `NoSuchMethodException: WorkDatabase_Impl.<init> []`
- `./gradlew :app:spotlessCheck` passes (CI will validate)

## Risk

Low. Adding a keep rule is additive; it prevents removal of a constructor that must exist at runtime. No logic changes.

Closes #502