### PR TITLE
chore: test/tooling + unresolved dependency cleanup wave (R505)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,7 +36,7 @@ quickjs-android = "app.cash.quickjs:quickjs-android:0.9.2"
 jsoup = "org.jsoup:jsoup:1.22.1"
 
 disklrucache = "com.jakewharton:disklrucache:2.0.2"
-unifile = "com.github.tachiyomiorg:unifile:e0def6b3dc"
+unifile = "com.github.tachiyomiorg:unifile:a9de196cc7"
 libarchive = "me.zhanghai.android.libarchive:library:1.1.4"
 
 sqlite-framework = { module = "androidx.sqlite:sqlite-framework", version.ref = "sqlite" }


### PR DESCRIPTION
## Ticket
- ID: R505
- Priority: P2
- Risk Tier: T2
- GitHub Issue: Closes #515

## Objective
Upgrade test/tooling dependency families and triage unresolved dependencies with explicit keep/pin/migrate decisions.

## Scope
- Upgraded test/tooling dependencies in `gradle/libs.versions.toml`:
  - `org.junit.jupiter:junit-jupiter` `5.11.4 -> 6.0.3`
  - `org.junit.platform:junit-platform-launcher` `1.11.4 -> 6.0.3`
  - `io.kotest:kotest-assertions-core` `5.9.1 -> 6.1.7`
  - `io.mockk:mockk` `1.13.17 -> 1.14.9`
- Upgraded unresolved dependency in-scope:
  - `com.github.tachiyomiorg:unifile` `e0def6b3dc -> a9de196cc7`
- Performed unresolved dependency triage for remaining ticket set:
  - `com.github.mihonapp:injekt@91edab2317` -> **keep pinned** (latest successful JitPack build for repo; repo archived)
  - `com.github.chrisbanes:PhotoView:2.3.0` -> **keep pinned** (current stable used in app; migration to alternate fork/group deferred)
  - `com.github.arkon.FlexibleAdapter:flexible-adapter@c8013533` -> **migrate planned/deferred** (JitPack reports error for current and many newer tags; move to dedicated migration ticket due UI risk)
  - `androidx.biometric:biometric-ktx:1.2.0-alpha05` -> **keep pinned** (no stable-only upgrade path; available updates are alpha)
  - `com.google.testing.platform:*` -> **remove from unresolved list** (not referenced in repo)

## Non-goals
- No runtime feature work.
- No cross-wave platform upgrades outside test/tooling version bumps.
- No refactors unrelated to dependency maintenance.

## Files Changed
- `gradle/libs.versions.toml`

## Verification
- Commands run:
  - `./gradlew spotlessCheck`
  - `./gradlew :app:compileDebugKotlin`
  - `./gradlew :app:testDebugUnitTest`
- Results:
  - All commands passed.
  - Unit tests passed under upgraded JUnit/Kotest/MockK versions.
  - Required checks re-run after unifile bump (`spotlessCheck`, `:app:compileDebugKotlin`) and passed.
- Not tested:
  - Manual device smoke flows (runtime behavior unchanged by this ticket scope).

## Risk
- Main risk is test runtime/engine compatibility shifts from JUnit 6 + newer MockK/Kotest.
- Secondary risk is UniFile commit-level behavior drift.
- Mitigation: bounded catalog-only changes, required compile/format checks, full unit-test execution on base tooling bump, and isolated rollback by reverting PR commits.

## SLO Impact
- No runtime SLO impact expected (dependency maintenance wave).

## Rollback
- Revert this PR commits to restore prior dependency versions.

## Release Notes
- Internal dependency maintenance update; no end-user visible feature changes.

## Checklist
- [x] Naming conventions followed (use "Rayniyomi" in user-facing text, see [naming conventions](../docs/governance/naming-conventions.md))
- [ ] Branch rebased on latest main and verification re-run (see [rebase policy](../docs/governance/agent-workflow.md#rebase-before-merge-policy-r45))
- [x] New coroutine scopes have documented owner and cancellation path
- [x] No new `runBlocking` on UI/main thread paths

## Definition of Done (DoD)
- [x] Acceptance criteria met and non-goals respected
- [x] Verification matrix completed (Risk Tier: T2)
- [x] Self-review completed
- [ ] Rebased on latest `main` and revalidated (mandatory for merge)
- [ ] Sprint board updated (branch, commit, checks, PR link)
- [x] Release notes drafted (if applicable)

## Fork Compliance Checklist (for new forks only)
If you are creating a new fork of this project, ensure the following:
- [ ] **App Identity**: Changed app name from "Aniyomi" to your fork name
- [ ] **App Icon**: Replaced launcher icon assets with fork-specific icons
- [ ] **Application ID**: Changed `applicationId` in `app/build.gradle.kts` from `xyz.rayniyomi` to your unique ID
- [ ] **Update Checker**: Configured `AppUpdateChecker.kt` to point to your fork's repository
- [ ] **Analytics**: Either disabled Firebase Analytics or configured with your own `google-services.json`
- [ ] **Crash Reporting**: Either disabled ACRA crash reporting or configured with your own endpoint credentials
