### PR TITLE
fix: avoid surfacing cancellation as UI errors (R445)

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/discover/DiscoverScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/discover/DiscoverScreenModel.kt
@@ -5,6 +5,7 @@ import cafe.adriel.voyager.core.model.StateScreenModel
 import cafe.adriel.voyager.core.model.screenModelScope
 import eu.kanade.domain.track.enrichment.DiscoverFeedCoordinator
 import eu.kanade.domain.track.enrichment.model.DiscoverFeedItem
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.catch
@@ -35,6 +36,7 @@ class DiscoverScreenModel(
             launch {
                 coordinator.observe(limit = DISCOVER_LIMIT)
                     .catch { error ->
+                        if (error is CancellationException) throw error
                         val message = error.message?.takeIf { it.isNotBlank() } ?: "Unknown error"
                         mutableState.update {
                             it.copy(
@@ -83,6 +85,7 @@ class DiscoverScreenModel(
                     _announcements.tryEmit("Discover updated: ${items.size} recommendations")
                 }
             }.onFailure { error ->
+                if (error is CancellationException) throw error
                 val message = error.message?.takeIf { it.isNotBlank() } ?: "Unable to refresh Discover"
                 mutableState.update {
                     it.copy(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/entries/common/EntryEnrichmentScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/entries/common/EntryEnrichmentScreenModel.kt
@@ -5,6 +5,7 @@ import cafe.adriel.voyager.core.model.screenModelScope
 import eu.kanade.domain.track.enrichment.EntryEnrichmentCoordinator
 import eu.kanade.domain.track.enrichment.model.EnrichedEntry
 import eu.kanade.domain.track.enrichment.model.EnrichmentMediaType
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.catch
@@ -42,6 +43,7 @@ class EntryEnrichmentScreenModel(
                         EnrichmentMediaType.ANIME -> coordinator.observeAnime(entryId)
                     }
                         .catch { error ->
+                            if (error is CancellationException) throw error
                             val message = error.message?.takeIf(String::isNotBlank)
                                 ?: "Unable to load recommendations"
                             mutableState.update {
@@ -114,6 +116,7 @@ class EntryEnrichmentScreenModel(
                 )
             }
         }.onFailure {
+            if (it is CancellationException) throw it
             val message = it.message?.takeIf(String::isNotBlank) ?: "Unable to sync recommendations"
             mutableState.update { state ->
                 state.copy(

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/discover/DiscoverScreenModelTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/discover/DiscoverScreenModelTest.kt
@@ -9,6 +9,7 @@ import eu.kanade.domain.track.enrichment.model.RecommendationChoice
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flow
@@ -148,6 +149,18 @@ class DiscoverScreenModelTest {
         // Error state should be properly set
         assertFalse(model.state.value.loading)
         assertEquals("Connection failed", model.state.value.errorText)
+    }
+
+    @Test
+    fun `cancellation exception in observe is not surfaced as user error`() = runTest {
+        val coordinator = mockk<DiscoverFeedCoordinator>()
+
+        every { coordinator.observe(limit = 40) } returns throwingFlow(CancellationException("cancelled"))
+        coEvery { coordinator.refresh(limit = 40, force = false) } returns emptyList()
+
+        val model = DiscoverScreenModel(coordinator)
+
+        assertEquals(null, model.state.value.errorText)
     }
 
     private fun createTestDiscoverFeedItem(

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/entries/common/EntryEnrichmentScreenModelTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/entries/common/EntryEnrichmentScreenModelTest.kt
@@ -7,6 +7,7 @@ import eu.kanade.domain.track.enrichment.model.EnrichmentMediaType
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flow
@@ -187,6 +188,26 @@ class EntryEnrichmentScreenModelTest {
 
         assertFalse(model.state.value.loading)
         assertEquals("Unable to load recommendations", model.state.value.errorText)
+    }
+
+    @Test
+    fun `observer cancellation is not surfaced as user error`() = runTest {
+        val coordinator = mockk<EntryEnrichmentCoordinator>()
+
+        every { coordinator.observeManga(1) } returns throwingFlow(CancellationException("cancelled"))
+        coEvery { coordinator.refreshManga(mangaId = 1, title = "Test Manga", force = true) } returns
+            createTestEnrichedEntry(entryId = 1)
+
+        val model = EntryEnrichmentScreenModel(
+            entryId = 1,
+            title = "Test Manga",
+            mediaType = EnrichmentMediaType.MANGA,
+            coordinator = coordinator,
+        )
+
+        advanceUntilIdle()
+
+        assertNull(model.state.value.errorText)
     }
 
     private fun createTestEnrichedEntry(


### PR DESCRIPTION
## Objective
Prevent coroutine cancellation from being reported as user-facing errors in the rayniyomi enrichment/discover UI flows.

## Scope
- `DiscoverScreenModel`: rethrow `CancellationException` in observer `.catch {}` and refresh failure handling
- `EntryEnrichmentScreenModel`: rethrow `CancellationException` in observer `.catch {}` and refresh failure handling
- Added cancellation regression tests in:
  - `DiscoverScreenModelTest`
  - `EntryEnrichmentScreenModelTest`
- No architectural refactors, no tracker/download-manager changes

## Verification
- `./gradlew :app:testDebugUnitTest --tests "*DiscoverScreenModelTest*" --tests "*EntryEnrichmentScreenModelTest*" --build-cache`
- `./gradlew spotlessCheck`
- `./gradlew :app:compileDebugKotlin`

## Risk
- Risk Tier: T1 (localized change in rayniyomi-only enrichment/discover surfaces)
- Main risk: cancellation paths could mask real failures if type-checking is incorrect
- Mitigation: focused regression tests verify only cancellation is exempt from `errorText` while existing failure tests remain passing

Closes #445
