### PR TITLE
chore: Firebase and Google services alignment wave (R504)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -337,9 +337,9 @@ dependencies {
     // google-services plugin is applied conditionally (release only) so the xml resources
     // only exist in release builds; Crashlytics plugin is unconditional so the build ID is
     // always embedded. Debug builds compile fine but Firebase won't initialize (no google_app_id).
-    implementation(platform("com.google.firebase:firebase-bom:32.7.0"))
-    implementation("com.google.firebase:firebase-analytics-ktx")
-    implementation("com.google.firebase:firebase-crashlytics-ktx")
+    implementation(platform("com.google.firebase:firebase-bom:34.10.0"))
+    implementation("com.google.firebase:firebase-analytics")
+    implementation("com.google.firebase:firebase-crashlytics")
 
     // Shizuku
     implementation(libs.bundles.shizuku)


### PR DESCRIPTION
## Objective
Align Firebase dependencies through a single BOM wave and keep Firebase runtime artifacts coherent with current upstream coordinates.

Closes #514

## Scope
- Updated Firebase BOM in `app/build.gradle.kts` from `32.7.0` to `34.10.0`
- Kept Google Services / Crashlytics Gradle plugin versions unchanged after compatibility verification
- Migrated Firebase runtime artifacts from removed KTX modules to base modules under the upgraded BOM:
  - `com.google.firebase:firebase-analytics-ktx` -> `com.google.firebase:firebase-analytics`
  - `com.google.firebase:firebase-crashlytics-ktx` -> `com.google.firebase:firebase-crashlytics`
- No Compose/AndroidX/Firebase feature refactors outside this dependency wave

## Verification
- `./gradlew spotlessCheck`
- `./gradlew :app:compileDebugKotlin`
- Pre-push hook reran both checks and passed

## Risk
- **Tier:** T2
- Primary risk is Firebase initialization/manifest metadata mismatch after BOM realignment.
- Mitigation: bounded dependency-only scope and successful app compile after artifact migration.
