### PR TITLE
chore: Compose stack upgrade wave (R503)

### DIFF
--- a/gradle/compose.versions.toml
+++ b/gradle/compose.versions.toml
@@ -1,8 +1,8 @@
 [versions]
-compose-bom = "2025.03.00"
+compose-bom = "2026.03.00"
 
 [libraries]
-activity = "androidx.activity:activity-compose:1.10.1"
+activity = "androidx.activity:activity-compose:1.13.0"
 bom = { group = "androidx.compose", name = "compose-bom", version.ref = "compose-bom" }
 foundation = { module = "androidx.compose.foundation:foundation" }
 animation = { module = "androidx.compose.animation:animation" }

--- a/presentation-core/src/main/java/tachiyomi/presentation/core/components/AdaptiveSheet.kt
+++ b/presentation-core/src/main/java/tachiyomi/presentation/core/components/AdaptiveSheet.kt
@@ -235,7 +235,7 @@ private fun <T> AnchoredDraggableState<T>.preUpPostDownNestedScrollConnection(
 
     override suspend fun onPreFling(available: Velocity): Velocity {
         val toFling = available.toFloat()
-        return if (toFling < 0 && offset > anchors.minAnchor()) {
+        return if (toFling < 0 && offset > 0f) {
             onFling(toFling)
             // since we go to the anchor with tween settling, consume all for the best UX
             available

--- a/presentation-core/src/main/java/tachiyomi/presentation/core/components/SettingsItems.kt
+++ b/presentation-core/src/main/java/tachiyomi/presentation/core/components/SettingsItems.kt
@@ -333,7 +333,7 @@ fun SelectItem(
         )
 
         ExposedDropdownMenu(
-            modifier = Modifier.exposedDropdownSize(matchTextFieldWidth = true),
+            modifier = Modifier.exposedDropdownSize(),
             expanded = expanded,
             onDismissRequest = { expanded = false },
         ) {


### PR DESCRIPTION
## Objective
Upgrade the Compose stack in one bounded wave to align runtime/UI dependencies and avoid mixed-version API mismatches.

Closes #513

## Scope
- Updated Compose BOM in `gradle/compose.versions.toml` from `2025.03.00` to `2026.03.00`
- Updated `androidx.activity:activity-compose` from `1.10.1` to `1.13.0`
- Applied minimal compatibility fixes required by upstream Compose API changes:
  - `AdaptiveSheet.kt`: replaced removed `anchors.minAnchor()` usage with equivalent offset guard
  - `SettingsItems.kt`: removed deprecated `matchTextFieldWidth` argument from `exposedDropdownSize()`
- Kept all changes constrained to the R503 wave

## Verification
- `./gradlew spotlessCheck`
- `./gradlew :app:compileDebugKotlin`
- `git push` pre-push hooks re-ran both checks and passed

## Risk
- **Tier:** T2
- Main risk is Compose behavior drift on sheet/dropdown interactions after API changes.
- Mitigation: minimal code delta, compile validation against the upgraded stack, and contained rollback via branch/PR revert.
