### PR TITLE
fix: migrate lifecycle-aware state collection in rayniyomi screens (R450)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -276,6 +276,7 @@ dependencies {
     implementation(aniyomilibs.mediasession)
 
     implementation(androidx.bundles.lifecycle)
+    implementation(androidx.lifecycle.runtimecompose)
 
     // Job scheduling
     implementation(androidx.workmanager)

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsSecurityScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsSecurityScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import eu.kanade.presentation.more.settings.Preference
 import eu.kanade.tachiyomi.core.security.PinHasher
 import eu.kanade.tachiyomi.core.security.SecurityPreferences
@@ -22,7 +23,6 @@ import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.i18n.pluralStringResource
 import tachiyomi.presentation.core.i18n.stringResource
-import tachiyomi.presentation.core.util.collectAsState
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import java.util.Base64
@@ -40,7 +40,8 @@ object SettingsSecurityScreen : SearchableSettings {
         val authSupported = remember { context.isAuthenticationSupported() }
 
         val useAuthPref = securityPreferences.useAuthenticator()
-        val useAuth by useAuthPref.collectAsState()
+        val usePinLockPref = securityPreferences.usePinLock()
+        val useAuth by useAuthPref.changes().collectAsStateWithLifecycle(initialValue = useAuthPref.get())
 
         var showPinSetupDialog by rememberSaveable { mutableStateOf(false) }
         var showChangePinDialog by rememberSaveable { mutableStateOf(false) }
@@ -68,7 +69,7 @@ object SettingsSecurityScreen : SearchableSettings {
 
                     if (!success) {
                         // Rollback - disable PIN lock and clear partial data
-                        securityPreferences.usePinLock().set(false)
+                        usePinLockPref.set(false)
                         securityPreferences.pinHash().delete()
                         securityPreferences.pinSalt().delete()
                         // TODO: Show error message to user
@@ -127,7 +128,7 @@ object SettingsSecurityScreen : SearchableSettings {
             )
             add(
                 Preference.PreferenceItem.SwitchPreference(
-                    preference = securityPreferences.usePinLock(),
+                    preference = usePinLockPref,
                     title = stringResource(MR.strings.lock_with_pin),
                     onValueChanged = {
                         // Show PIN setup dialog when enabling
@@ -145,7 +146,9 @@ object SettingsSecurityScreen : SearchableSettings {
                 ),
             )
 
-            val usePinLock by securityPreferences.usePinLock().collectAsState()
+            val usePinLock by usePinLockPref
+                .changes()
+                .collectAsStateWithLifecycle(initialValue = usePinLockPref.get())
 
             if (usePinLock) {
                 add(
@@ -158,7 +161,9 @@ object SettingsSecurityScreen : SearchableSettings {
                 )
             }
 
-            val useBiometric by useAuthPref.collectAsState()
+            val useBiometric by useAuthPref
+                .changes()
+                .collectAsStateWithLifecycle(initialValue = useAuthPref.get())
 
             if (useBiometric && usePinLock) {
                 add(

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/discover/DiscoverScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/discover/DiscoverScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -31,6 +30,7 @@ import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import cafe.adriel.voyager.core.model.rememberScreenModel
 import eu.kanade.domain.track.enrichment.model.DiscoverFeedItem
 import eu.kanade.domain.track.enrichment.model.RecommendationChoice
@@ -50,7 +50,7 @@ class DiscoverScreen : Screen() {
     override fun Content() {
         val context = LocalContext.current
         val screenModel = rememberScreenModel { DiscoverScreenModel() }
-        val state by screenModel.state.collectAsState()
+        val state by screenModel.state.collectAsStateWithLifecycle()
         val backPress = LocalBackPress.current
         var chooserOptions by remember { mutableStateOf<List<RecommendationChoice>>(emptyList()) }
 

--- a/gradle/androidx.versions.toml
+++ b/gradle/androidx.versions.toml
@@ -20,6 +20,7 @@ profileinstaller = "androidx.profileinstaller:profileinstaller:1.4.1"
 lifecycle-common = { module = "androidx.lifecycle:lifecycle-common", version.ref = "lifecycle_version" }
 lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version.ref = "lifecycle_version" }
 lifecycle-runtimektx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycle_version" }
+lifecycle-runtimecompose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "lifecycle_version" }
 
 workmanager = "androidx.work:work-runtime:2.10.0"
 


### PR DESCRIPTION
## Ticket
- ID: R450
- Priority: P2
- Risk Tier: T1
- GitHub Issue: Closes #450

## Objective
- Stop background Flow collection for rayniyomi-only screens when UI is STOPPED by migrating scoped UI state collection to lifecycle-aware APIs.

## Scope
- Discover screen: `screenModel.state.collectAsState()` -> `collectAsStateWithLifecycle()`.
- Security settings screen: replace preference helper collection with `changes().collectAsStateWithLifecycle(initialValue = get())` for authenticator and PIN-lock state.
- Dependency hardening: add explicit `androidx.lifecycle:lifecycle-runtime-compose` to version catalog and app dependencies.

## Non-goals
- No global change to shared `Preference.collectAsState()` helper.
- No changes to deferred high-conflict shared screens (Anime/browse areas).

## Files Changed
- `app/src/main/java/eu/kanade/tachiyomi/ui/discover/DiscoverScreen.kt`
- `app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsSecurityScreen.kt`
- `gradle/androidx.versions.toml`
- `app/build.gradle.kts`

## Verification
- Commands run:
  - `./gradlew spotlessCheck`
  - `./gradlew :app:compileDebugKotlin`
  - `./gradlew :app:testDebugUnitTest`
- Results:
  - All commands passed.
- Not tested:
  - Manual device/emulator rotation smoke checks for Discover/Security/Enrichment UI continuity.

## Risk
- Low (T1): localized call-site migration and explicit dependency declaration.
- Mitigation: compile + unit test suite + separate-agent review pass with no blocking findings.

## SLO Impact
- Expected positive background resource impact by avoiding unnecessary UI collection while stopped.
- No expected latency or reliability regressions.

## Rollback
- Revert this PR commit to restore previous collection calls and dependency declaration.

## Release Notes
- Internal lifecycle-safety improvement for rayniyomi-only UI state collection.

## Checklist
- [x] Naming conventions followed (use "Rayniyomi" in user-facing text, see [naming conventions](../docs/governance/naming-conventions.md))
- [x] Branch rebased on latest main and verification re-run (see [rebase policy](../docs/governance/agent-workflow.md#rebase-before-merge-policy-r45))
- [x] New coroutine scopes have documented owner and cancellation path
- [x] No new `runBlocking` on UI/main thread paths

## Definition of Done (DoD)
- [x] Acceptance criteria met and non-goals respected
- [x] Verification matrix completed (Risk Tier: T1)
- [x] Self-review completed
- [x] Rebased on latest `main` and revalidated (mandatory for merge)
- [ ] Sprint board updated (branch, commit, checks, PR link)
- [x] Release notes drafted (if applicable)
