### PR TITLE
refactor: remove redundant state recollection in updates tabs (R507)

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/updates/anime/AnimeUpdatesTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/updates/anime/AnimeUpdatesTab.kt
@@ -155,7 +155,7 @@ fun Screen.animeUpdatesTab(
             }
         },
         actions =
-        if (screenModel.state.collectAsState().value.selected.isNotEmpty()) {
+        if (state.selected.isNotEmpty()) {
             persistentListOf(
                 AppBar.Action(
                     title = stringResource(MR.strings.action_select_all),

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/updates/manga/MangaUpdatesTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/updates/manga/MangaUpdatesTab.kt
@@ -129,7 +129,7 @@ fun Screen.mangaUpdatesTab(
             }
         },
         actions =
-        if (screenModel.state.collectAsState().value.selected.isNotEmpty()) {
+        if (state.selected.isNotEmpty()) {
             persistentListOf(
                 AppBar.Action(
                     title = stringResource(MR.strings.action_select_all),


### PR DESCRIPTION
## Objective
Remove redundant `collectAsState()` calls in the `actions` lambda of `AnimeUpdatesTab` and `MangaUpdatesTab`. Both files collected the same flow twice — once into a local `state` variable at composition time, and again inline to check `selected.isNotEmpty()` for the actions bar.

## Scope
- `AnimeUpdatesTab.kt`: replace `screenModel.state.collectAsState().value.selected` with `state.selected`
- `MangaUpdatesTab.kt`: replace `screenModel.state.collectAsState().value.selected` with `state.selected`
- `MoreTab.kt`: no changes — confirmed distinct flows, no redundancy

## Verification
- `./gradlew :app:spotlessApply` — PASS
- `./gradlew :app:compileDebugKotlin` — PASS

## Risk
P3 / T1 — pure refactor, no behavioral change. Reduces unnecessary state subscriptions and recomposition overhead.

Closes #520