### PR TITLE
fix: harden one-off UI event delivery with buffered channels (R521)

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/player/custombutton/PlayerSettingsCustomButtonScreenModel.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/player/custombutton/PlayerSettingsCustomButtonScreenModel.kt
@@ -32,7 +32,7 @@ class PlayerSettingsCustomButtonScreenModel(
     private val toggleFavoriteCustomButton: ToggleFavoriteCustomButton = Injekt.get(),
 ) : StateScreenModel<CustomButtonScreenState>(CustomButtonScreenState.Loading) {
 
-    private val _events: Channel<CustomButtonEvent> = Channel()
+    private val _events: Channel<CustomButtonEvent> = Channel(Channel.BUFFERED)
     val events = _events.receiveAsFlow()
 
     init {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/anime/migration/anime/MigrateAnimeScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/anime/migration/anime/MigrateAnimeScreenModel.kt
@@ -29,7 +29,7 @@ class MigrateAnimeScreenModel(
     private val getFavorites: GetAnimeFavorites = Injekt.get(),
 ) : StateScreenModel<MigrateAnimeScreenModel.State>(State()) {
 
-    private val _events: Channel<MigrationAnimeEvent> = Channel()
+    private val _events: Channel<MigrationAnimeEvent> = Channel(Channel.BUFFERED)
     val events: Flow<MigrationAnimeEvent> = _events.receiveAsFlow()
 
     init {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/manga/migration/manga/MigrateMangaScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/manga/migration/manga/MigrateMangaScreenModel.kt
@@ -29,7 +29,7 @@ class MigrateMangaScreenModel(
     private val getFavorites: GetMangaFavorites = Injekt.get(),
 ) : StateScreenModel<MigrateMangaScreenModel.State>(State()) {
 
-    private val _events: Channel<MigrationMangaEvent> = Channel()
+    private val _events: Channel<MigrationMangaEvent> = Channel(Channel.BUFFERED)
     val events: Flow<MigrationMangaEvent> = _events.receiveAsFlow()
 
     init {

--- a/app/src/test/java/eu/kanade/presentation/more/settings/screen/browse/ExtensionReposScreenModelTest.kt
+++ b/app/src/test/java/eu/kanade/presentation/more/settings/screen/browse/ExtensionReposScreenModelTest.kt
@@ -7,13 +7,17 @@ import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
 import mihon.domain.extensionrepo.model.ExtensionRepo
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertInstanceOf
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -56,6 +60,24 @@ class ExtensionReposScreenModelTest {
 
         // Verify subscribeAll is called during init
         coVerify { deps.subscribeAll() }
+    }
+
+    @Test
+    fun `invalid url event is delivered even when collector attaches late`() = runTest {
+        val deps = createMockDependencies(emptyFlow())
+        coEvery { deps.createRepo("not-a-url") } returns ExtensionReposScreenModel.CreateResult.InvalidUrl
+        val model = ExtensionReposScreenModel(deps)
+
+        model.createRepo("not-a-url")
+
+        val event = withContext(Dispatchers.Default.limitedParallelism(1)) {
+            withTimeout(5_000) {
+                model.events.first()
+            }
+        }
+
+        assertEquals(RepoEvent.InvalidUrl, event)
+        coVerify { deps.createRepo("not-a-url") }
     }
 
     private fun createMockDependencies(

--- a/app/src/test/java/eu/kanade/presentation/more/settings/screen/player/custombutton/PlayerSettingsCustomButtonScreenModelTest.kt
+++ b/app/src/test/java/eu/kanade/presentation/more/settings/screen/player/custombutton/PlayerSettingsCustomButtonScreenModelTest.kt
@@ -1,0 +1,79 @@
+package eu.kanade.presentation.more.settings.screen.player.custombutton
+
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.withTimeout
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import tachiyomi.domain.custombuttons.interactor.CreateCustomButton
+import tachiyomi.domain.custombuttons.interactor.DeleteCustomButton
+import tachiyomi.domain.custombuttons.interactor.GetCustomButtons
+import tachiyomi.domain.custombuttons.interactor.ReorderCustomButton
+import tachiyomi.domain.custombuttons.interactor.ToggleFavoriteCustomButton
+import tachiyomi.domain.custombuttons.interactor.UpdateCustomButton
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PlayerSettingsCustomButtonScreenModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `internal error event is delivered even when collector attaches late`() = runTest {
+        val getCustomButtons = mockk<GetCustomButtons>()
+        val createCustomButton = mockk<CreateCustomButton>()
+
+        every { getCustomButtons.subscribeAll() } returns emptyFlow()
+        coEvery {
+            createCustomButton.await(
+                "name",
+                "content",
+                "longPress",
+                "startup",
+            )
+        } returns CreateCustomButton.Result.InternalError(RuntimeException("boom"))
+
+        val model = PlayerSettingsCustomButtonScreenModel(
+            getCustomButtons = getCustomButtons,
+            createCustomButton = createCustomButton,
+            deleteCustomButton = mockk<DeleteCustomButton>(relaxed = true),
+            updateCustomButton = mockk<UpdateCustomButton>(relaxed = true),
+            reorderCustomButton = mockk<ReorderCustomButton>(relaxed = true),
+            toggleFavoriteCustomButton = mockk<ToggleFavoriteCustomButton>(relaxed = true),
+        )
+
+        model.createCustomButton("name", "content", "longPress", "startup")
+        advanceUntilIdle()
+
+        val event = withTimeout(1_000) {
+            model.events.first()
+        }
+
+        assertEquals(CustomButtonEvent.InternalError, event)
+        coVerify(exactly = 1) {
+            createCustomButton.await("name", "content", "longPress", "startup")
+        }
+    }
+}

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/browse/anime/migration/anime/MigrateAnimeScreenModelTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/browse/anime/migration/anime/MigrateAnimeScreenModelTest.kt
@@ -1,0 +1,63 @@
+package eu.kanade.tachiyomi.ui.browse.anime.migration.anime
+
+import eu.kanade.tachiyomi.animesource.AnimeSource
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.withTimeout
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import tachiyomi.domain.entries.anime.interactor.GetAnimeFavorites
+import tachiyomi.domain.source.anime.service.AnimeSourceManager
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MigrateAnimeScreenModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `favorite loading failure is buffered and delivered after delayed collector attach`() = runTest {
+        val sourceManager = mockk<AnimeSourceManager>()
+        val getFavorites = mockk<GetAnimeFavorites>()
+
+        every { sourceManager.getOrStub(1L) } returns mockk<AnimeSource>(relaxed = true)
+        every { getFavorites.subscribe(1L) } returns flow { throw RuntimeException("boom") }
+
+        val model = MigrateAnimeScreenModel(
+            sourceId = 1L,
+            sourceManager = sourceManager,
+            getFavorites = getFavorites,
+        )
+
+        advanceUntilIdle()
+
+        // If event emission suspended, loading never clears because titleList update is after send().
+        assertFalse(model.state.value.isLoading)
+
+        val event = withTimeout(1_000) {
+            model.events.first()
+        }
+        assertEquals(MigrationAnimeEvent.FailedFetchingFavorites, event)
+    }
+}

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/browse/manga/migration/manga/MigrateMangaScreenModelTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/browse/manga/migration/manga/MigrateMangaScreenModelTest.kt
@@ -1,0 +1,63 @@
+package eu.kanade.tachiyomi.ui.browse.manga.migration.manga
+
+import eu.kanade.tachiyomi.source.MangaSource
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.withTimeout
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import tachiyomi.domain.entries.manga.interactor.GetMangaFavorites
+import tachiyomi.domain.source.manga.service.MangaSourceManager
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MigrateMangaScreenModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `favorite loading failure is buffered and delivered after delayed collector attach`() = runTest {
+        val sourceManager = mockk<MangaSourceManager>()
+        val getFavorites = mockk<GetMangaFavorites>()
+
+        every { sourceManager.getOrStub(1L) } returns mockk<MangaSource>(relaxed = true)
+        every { getFavorites.subscribe(1L) } returns flow { throw RuntimeException("boom") }
+
+        val model = MigrateMangaScreenModel(
+            sourceId = 1L,
+            sourceManager = sourceManager,
+            getFavorites = getFavorites,
+        )
+
+        advanceUntilIdle()
+
+        // If event emission suspended, loading never clears because titleList update is after send().
+        assertFalse(model.state.value.isLoading)
+
+        val event = withTimeout(1_000) {
+            model.events.first()
+        }
+        assertEquals(MigrationMangaEvent.FailedFetchingFavorites, event)
+    }
+}


### PR DESCRIPTION
## Objective
Harden one-off UI event delivery so event producers do not suspend when UI collectors are temporarily inactive during lifecycle/recreation transitions.

## Scope
- Switch rendezvous event channels to buffered channels in:
  - `MigrateAnimeScreenModel`
  - `MigrateMangaScreenModel`
  - `PlayerSettingsCustomButtonScreenModel`
- Keep `receiveAsFlow()` usage and UI collector wiring unchanged.
- Validate existing buffered behavior in extension repos flow with an added regression test.
- Add lifecycle/event continuity tests for the three updated screen models.

## Verification
- `./gradlew spotlessCheck`
- `./gradlew :app:compileDebugKotlin`
- `./gradlew :app:testDebugUnitTest`
- Static check (zero matches in scoped files):
  - `rg -n "private val _events:\\s*Channel<.*>\\s*=\\s*Channel\\(\\)" app/src/main/java/eu/kanade/tachiyomi/ui/browse/anime/migration/anime/MigrateAnimeScreenModel.kt app/src/main/java/eu/kanade/tachiyomi/ui/browse/manga/migration/manga/MigrateMangaScreenModel.kt app/src/main/java/eu/kanade/presentation/more/settings/screen/player/custombutton/PlayerSettingsCustomButtonScreenModel.kt`

## Risk
P2 / T2 (medium): touches transient UI-event delivery semantics. Behavior is intentionally unchanged for collectors; change is limited to buffering policy and test coverage.

## Notes
- Separate-agent review was run before merge prep.
- Review surfaced that two tests are continuity-focused (late-collector delivery) rather than strict non-blocking proofs for every path.

Closes #521
