### PR TITLE
feat: add custom theme mode foundation wiring (R552)

### DIFF
--- a/app/src/main/java/eu/kanade/domain/ui/model/AppTheme.kt
+++ b/app/src/main/java/eu/kanade/domain/ui/model/AppTheme.kt
@@ -6,6 +6,7 @@ import tachiyomi.i18n.aniyomi.AYMR
 
 enum class AppTheme(val titleRes: StringResource?) {
     DEFAULT(MR.strings.label_default),
+    CUSTOM(null),
     MONET(MR.strings.theme_monet),
     CLOUDFLARE(AYMR.strings.theme_cloudflare),
     COTTONCANDY(AYMR.strings.theme_cottoncandy),

--- a/app/src/main/java/eu/kanade/domain/ui/model/ThemeMode.kt
+++ b/app/src/main/java/eu/kanade/domain/ui/model/ThemeMode.kt
@@ -6,14 +6,15 @@ enum class ThemeMode {
     LIGHT,
     DARK,
     SYSTEM,
+    CUSTOM,
 }
 
 fun setAppCompatDelegateThemeMode(themeMode: ThemeMode) {
-    AppCompatDelegate.setDefaultNightMode(
-        when (themeMode) {
-            ThemeMode.LIGHT -> AppCompatDelegate.MODE_NIGHT_NO
-            ThemeMode.DARK -> AppCompatDelegate.MODE_NIGHT_YES
-            ThemeMode.SYSTEM -> AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
-        },
-    )
+    AppCompatDelegate.setDefaultNightMode(themeMode.toAppCompatDelegateMode())
+}
+
+fun ThemeMode.toAppCompatDelegateMode(): Int = when (this) {
+    ThemeMode.LIGHT -> AppCompatDelegate.MODE_NIGHT_NO
+    ThemeMode.DARK -> AppCompatDelegate.MODE_NIGHT_YES
+    ThemeMode.SYSTEM, ThemeMode.CUSTOM -> AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
 }

--- a/app/src/main/java/eu/kanade/presentation/theme/TachiyomiTheme.kt
+++ b/app/src/main/java/eu/kanade/presentation/theme/TachiyomiTheme.kt
@@ -103,6 +103,7 @@ val playerRippleConfiguration
 
 private val colorSchemes: Map<AppTheme, BaseColorScheme> = mapOf(
     AppTheme.DEFAULT to TachiyomiColorScheme,
+    AppTheme.CUSTOM to TachiyomiColorScheme,
     AppTheme.CLOUDFLARE to CloudflareColorScheme,
     AppTheme.COTTONCANDY to CottoncandyColorScheme,
     AppTheme.DOOM to DoomColorScheme,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/base/delegate/ThemingDelegate.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/base/delegate/ThemingDelegate.kt
@@ -32,6 +32,7 @@ class ThemingDelegateImpl : ThemingDelegate {
 }
 
 private val themeResources: Map<AppTheme, Int> = mapOf(
+    AppTheme.CUSTOM to R.style.Theme_Tachiyomi,
     AppTheme.MONET to R.style.Theme_Tachiyomi_Monet,
     AppTheme.COTTONCANDY to R.style.Theme_Tachiyomi_CottonCandy,
     AppTheme.GREEN_APPLE to R.style.Theme_Tachiyomi_GreenApple,

--- a/app/src/main/java/eu/kanade/tachiyomi/util/system/ContextExtensions.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/system/ContextExtensions.kt
@@ -123,7 +123,7 @@ fun Context.createReaderThemeContext(): Context {
     val isDarkBackground = when (readerPreferences.readerTheme().get()) {
         1, 2 -> true // Black, Gray
         3 -> when (themeMode) { // Automatic bg uses activity background by default
-            ThemeMode.SYSTEM -> applicationContext.isNightMode()
+            ThemeMode.SYSTEM, ThemeMode.CUSTOM -> applicationContext.isNightMode()
             else -> themeMode == ThemeMode.DARK
         }
         else -> false // White

--- a/app/src/test/java/eu/kanade/domain/ui/model/ThemeModeTest.kt
+++ b/app/src/test/java/eu/kanade/domain/ui/model/ThemeModeTest.kt
@@ -1,0 +1,28 @@
+package eu.kanade.domain.ui.model
+
+import androidx.appcompat.app.AppCompatDelegate
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class ThemeModeTest {
+
+    @Test
+    fun `light mode maps to MODE_NIGHT_NO`() {
+        assertEquals(AppCompatDelegate.MODE_NIGHT_NO, ThemeMode.LIGHT.toAppCompatDelegateMode())
+    }
+
+    @Test
+    fun `dark mode maps to MODE_NIGHT_YES`() {
+        assertEquals(AppCompatDelegate.MODE_NIGHT_YES, ThemeMode.DARK.toAppCompatDelegateMode())
+    }
+
+    @Test
+    fun `system mode maps to MODE_NIGHT_FOLLOW_SYSTEM`() {
+        assertEquals(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM, ThemeMode.SYSTEM.toAppCompatDelegateMode())
+    }
+
+    @Test
+    fun `custom mode maps to MODE_NIGHT_FOLLOW_SYSTEM`() {
+        assertEquals(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM, ThemeMode.CUSTOM.toAppCompatDelegateMode())
+    }
+}

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/base/delegate/ThemingDelegateTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/base/delegate/ThemingDelegateTest.kt
@@ -1,0 +1,19 @@
+package eu.kanade.tachiyomi.ui.base.delegate
+
+import eu.kanade.domain.ui.model.AppTheme
+import eu.kanade.tachiyomi.R
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class ThemingDelegateTest {
+
+    @Test
+    fun `custom app theme resolves to base tachiyomi style`() {
+        val resIds = ThemingDelegate.getThemeResIds(
+            appTheme = AppTheme.CUSTOM,
+            isAmoled = false,
+        )
+
+        assertEquals(listOf(R.style.Theme_Tachiyomi), resIds)
+    }
+}


### PR DESCRIPTION
## Ticket
- ID: R552
- Priority: P2
- Risk Tier: T1
- GitHub Issue: Closes #555

## Objective
- Add a custom theme mode foundation path in preferences/enums without changing current runtime behavior for existing users.

## Scope
- Added `ThemeMode.CUSTOM` and explicit mapping to `MODE_NIGHT_FOLLOW_SYSTEM`.
- Added `AppTheme.CUSTOM` as a hidden foundation enum value.
- Wired CUSTOM fallback in Compose (`TachiyomiTheme`) and activity theming (`ThemingDelegate`) to existing base Tachiyomi theme.
- Updated reader theme context handling so CUSTOM behaves like SYSTEM for automatic background mode.
- Added unit tests for theme mode mapping and custom app theme resource fallback.

## Non-goals
- No custom accent picker or custom color generation.
- No UI exposure of the custom app theme option yet.

## Files Changed
- `app/src/main/java/eu/kanade/domain/ui/model/ThemeMode.kt`
- `app/src/main/java/eu/kanade/domain/ui/model/AppTheme.kt`
- `app/src/main/java/eu/kanade/presentation/theme/TachiyomiTheme.kt`
- `app/src/main/java/eu/kanade/tachiyomi/ui/base/delegate/ThemingDelegate.kt`
- `app/src/main/java/eu/kanade/tachiyomi/util/system/ContextExtensions.kt`
- `app/src/test/java/eu/kanade/domain/ui/model/ThemeModeTest.kt`
- `app/src/test/java/eu/kanade/tachiyomi/ui/base/delegate/ThemingDelegateTest.kt`

## Verification
- Commands run:
  - `./gradlew :app:testDebugUnitTest --tests "eu.kanade.domain.ui.model.ThemeModeTest" --tests "eu.kanade.tachiyomi.ui.base.delegate.ThemingDelegateTest"`
  - `./gradlew spotlessCheck`
  - `./gradlew :app:compileDebugKotlin`
- Results:
  - All commands passed.
- Not tested:
  - Manual UI smoke test (ticket scoped to foundation wiring/tests only).

## Risk
- Low risk. Added enum cases and explicit fallback mappings so behavior remains stable unless CUSTOM is explicitly selected later.

## SLO Impact
- None expected.

## Rollback
- Revert this PR commit to remove CUSTOM enum paths and tests.

## Release Notes
- Adds internal theming foundation for future custom mode support; no visible behavior change yet.

## Checklist
- [x] Naming conventions followed (use "Rayniyomi" in user-facing text, see [naming conventions](../docs/governance/naming-conventions.md))
- [x] Branch rebased on latest main and verification re-run (see [rebase policy](../docs/governance/agent-workflow.md#rebase-before-merge-policy-r45))
- [x] New coroutine scopes have documented owner and cancellation path
- [x] No new `runBlocking` on UI/main thread paths

## Definition of Done (DoD)
- [x] Acceptance criteria met and non-goals respected
- [x] Verification matrix completed (Risk Tier: T1)
- [x] Self-review completed
- [x] Rebased on latest `main` and revalidated (mandatory for merge)
- [ ] Sprint board updated (branch, commit, checks, PR link)
- [x] Release notes drafted (if applicable)

## Fork Compliance Checklist (for new forks only)
If you are creating a new fork of this project, ensure the following:
- [ ] **App Identity**: Changed app name from "Aniyomi" to your fork name
- [ ] **App Icon**: Replaced launcher icon assets with fork-specific icons
- [ ] **Application ID**: Changed `applicationId` in `app/build.gradle.kts` from `xyz.rayniyomi` to your unique ID
- [ ] **Update Checker**: Configured `AppUpdateChecker.kt` to point to your fork's repository
- [ ] **Analytics**: Either disabled Firebase Analytics or configured with your own `google-services.json`
- [ ] **Crash Reporting**: Either disabled ACRA crash reporting or configured with your own endpoint credentials
