### PR TITLE
refactor: migrate PlayerControls to collectAsStateWithLifecycle (R531)

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/PlayerControls.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/PlayerControls.kt
@@ -41,7 +41,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -55,6 +54,7 @@ import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.Dimension
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import eu.kanade.presentation.more.settings.screen.player.custombutton.getButtons
 import eu.kanade.presentation.theme.playerRippleConfiguration
 import eu.kanade.tachiyomi.ui.player.Dialogs
@@ -85,7 +85,7 @@ import kotlinx.coroutines.flow.update
 import tachiyomi.i18n.aniyomi.AYMR
 import tachiyomi.presentation.core.components.material.padding
 import tachiyomi.presentation.core.i18n.stringResource
-import tachiyomi.presentation.core.util.collectAsState
+import tachiyomi.presentation.core.util.collectAsStateWithLifecycle
 import tachiyomi.source.local.entries.anime.LocalAnimeSource
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
@@ -106,35 +106,35 @@ fun PlayerControls(
     val subtitlePreferences = remember { Injekt.get<SubtitlePreferences>() }
     val interactionSource = remember { MutableInteractionSource() }
 
-    val controlsShown by viewModel.controlsShown.collectAsState()
-    val areControlsLocked by viewModel.areControlsLocked.collectAsState()
-    val seekBarShown by viewModel.seekBarShown.collectAsState()
-    val isLoading by viewModel.isLoading.collectAsState()
-    val isLoadingEpisode by viewModel.isLoadingEpisode.collectAsState()
-    val duration by viewModel.duration.collectAsState()
-    val position by viewModel.pos.collectAsState()
-    val paused by viewModel.paused.collectAsState()
-    val gestureSeekAmount by viewModel.gestureSeekAmount.collectAsState()
-    val doubleTapSeekAmount by viewModel.doubleTapSeekAmount.collectAsState()
-    val seekText by viewModel.seekText.collectAsState()
-    val currentChapter by viewModel.currentChapter.collectAsState()
-    val chapters by viewModel.chapters.collectAsState()
-    val currentBrightness by viewModel.currentBrightness.collectAsState()
+    val controlsShown by viewModel.controlsShown.collectAsStateWithLifecycle()
+    val areControlsLocked by viewModel.areControlsLocked.collectAsStateWithLifecycle()
+    val seekBarShown by viewModel.seekBarShown.collectAsStateWithLifecycle()
+    val isLoading by viewModel.isLoading.collectAsStateWithLifecycle()
+    val isLoadingEpisode by viewModel.isLoadingEpisode.collectAsStateWithLifecycle()
+    val duration by viewModel.duration.collectAsStateWithLifecycle()
+    val position by viewModel.pos.collectAsStateWithLifecycle()
+    val paused by viewModel.paused.collectAsStateWithLifecycle()
+    val gestureSeekAmount by viewModel.gestureSeekAmount.collectAsStateWithLifecycle()
+    val doubleTapSeekAmount by viewModel.doubleTapSeekAmount.collectAsStateWithLifecycle()
+    val seekText by viewModel.seekText.collectAsStateWithLifecycle()
+    val currentChapter by viewModel.currentChapter.collectAsStateWithLifecycle()
+    val chapters by viewModel.chapters.collectAsStateWithLifecycle()
+    val currentBrightness by viewModel.currentBrightness.collectAsStateWithLifecycle()
 
     val castManager = remember { Injekt.get<CastManager>() }
-    val castState by castManager.castState.collectAsState()
+    val castState by castManager.castState.collectAsStateWithLifecycle()
     val isCasting = (castState == CastState.CONNECTED)
-    val castProgress by viewModel.castProgress.collectAsState()
-    val currentVideo by viewModel.currentVideo.collectAsState()
-    val currentEpisode by viewModel.currentEpisode.collectAsState()
-    val currentAnime by viewModel.currentAnime.collectAsState()
+    val castProgress by viewModel.castProgress.collectAsStateWithLifecycle()
+    val currentVideo by viewModel.currentVideo.collectAsStateWithLifecycle()
+    val currentEpisode by viewModel.currentEpisode.collectAsStateWithLifecycle()
+    val currentAnime by viewModel.currentAnime.collectAsStateWithLifecycle()
 
-    val playerTimeToDisappear by playerPreferences.playerTimeToDisappear().collectAsState()
+    val playerTimeToDisappear by playerPreferences.playerTimeToDisappear().collectAsStateWithLifecycle()
     var isSeeking by remember { mutableStateOf(false) }
     var resetControls by remember { mutableStateOf(true) }
 
-    val customButtons by viewModel.customButtons.collectAsState()
-    val customButton by viewModel.primaryButton.collectAsState()
+    val customButtons by viewModel.customButtons.collectAsStateWithLifecycle()
+    val customButton by viewModel.primaryButton.collectAsStateWithLifecycle()
 
     LaunchedEffect(
         controlsShown,
@@ -188,15 +188,15 @@ fun PlayerControls(
                 val seekbar = createRef()
                 val (playerUpdates) = createRefs()
 
-                val hasPreviousEpisode by viewModel.hasPreviousEpisode.collectAsState()
-                val hasNextEpisode by viewModel.hasNextEpisode.collectAsState()
-                val isBrightnessSliderShown by viewModel.isBrightnessSliderShown.collectAsState()
-                val isVolumeSliderShown by viewModel.isVolumeSliderShown.collectAsState()
-                val brightness by viewModel.currentBrightness.collectAsState()
-                val volume by viewModel.currentVolume.collectAsState()
-                val mpvVolume by viewModel.currentMPVVolume.collectAsState()
-                val swapVolumeAndBrightness by gesturePreferences.swapVolumeBrightness().collectAsState()
-                val reduceMotion by playerPreferences.reduceMotion().collectAsState()
+                val hasPreviousEpisode by viewModel.hasPreviousEpisode.collectAsStateWithLifecycle()
+                val hasNextEpisode by viewModel.hasNextEpisode.collectAsStateWithLifecycle()
+                val isBrightnessSliderShown by viewModel.isBrightnessSliderShown.collectAsStateWithLifecycle()
+                val isVolumeSliderShown by viewModel.isVolumeSliderShown.collectAsStateWithLifecycle()
+                val brightness by viewModel.currentBrightness.collectAsStateWithLifecycle()
+                val volume by viewModel.currentVolume.collectAsStateWithLifecycle()
+                val mpvVolume by viewModel.currentMPVVolume.collectAsStateWithLifecycle()
+                val swapVolumeAndBrightness by gesturePreferences.swapVolumeBrightness().collectAsStateWithLifecycle()
+                val reduceMotion by playerPreferences.reduceMotion().collectAsStateWithLifecycle()
 
                 LaunchedEffect(volume, mpvVolume, isVolumeSliderShown) {
                     delay(2000)
@@ -281,8 +281,8 @@ fun PlayerControls(
                         bottom.linkTo(parent.bottom)
                     },
                 ) {
-                    val boostCap by audioPreferences.volumeBoostCap().collectAsState()
-                    val displayVolumeAsPercentage by playerPreferences.displayVolPer().collectAsState()
+                    val boostCap by audioPreferences.volumeBoostCap().collectAsStateWithLifecycle()
+                    val displayVolumeAsPercentage by playerPreferences.displayVolPer().collectAsStateWithLifecycle()
                     VolumeSlider(
                         volume = volume,
                         mpvVolume = mpvVolume,
@@ -292,8 +292,8 @@ fun PlayerControls(
                     )
                 }
 
-                val currentPlayerUpdate by viewModel.playerUpdate.collectAsState()
-                val aspectRatio by playerPreferences.aspectState().collectAsState()
+                val currentPlayerUpdate by viewModel.playerUpdate.collectAsStateWithLifecycle()
+                val aspectRatio by playerPreferences.aspectState().collectAsStateWithLifecycle()
                 LaunchedEffect(currentPlayerUpdate, aspectRatio) {
                     if (currentPlayerUpdate is PlayerUpdates.DoubleSpeed ||
                         currentPlayerUpdate is PlayerUpdates.SpeedBoost ||
@@ -357,7 +357,7 @@ fun PlayerControls(
                         bottom.linkTo(parent.bottom)
                     },
                 ) {
-                    val showLoadingCircle by playerPreferences.showLoadingCircle().collectAsState()
+                    val showLoadingCircle by playerPreferences.showLoadingCircle().collectAsStateWithLifecycle()
                     MiddlePlayerControls(
                         hasPrevious = hasPreviousEpisode,
                         onSkipPrevious = { viewModel.changeEpisode(true) },
@@ -410,9 +410,9 @@ fun PlayerControls(
                             },
                         )
                     } else {
-                        val invertDuration by playerPreferences.invertDuration().collectAsState()
-                        val readAhead by viewModel.readAhead.collectAsState()
-                        val preciseSeeking by gesturePreferences.playerSmoothSeek().collectAsState()
+                        val invertDuration by playerPreferences.invertDuration().collectAsStateWithLifecycle()
+                        val readAhead by viewModel.readAhead.collectAsStateWithLifecycle()
+                        val preciseSeeking by gesturePreferences.playerSmoothSeek().collectAsStateWithLifecycle()
                         SeekbarWithTimers(
                             position = position,
                             duration = duration,
@@ -430,8 +430,8 @@ fun PlayerControls(
                         )
                     }
                 }
-                val mediaTitle by viewModel.mediaTitle.collectAsState()
-                val animeTitle by viewModel.animeTitle.collectAsState()
+                val mediaTitle by viewModel.mediaTitle.collectAsStateWithLifecycle()
+                val animeTitle by viewModel.animeTitle.collectAsStateWithLifecycle()
                 AnimatedVisibility(
                     controlsShown && !areControlsLocked,
                     enter = if (!reduceMotion) {
@@ -461,8 +461,8 @@ fun PlayerControls(
                     )
                 }
                 // Top right controls
-                val autoPlayEnabled by playerPreferences.autoplayEnabled().collectAsState()
-                val isEpisodeOnline by viewModel.isEpisodeOnline.collectAsState()
+                val autoPlayEnabled by playerPreferences.autoplayEnabled().collectAsStateWithLifecycle()
+                val isEpisodeOnline by viewModel.isEpisodeOnline.collectAsStateWithLifecycle()
                 AnimatedVisibility(
                     controlsShown && !areControlsLocked,
                     enter = if (!reduceMotion) {
@@ -498,8 +498,8 @@ fun PlayerControls(
                     )
                 }
                 // Bottom right controls
-                val skipIntroButton by viewModel.skipIntroText.collectAsState()
-                val customButtonTitle by viewModel.primaryButtonTitle.collectAsState()
+                val skipIntroButton by viewModel.skipIntroText.collectAsStateWithLifecycle()
+                val customButtonTitle by viewModel.primaryButtonTitle.collectAsStateWithLifecycle()
                 AnimatedVisibility(
                     controlsShown && !areControlsLocked,
                     enter = if (!reduceMotion) {
@@ -543,7 +543,7 @@ fun PlayerControls(
                     )
                 }
                 // Bottom left controls
-                val playbackSpeed by viewModel.playbackSpeed.collectAsState()
+                val playbackSpeed by viewModel.playbackSpeed.collectAsStateWithLifecycle()
                 AnimatedVisibility(
                     controlsShown && !areControlsLocked,
                     enter = if (!reduceMotion) {
@@ -579,23 +579,23 @@ fun PlayerControls(
             }
         }
 
-        val sheetShown by viewModel.sheetShown.collectAsState()
-        val dismissSheet by viewModel.dismissSheet.collectAsState()
-        val subtitles by viewModel.subtitleTracks.collectAsState()
-        val selectedSubtitles by viewModel.selectedSubtitles.collectAsState()
-        val audioTracks by viewModel.audioTracks.collectAsState()
-        val selectedAudio by viewModel.selectedAudio.collectAsState()
-        val isLoadingHosters by viewModel.isLoadingHosters.collectAsState()
-        val hosterState by viewModel.hosterState.collectAsState()
-        val expandedState by viewModel.hosterExpandedList.collectAsState()
-        val selectedHosterVideoIndex by viewModel.selectedHosterVideoIndex.collectAsState()
-        val decoder by viewModel.currentDecoder.collectAsState()
-        val speed by viewModel.playbackSpeed.collectAsState()
-        val sleepTimerTimeRemaining by viewModel.remainingTime.collectAsState()
-        val showSubtitles by subtitlePreferences.screenshotSubtitles().collectAsState()
-        val currentSource by viewModel.currentSource.collectAsState()
-        val showFailedHosters by playerPreferences.showFailedHosters().collectAsState()
-        val emptyHosters by playerPreferences.showEmptyHosters().collectAsState()
+        val sheetShown by viewModel.sheetShown.collectAsStateWithLifecycle()
+        val dismissSheet by viewModel.dismissSheet.collectAsStateWithLifecycle()
+        val subtitles by viewModel.subtitleTracks.collectAsStateWithLifecycle()
+        val selectedSubtitles by viewModel.selectedSubtitles.collectAsStateWithLifecycle()
+        val audioTracks by viewModel.audioTracks.collectAsStateWithLifecycle()
+        val selectedAudio by viewModel.selectedAudio.collectAsStateWithLifecycle()
+        val isLoadingHosters by viewModel.isLoadingHosters.collectAsStateWithLifecycle()
+        val hosterState by viewModel.hosterState.collectAsStateWithLifecycle()
+        val expandedState by viewModel.hosterExpandedList.collectAsStateWithLifecycle()
+        val selectedHosterVideoIndex by viewModel.selectedHosterVideoIndex.collectAsStateWithLifecycle()
+        val decoder by viewModel.currentDecoder.collectAsStateWithLifecycle()
+        val speed by viewModel.playbackSpeed.collectAsStateWithLifecycle()
+        val sleepTimerTimeRemaining by viewModel.remainingTime.collectAsStateWithLifecycle()
+        val showSubtitles by subtitlePreferences.screenshotSubtitles().collectAsStateWithLifecycle()
+        val currentSource by viewModel.currentSource.collectAsStateWithLifecycle()
+        val showFailedHosters by playerPreferences.showFailedHosters().collectAsStateWithLifecycle()
+        val emptyHosters by playerPreferences.showEmptyHosters().collectAsStateWithLifecycle()
 
         PlayerSheets(
             sheetShown = sheetShown,
@@ -648,16 +648,16 @@ fun PlayerControls(
             onDismissRequest = { viewModel.showSheet(Sheets.None) },
             dismissSheet = dismissSheet,
         )
-        val panel by viewModel.panelShown.collectAsState()
+        val panel by viewModel.panelShown.collectAsStateWithLifecycle()
         PlayerPanels(
             panelShown = panel,
             onDismissRequest = { viewModel.showPanel(Panels.None) },
         )
 
         val activity = LocalContext.current as PlayerActivity
-        val dialog by viewModel.dialogShown.collectAsState()
-        val anime by viewModel.currentAnime.collectAsState()
-        val playlist by viewModel.currentPlaylist.collectAsState()
+        val dialog by viewModel.dialogShown.collectAsStateWithLifecycle()
+        val anime by viewModel.currentAnime.collectAsStateWithLifecycle()
+        val playlist by viewModel.currentPlaylist.collectAsStateWithLifecycle()
 
         PlayerDialogs(
             dialogShown = dialog,

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/lifecycle/CollectAsStateUsageGuardrailTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/lifecycle/CollectAsStateUsageGuardrailTest.kt
@@ -87,19 +87,6 @@ class CollectAsStateUsageGuardrailTest {
         )
     }
 
-    @Test
-    fun `non-screen helper raw collectAsState usage is out of scope for this ticket`() {
-        val helperPath = projectRoot.resolve(
-            "app/src/main/java/eu/kanade/presentation/more/settings/PreferenceItem.kt",
-        )
-        assertTrue(Files.isRegularFile(helperPath), "Expected helper file to exist.")
-        assertTrue(!isScopedTargetFile(helperPath), "Helper file should remain outside R451 scope.")
-        assertTrue(
-            RAW_COLLECT_AS_STATE.containsMatchIn(readNormalizedCode(helperPath)),
-            "Expected raw collectAsState() to remain in out-of-scope helper file for R451.",
-        )
-    }
-
     private fun assertFileContains(relativePath: String, regex: Regex) {
         val content = projectRoot.resolve(relativePath).toFile().readText()
         assertTrue(
@@ -127,6 +114,9 @@ class CollectAsStateUsageGuardrailTest {
     }
 
     private fun isScopedTargetFile(path: Path): Boolean {
+        if (EXPLICIT_SCOPED_TARGETS.contains(relativePath(path))) {
+            return true
+        }
         val fileName = path.fileName.toString()
         return SCOPED_SUFFIXES.any(fileName::endsWith)
     }
@@ -227,6 +217,7 @@ class CollectAsStateUsageGuardrailTest {
             "app/src/main/java/eu/kanade/tachiyomi/ui/download/DownloadsTab.kt",
             "app/src/main/java/eu/kanade/tachiyomi/ui/download/anime/AnimeDownloadQueueTab.kt",
             "app/src/main/java/eu/kanade/tachiyomi/ui/download/manga/MangaDownloadQueueTab.kt",
+            "app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/PlayerControls.kt",
             "app/src/main/java/eu/kanade/tachiyomi/ui/entries/anime/AnimeScreen.kt",
             "app/src/main/java/eu/kanade/tachiyomi/ui/entries/anime/track/AnimeTrackInfoDialog.kt",
             "app/src/main/java/eu/kanade/tachiyomi/ui/entries/manga/MangaScreen.kt",
@@ -248,6 +239,9 @@ class CollectAsStateUsageGuardrailTest {
             "app/src/main/java/eu/kanade/tachiyomi/ui/updates/manga/MangaUpdatesTab.kt",
             "app/src/main/java/mihon/feature/upcoming/anime/UpcomingAnimeScreen.kt",
             "app/src/main/java/mihon/feature/upcoming/manga/UpcomingMangaScreen.kt",
+        )
+        val EXPLICIT_SCOPED_TARGETS = setOf(
+            "app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/PlayerControls.kt",
         )
     }
 }


### PR DESCRIPTION
## Ticket
- ID: R531
- Priority: P1
- Risk Tier: T2
- GitHub Issue: Closes #531

## Objective
- Migrate `PlayerControls.kt` state collection from raw `collectAsState()` to lifecycle-aware `collectAsStateWithLifecycle()` and extend the guardrail to explicitly cover this file.

## Scope
- Replace raw `collectAsState()` calls in `app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/PlayerControls.kt`.
- Keep preference-backed collectors lifecycle-aware via project extension overloads.
- Update `CollectAsStateUsageGuardrailTest` bounded target detection to include `PlayerControls.kt` through an explicit scoped include.
- Remove the old R451 helper exemption test that is no longer valid for R531 scope.

## Non-goals
- No viewmodel/data-flow refactors.
- No UI behavior changes.
- No broad lifecycle migration outside `PlayerControls.kt`.

## Files Changed
- `app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/PlayerControls.kt`
- `app/src/test/java/eu/kanade/tachiyomi/ui/lifecycle/CollectAsStateUsageGuardrailTest.kt`

## Verification
- Commands run:
  - `./gradlew :app:testDebugUnitTest --tests "*CollectAsStateUsageGuardrailTest*"`
  - `./gradlew spotlessCheck`
  - `./gradlew :app:compileDebugKotlin`
  - `rg -n "collectAsState\\(" app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/PlayerControls.kt`
- Results:
  - Guardrail tests pass, including bounded target drift and raw collector checks.
  - Spotless and compile checks pass.
  - Raw `collectAsState(` has no matches in `PlayerControls.kt`.
- Not tested:
  - Manual player UI smoke in emulator/device.

## Risk
- Main risk is lifecycle collector overload mismatch for preference-backed state.
- Mitigation: kept project preference lifecycle extension import in place and validated with unit/compile gates.

## SLO Impact
- No expected impact to runtime SLOs. This is a lifecycle-safety migration with unchanged business behavior.

## Rollback
- Revert this PR commit to restore previous collector usage and guardrail scope.

## Release Notes
- Internal quality update: `PlayerControls` now uses lifecycle-aware state collection and guardrail coverage is extended for this file.

## Checklist
- [x] Naming conventions followed (use "Rayniyomi" in user-facing text, see [naming conventions](../docs/governance/naming-conventions.md))
- [x] Branch rebased on latest main and verification re-run (see [rebase policy](../docs/governance/agent-workflow.md#rebase-before-merge-policy-r45))
- [x] New coroutine scopes have documented owner and cancellation path
- [x] No new `runBlocking` on UI/main thread paths

## Definition of Done (DoD)
- [x] Acceptance criteria met and non-goals respected
- [x] Verification matrix completed (Risk Tier: T2)
- [x] Self-review completed
- [x] Rebased on latest `main` and revalidated (mandatory for merge)
- [ ] Sprint board updated (branch, commit, checks, PR link)
- [x] Release notes drafted (if applicable)
