### PR TITLE
ci: add workflow_dispatch to CI for manual release triggers (R506)

### DIFF
--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -9,6 +9,12 @@ on:
       - '*'
     tags:
       - v*
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Tag or branch to build (e.g. v0.18.1.79)'
+        required: false
+        default: ''
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Objective
Add \`workflow_dispatch\` trigger to the CI workflow so release builds can be manually triggered when automatic tag-triggered CI is blocked.

## Scope
- **\`.github/workflows/build_push.yml\`** — adds \`workflow_dispatch\` trigger

## Background
GitHub blocks automatic CI execution when a push modifies workflow files (security restriction against workflow poisoning). This means after merging PRs that touch \`.github/workflows/\`, subsequent tag pushes may not trigger CI. \`workflow_dispatch\` provides a manual escape hatch.

## Verification
After merge: go to Actions → CI → Run workflow → specify tag/branch to build.

## Risk
Minimal. Additive-only change. Existing push/tag triggers unaffected.

Closes #506