### PR TITLE
chore: pin real SHA-256 cert fingerprints in LightNovelPluginManager (R536)

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/feature/novel/LightNovelPluginManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/feature/novel/LightNovelPluginManager.kt
@@ -472,8 +472,7 @@ class LightNovelPluginManager(
             "https://github.com/ryacub/rayniyomi/releases/download/plugin-beta/lightnovel-plugin-manifest.json"
 
         private val TRUSTED_PLUGIN_CERT_SHA256 = setOf(
-            "7b7f000000000000000000000000000000000000000000000000000000000000",
-            "8c8f000000000000000000000000000000000000000000000000000000000000",
+            "f3565300f2957a3e1f2aab2870d25dc1d222a996a350ffa840484623e85f2098",
         )
 
         private val TRUSTED_PLUGIN_CERT_DENYLIST = setOf<String>()

--- a/app/src/test/java/eu/kanade/tachiyomi/feature/novel/LightNovelPluginManagerTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/feature/novel/LightNovelPluginManagerTest.kt
@@ -73,7 +73,7 @@ class LightNovelPluginManagerTest {
         // Mock Hash.sha256 so signature bytes can be arbitrary test values
         mockkObject(Hash)
         every { Hash.sha256(any<ByteArray>()) } returns
-            "7b7f000000000000000000000000000000000000000000000000000000000000"
+            "f3565300f2957a3e1f2aab2870d25dc1d222a996a350ffa840484623e85f2098"
 
         network = mockk<NetworkHelper>(relaxed = true)
         val json = Json { ignoreUnknownKeys = true }


### PR DESCRIPTION
## Objective

Replace placeholder SHA-256 fingerprints in `LightNovelPluginManager.TRUSTED_PLUGIN_CERT_SHA256` with the real certificate digest extracted from the signed `plugin-v0.2.0` release APK.

## Scope

- `LightNovelPluginManager.kt`: Replace 2 placeholder entries with 1 real fingerprint (`f3565300...`)
- `LightNovelPluginManagerTest.kt`: Update `Hash.sha256` mock to match the new trusted value

Both `plugin-v0.1.0` and `plugin-v0.2.0` use the same signing certificate (CN=Rayniyomi Project, OU=Plugin Development), so one entry in the trusted set is sufficient.

## Verification

- T1: `./gradlew :app:testDebugUnitTest --tests "*LightNovelPluginManagerTest*"` — 36/36 passing

## Risk

T1 — Low. Only changes a constant value in the plugin cert trust list and the matching test mock. No logic changes.

Closes #536