### PR TITLE
chore: core runtime dependency upgrade wave (R501)

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/player/components/PlayerSheet.kt
+++ b/app/src/main/java/eu/kanade/presentation/player/components/PlayerSheet.kt
@@ -223,7 +223,7 @@ private fun <T> AnchoredDraggableState<T>.preUpPostDownNestedScrollConnection() 
 
     override suspend fun onPreFling(available: Velocity): Velocity {
         val toFling = available.toFloat()
-        return if (toFling < 0 && offset > anchors.minAnchor()) {
+        return if (toFling < 0 && offset > 0f) {
             settle(toFling)
             available
         } else {

--- a/app/src/main/java/eu/kanade/presentation/player/components/SwitchPreference.kt
+++ b/app/src/main/java/eu/kanade/presentation/player/components/SwitchPreference.kt
@@ -39,7 +39,12 @@ fun SwitchPreference(
 ) {
     Row(
         modifier = modifier
-            .toggleable(value, true, Role.Switch, onValueChange)
+            .toggleable(
+                value = value,
+                enabled = true,
+                role = Role.Switch,
+                onValueChange = onValueChange,
+            )
             .padding(horizontal = MaterialTheme.padding.large, vertical = MaterialTheme.padding.small)
             .fillMaxWidth(),
         horizontalArrangement = Arrangement.SpaceBetween,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,7 @@ okhttp-core = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp_ve
 okhttp-logging = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp_version" }
 okhttp-brotli = { module = "com.squareup.okhttp3:okhttp-brotli", version.ref = "okhttp_version" }
 okhttp-dnsoverhttps = { module = "com.squareup.okhttp3:okhttp-dnsoverhttps", version.ref = "okhttp_version" }
-okio = "com.squareup.okio:okio:3.10.2"
+okio = "com.squareup.okio:okio:3.17.0"
 
 androidx-mediarouter = { module = "androidx.mediarouter:mediarouter", version.ref = "mediarouter" }
 play-services-cast-framework = { module = "com.google.android.gms:play-services-cast-framework", version.ref = "cast" }
@@ -33,7 +33,7 @@ conscrypt-android = "org.conscrypt:conscrypt-android:2.5.3"
 
 quickjs-android = "app.cash.quickjs:quickjs-android:0.9.2"
 
-jsoup = "org.jsoup:jsoup:1.19.1"
+jsoup = "org.jsoup:jsoup:1.22.1"
 
 disklrucache = "com.jakewharton:disklrucache:2.0.2"
 unifile = "com.github.tachiyomiorg:unifile:e0def6b3dc"
@@ -47,7 +47,7 @@ preferencektx = "androidx.preference:preference-ktx:1.2.1"
 
 injekt = "com.github.mihonapp:injekt:91edab2317"
 
-coil-bom = { module = "io.coil-kt.coil3:coil-bom", version = "3.1.0" }
+coil-bom = { module = "io.coil-kt.coil3:coil-bom", version = "3.4.0" }
 coil-core = { module = "io.coil-kt.coil3:coil" }
 coil-gif = { module = "io.coil-kt.coil3:coil-gif" }
 coil-compose = { module = "io.coil-kt.coil3:coil-compose" }
@@ -61,7 +61,7 @@ natural-comparator = "com.github.gpanther:java-nat-sort:natural-comparator-1.1"
 richtext-commonmark = { module = "com.halilibo.compose-richtext:richtext-commonmark", version.ref = "richtext" }
 richtext-m3 = { module = "com.halilibo.compose-richtext:richtext-ui-material3", version.ref = "richtext" }
 
-material = "com.google.android.material:material:1.12.0"
+material = "com.google.android.material:material:1.13.0"
 flexible-adapter-core = "com.github.arkon.FlexibleAdapter:flexible-adapter:c8013533"
 photoview = "com.github.chrisbanes:PhotoView:2.3.0"
 directionalviewpager = "com.github.tachiyomiorg:DirectionalViewPager:1.0.0"


### PR DESCRIPTION
## Ticket
- ID: R501
- Priority: P1
- Risk Tier: T2
- GitHub Issue: Closes #511

## Objective
Upgrade the first dependency wave for core runtime libraries with low-risk, bounded changes.

## Scope
- Upgrade runtime dependencies in `gradle/libs.versions.toml`:
  - `org.jsoup:jsoup` `1.19.1 -> 1.22.1`
  - `io.coil-kt.coil3:coil-bom` `3.1.0 -> 3.4.0`
  - `com.google.android.material:material` `1.12.0 -> 1.13.0`
  - `com.squareup.okio:okio` `3.10.2 -> 3.17.0`
- Compose compatibility fixes required by upgraded dependency graph:
  - `SwitchPreference` uses named args for `toggleable(...)`
  - `PlayerSheet` removes `anchors.minAnchor()` usage (uses equivalent `offset > 0f` guard)

## Non-goals
- No AndroidX platform wave changes (R502)
- No Compose BOM wave changes (R503)
- No Firebase wave changes (R504)
- No test/tooling wave changes (R505)
- `dev.rikka.shizuku` remains pinned at `13.1.0` in this ticket due API break (`Shizuku.newProcess` no longer public in `13.1.5`); deferred to R505 unresolved/cleanup wave.

## Files Changed
- `gradle/libs.versions.toml`
- `app/src/main/java/eu/kanade/presentation/player/components/SwitchPreference.kt`
- `app/src/main/java/eu/kanade/presentation/player/components/PlayerSheet.kt`

## Verification
- Commands run:
  - `./gradlew spotlessCheck`
  - `./gradlew :app:compileDebugKotlin`
  - pre-push hook reran both checks successfully
- Results:
  - All above checks passed
- Not tested:
  - Manual runtime smoke flows (startup/reader/player/downloads)

## Risk
- Regression risks:
  - UI interaction behavior in player sheet nested scroll pre-fling condition
  - Compose API surface drift around toggles/anchored draggable
- Mitigations:
  - Kept code changes minimal and localized
  - Verified full debug Kotlin compile and spotless
  - Deferred high-risk Shizuku API migration instead of partial workaround in this wave

## SLO Impact
- No expected direct SLO impact. Dependency updates are compile/runtime library upgrades only.

## Rollback
- Revert this PR to restore prior dependency versions and compatibility call sites.

## Release Notes
- Updated core runtime dependency wave (jsoup, Coil BOM, Material, Okio) with minimal compatibility fixes in player preference/sheet components.

## Checklist
- [x] Naming conventions followed (use "Rayniyomi" in user-facing text)
- [x] Branch rebased on latest main and verification re-run
- [x] New coroutine scopes have documented owner and cancellation path
- [x] No new `runBlocking` on UI/main thread paths

## Definition of Done (DoD)
- [x] Acceptance criteria met and non-goals respected
- [x] Verification matrix completed (Risk Tier: T2)
- [x] Self-review completed
- [x] Rebased on latest `main` and revalidated (mandatory for merge)
- [ ] Sprint board updated (branch, commit, checks, PR link)
- [x] Release notes drafted (if applicable)
