### PR TITLE
feat: custom accent theme engine (R553)

### DIFF
--- a/app/src/main/java/eu/kanade/domain/ui/UiPreferences.kt
+++ b/app/src/main/java/eu/kanade/domain/ui/UiPreferences.kt
@@ -17,6 +17,14 @@ class UiPreferences(
     private val preferenceStore: PreferenceStore,
 ) {
 
+    companion object {
+        const val CUSTOM_THEME_ACCENT_SEED_UNSET = Int.MIN_VALUE
+        fun dateFormat(format: String): DateTimeFormatter = when (format) {
+            "" -> DateTimeFormatter.ofLocalizedDate(FormatStyle.SHORT)
+            else -> DateTimeFormatter.ofPattern(format, Locale.getDefault())
+        }
+    }
+
     fun themeMode() = preferenceStore.getEnum("pref_theme_mode_key", ThemeMode.SYSTEM)
 
     fun appTheme() = preferenceStore.getEnum(
@@ -30,6 +38,10 @@ class UiPreferences(
 
     fun themeDarkAmoled() = preferenceStore.getBoolean("pref_theme_dark_amoled_key", false)
     fun dynamicEntryCoverTheming() = preferenceStore.getBoolean("pref_dynamic_entry_cover_theming", false)
+    fun customThemeAccentSeed() = preferenceStore.getInt(
+        "pref_custom_theme_accent_seed",
+        CUSTOM_THEME_ACCENT_SEED_UNSET,
+    )
 
     fun relativeTime() = preferenceStore.getBoolean("relative_time_v2", true)
 
@@ -40,11 +52,4 @@ class UiPreferences(
     fun startScreen() = preferenceStore.getEnum("start_screen", StartScreen.ANIME)
 
     fun navStyle() = preferenceStore.getEnum("bottom_rail_nav_style", NavStyle.MOVE_HISTORY_TO_MORE)
-
-    companion object {
-        fun dateFormat(format: String): DateTimeFormatter = when (format) {
-            "" -> DateTimeFormatter.ofLocalizedDate(FormatStyle.SHORT)
-            else -> DateTimeFormatter.ofPattern(format, Locale.getDefault())
-        }
-    }
 }

--- a/app/src/main/java/eu/kanade/presentation/theme/TachiyomiTheme.kt
+++ b/app/src/main/java/eu/kanade/presentation/theme/TachiyomiTheme.kt
@@ -14,6 +14,7 @@ import eu.kanade.domain.ui.model.AppTheme
 import eu.kanade.presentation.theme.colorscheme.BaseColorScheme
 import eu.kanade.presentation.theme.colorscheme.CloudflareColorScheme
 import eu.kanade.presentation.theme.colorscheme.CottoncandyColorScheme
+import eu.kanade.presentation.theme.colorscheme.CustomAccentColorScheme
 import eu.kanade.presentation.theme.colorscheme.DoomColorScheme
 import eu.kanade.presentation.theme.colorscheme.GreenAppleColorScheme
 import eu.kanade.presentation.theme.colorscheme.LavenderColorScheme
@@ -73,16 +74,35 @@ private fun getThemeColorScheme(
     appTheme: AppTheme,
     isAmoled: Boolean,
 ): ColorScheme {
+    val context = LocalContext.current
     val uiPreferences = Injekt.get<UiPreferences>()
-    val colorScheme = if (appTheme == AppTheme.MONET) {
-        MonetColorScheme(LocalContext.current)
-    } else {
-        colorSchemes.getOrDefault(appTheme, TachiyomiColorScheme)
-    }
+    val colorScheme = resolveBaseColorScheme(
+        appTheme = appTheme,
+        customAccentSeed = uiPreferences.customThemeAccentSeed().get(),
+        context = context,
+    )
     return colorScheme.getColorScheme(
         isSystemInDarkTheme(),
         isAmoled,
     )
+}
+
+internal fun resolveBaseColorScheme(
+    appTheme: AppTheme,
+    customAccentSeed: Int,
+    context: android.content.Context,
+): BaseColorScheme {
+    return when (appTheme) {
+        AppTheme.MONET -> MonetColorScheme(context)
+        AppTheme.CUSTOM -> {
+            if (customAccentSeed == UiPreferences.CUSTOM_THEME_ACCENT_SEED_UNSET) {
+                TachiyomiColorScheme
+            } else {
+                CustomAccentColorScheme(context = context, seed = customAccentSeed)
+            }
+        }
+        else -> colorSchemes.getOrDefault(appTheme, TachiyomiColorScheme)
+    }
 }
 
 private const val RIPPLE_DRAGGED_ALPHA = .1f
@@ -103,7 +123,6 @@ val playerRippleConfiguration
 
 private val colorSchemes: Map<AppTheme, BaseColorScheme> = mapOf(
     AppTheme.DEFAULT to TachiyomiColorScheme,
-    AppTheme.CUSTOM to TachiyomiColorScheme,
     AppTheme.CLOUDFLARE to CloudflareColorScheme,
     AppTheme.COTTONCANDY to CottoncandyColorScheme,
     AppTheme.DOOM to DoomColorScheme,

--- a/app/src/main/java/eu/kanade/presentation/theme/colorscheme/CustomAccentColorScheme.kt
+++ b/app/src/main/java/eu/kanade/presentation/theme/colorscheme/CustomAccentColorScheme.kt
@@ -1,0 +1,165 @@
+package eu.kanade.presentation.theme.colorscheme
+
+import android.app.UiModeManager
+import android.content.Context
+import android.os.Build
+import androidx.compose.material3.ColorScheme
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
+import com.google.android.material.color.utilities.Hct
+import com.google.android.material.color.utilities.MaterialDynamicColors
+import com.google.android.material.color.utilities.SchemeContent
+import kotlin.math.max
+import kotlin.math.min
+
+internal class CustomAccentColorScheme(
+    private val context: Context,
+    seed: Int,
+) : BaseColorScheme() {
+
+    private val normalizedSeed = seed or OPAQUE_ALPHA_MASK
+
+    override val lightScheme = ensureReadableOrFallback(
+        source = generateColorSchemeFromSeed(
+            context = context,
+            seed = normalizedSeed,
+            dark = false,
+        ),
+        fallback = TachiyomiColorScheme.lightScheme,
+    )
+
+    override val darkScheme = ensureReadableOrFallback(
+        source = generateColorSchemeFromSeed(
+            context = context,
+            seed = normalizedSeed,
+            dark = true,
+        ),
+        fallback = TachiyomiColorScheme.darkScheme,
+    )
+}
+
+private const val OPAQUE_ALPHA_MASK = -0x1000000
+private const val MIN_CONTRAST_RATIO = 4.5
+
+internal fun ensureReadableOrFallback(source: ColorScheme, fallback: ColorScheme): ColorScheme {
+    if (isReadable(source)) return source
+
+    val clamped = clampOnColorsForContrast(source)
+    return if (isReadable(clamped)) clamped else fallback
+}
+
+internal fun isReadable(colorScheme: ColorScheme): Boolean {
+    val pairs = listOf(
+        colorScheme.primary to colorScheme.onPrimary,
+        colorScheme.secondary to colorScheme.onSecondary,
+        colorScheme.background to colorScheme.onBackground,
+        colorScheme.surface to colorScheme.onSurface,
+    )
+    return pairs.all { (background, foreground) ->
+        if (!background.hasValidComponents() || !foreground.hasValidComponents()) {
+            return@all false
+        }
+        val ratio = contrastRatio(background, foreground)
+        ratio.isFinite() && ratio >= MIN_CONTRAST_RATIO
+    }
+}
+
+internal fun clampOnColorsForContrast(colorScheme: ColorScheme): ColorScheme {
+    val onPrimary = bestReadableOnColor(colorScheme.primary)
+    val onSecondary = bestReadableOnColor(colorScheme.secondary)
+    val onBackground = bestReadableOnColor(colorScheme.background)
+    val onSurface = bestReadableOnColor(colorScheme.surface)
+
+    return colorScheme.copy(
+        onPrimary = onPrimary,
+        onSecondary = onSecondary,
+        onBackground = onBackground,
+        onSurface = onSurface,
+    )
+}
+
+private fun bestReadableOnColor(background: Color): Color {
+    val blackContrast = contrastRatio(background, Color.Black)
+    val whiteContrast = contrastRatio(background, Color.White)
+    return if (blackContrast >= whiteContrast) Color.Black else Color.White
+}
+
+internal fun contrastRatio(background: Color, foreground: Color): Double {
+    val lighter = max(background.luminance(), foreground.luminance())
+    val darker = min(background.luminance(), foreground.luminance())
+    return (lighter + 0.05) / (darker + 0.05)
+}
+
+private fun Color.hasValidComponents(): Boolean {
+    return red.isFinite() &&
+        green.isFinite() &&
+        blue.isFinite() &&
+        alpha.isFinite() &&
+        alpha >= 0.999f
+}
+
+internal fun resolveCustomSchemeContrast(sdkInt: Int, uiModeContrast: Float?): Double {
+    return if (sdkInt >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+        uiModeContrast?.toDouble() ?: 0.0
+    } else {
+        0.0
+    }
+}
+
+private fun generateColorSchemeFromSeed(context: Context, seed: Int, dark: Boolean): ColorScheme {
+    val uiModeContrast = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+        context.getSystemService(UiModeManager::class.java)?.contrast
+    } else {
+        null
+    }
+    val contrast = resolveCustomSchemeContrast(
+        sdkInt = Build.VERSION.SDK_INT,
+        uiModeContrast = uiModeContrast,
+    )
+    val scheme = SchemeContent(
+        Hct.fromInt(seed),
+        dark,
+        contrast,
+    )
+    val dynamicColors = MaterialDynamicColors()
+    return ColorScheme(
+        primary = dynamicColors.primary().getArgb(scheme).toComposeColor(),
+        onPrimary = dynamicColors.onPrimary().getArgb(scheme).toComposeColor(),
+        primaryContainer = dynamicColors.primaryContainer().getArgb(scheme).toComposeColor(),
+        onPrimaryContainer = dynamicColors.onPrimaryContainer().getArgb(scheme).toComposeColor(),
+        inversePrimary = dynamicColors.inversePrimary().getArgb(scheme).toComposeColor(),
+        secondary = dynamicColors.secondary().getArgb(scheme).toComposeColor(),
+        onSecondary = dynamicColors.onSecondary().getArgb(scheme).toComposeColor(),
+        secondaryContainer = dynamicColors.secondaryContainer().getArgb(scheme).toComposeColor(),
+        onSecondaryContainer = dynamicColors.onSecondaryContainer().getArgb(scheme).toComposeColor(),
+        tertiary = dynamicColors.tertiary().getArgb(scheme).toComposeColor(),
+        onTertiary = dynamicColors.onTertiary().getArgb(scheme).toComposeColor(),
+        tertiaryContainer = dynamicColors.tertiaryContainer().getArgb(scheme).toComposeColor(),
+        onTertiaryContainer = dynamicColors.onTertiaryContainer().getArgb(scheme).toComposeColor(),
+        background = dynamicColors.background().getArgb(scheme).toComposeColor(),
+        onBackground = dynamicColors.onBackground().getArgb(scheme).toComposeColor(),
+        surface = dynamicColors.surface().getArgb(scheme).toComposeColor(),
+        onSurface = dynamicColors.onSurface().getArgb(scheme).toComposeColor(),
+        surfaceVariant = dynamicColors.surfaceVariant().getArgb(scheme).toComposeColor(),
+        onSurfaceVariant = dynamicColors.onSurfaceVariant().getArgb(scheme).toComposeColor(),
+        surfaceTint = dynamicColors.surfaceTint().getArgb(scheme).toComposeColor(),
+        inverseSurface = dynamicColors.inverseSurface().getArgb(scheme).toComposeColor(),
+        inverseOnSurface = dynamicColors.inverseOnSurface().getArgb(scheme).toComposeColor(),
+        error = dynamicColors.error().getArgb(scheme).toComposeColor(),
+        onError = dynamicColors.onError().getArgb(scheme).toComposeColor(),
+        errorContainer = dynamicColors.errorContainer().getArgb(scheme).toComposeColor(),
+        onErrorContainer = dynamicColors.onErrorContainer().getArgb(scheme).toComposeColor(),
+        outline = dynamicColors.outline().getArgb(scheme).toComposeColor(),
+        outlineVariant = dynamicColors.outlineVariant().getArgb(scheme).toComposeColor(),
+        scrim = Color.Black,
+        surfaceBright = dynamicColors.surfaceBright().getArgb(scheme).toComposeColor(),
+        surfaceDim = dynamicColors.surfaceDim().getArgb(scheme).toComposeColor(),
+        surfaceContainer = dynamicColors.surfaceContainer().getArgb(scheme).toComposeColor(),
+        surfaceContainerHigh = dynamicColors.surfaceContainerHigh().getArgb(scheme).toComposeColor(),
+        surfaceContainerHighest = dynamicColors.surfaceContainerHighest().getArgb(scheme).toComposeColor(),
+        surfaceContainerLow = dynamicColors.surfaceContainerLow().getArgb(scheme).toComposeColor(),
+        surfaceContainerLowest = dynamicColors.surfaceContainerLowest().getArgb(scheme).toComposeColor(),
+    )
+}
+
+private fun Int.toComposeColor(): Color = Color(this)

--- a/app/src/test/java/eu/kanade/domain/ui/UiPreferencesTest.kt
+++ b/app/src/test/java/eu/kanade/domain/ui/UiPreferencesTest.kt
@@ -1,0 +1,99 @@
+package eu.kanade.domain.ui
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import tachiyomi.core.common.preference.Preference
+import tachiyomi.core.common.preference.PreferenceStore
+
+class UiPreferencesTest {
+
+    @Test
+    fun `custom theme accent seed defaults to unset sentinel`() {
+        val preferences = UiPreferences(MutablePreferenceStore())
+
+        assertEquals(UiPreferences.CUSTOM_THEME_ACCENT_SEED_UNSET, preferences.customThemeAccentSeed().get())
+    }
+
+    @Test
+    fun `custom theme accent seed persists chosen value`() {
+        val preferences = UiPreferences(MutablePreferenceStore())
+
+        preferences.customThemeAccentSeed().set(0xFF4285F4.toInt())
+
+        assertEquals(0xFF4285F4.toInt(), preferences.customThemeAccentSeed().get())
+    }
+
+    private class MutablePreferenceStore(initialValues: Map<String, Any?> = emptyMap()) : PreferenceStore {
+        private val data = initialValues.toMutableMap()
+
+        override fun getString(key: String, defaultValue: String): Preference<String> = MutablePreference(
+            key,
+            defaultValue,
+        )
+
+        override fun getLong(key: String, defaultValue: Long): Preference<Long> = MutablePreference(key, defaultValue)
+
+        override fun getInt(key: String, defaultValue: Int): Preference<Int> = MutablePreference(key, defaultValue)
+
+        override fun getFloat(key: String, defaultValue: Float): Preference<Float> = MutablePreference(
+            key,
+            defaultValue,
+        )
+
+        override fun getBoolean(key: String, defaultValue: Boolean): Preference<Boolean> = MutablePreference(
+            key,
+            defaultValue,
+        )
+
+        override fun getStringSet(key: String, defaultValue: Set<String>): Preference<Set<String>> = MutablePreference(
+            key,
+            defaultValue,
+        )
+
+        override fun <T> getObject(
+            key: String,
+            defaultValue: T,
+            serializer: (T) -> String,
+            deserializer: (String) -> T,
+        ): Preference<T> = MutablePreference(key, defaultValue)
+
+        override fun getAll(): Map<String, *> = data
+
+        private inner class MutablePreference<T>(
+            private val key: String,
+            private val defaultValue: T,
+        ) : Preference<T> {
+            private val state = MutableStateFlow(get())
+
+            override fun key(): String = key
+
+            override fun get(): T {
+                @Suppress("UNCHECKED_CAST")
+                return (data[key] as T?) ?: defaultValue
+            }
+
+            override fun set(value: T) {
+                data[key] = value
+                state.value = value
+            }
+
+            override fun isSet(): Boolean = data.containsKey(key)
+
+            override fun delete() {
+                data.remove(key)
+                state.value = defaultValue
+            }
+
+            override fun defaultValue(): T = defaultValue
+
+            override fun changes(): Flow<T> = state.asStateFlow()
+
+            override fun stateIn(scope: CoroutineScope): StateFlow<T> = state.asStateFlow()
+        }
+    }
+}

--- a/app/src/test/java/eu/kanade/presentation/theme/TachiyomiThemeRoutingTest.kt
+++ b/app/src/test/java/eu/kanade/presentation/theme/TachiyomiThemeRoutingTest.kt
@@ -1,0 +1,49 @@
+package eu.kanade.presentation.theme
+
+import android.content.Context
+import eu.kanade.domain.ui.UiPreferences
+import eu.kanade.domain.ui.model.AppTheme
+import eu.kanade.presentation.theme.colorscheme.CustomAccentColorScheme
+import eu.kanade.presentation.theme.colorscheme.TachiyomiColorScheme
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class TachiyomiThemeRoutingTest {
+
+    private val context: Context = mockk(relaxed = true)
+
+    @Test
+    fun `custom theme uses default scheme when accent seed is unset`() {
+        val resolved = resolveBaseColorScheme(
+            appTheme = AppTheme.CUSTOM,
+            customAccentSeed = UiPreferences.CUSTOM_THEME_ACCENT_SEED_UNSET,
+            context = context,
+        )
+
+        assertSame(TachiyomiColorScheme, resolved)
+    }
+
+    @Test
+    fun `custom theme uses generated accent scheme when seed is set`() {
+        val resolved = resolveBaseColorScheme(
+            appTheme = AppTheme.CUSTOM,
+            customAccentSeed = 0xFF4285F4.toInt(),
+            context = context,
+        )
+
+        assertTrue(resolved is CustomAccentColorScheme)
+    }
+
+    @Test
+    fun `default theme remains mapped to tachiyomi scheme`() {
+        val resolved = resolveBaseColorScheme(
+            appTheme = AppTheme.DEFAULT,
+            customAccentSeed = 0xFF4285F4.toInt(),
+            context = context,
+        )
+
+        assertSame(TachiyomiColorScheme, resolved)
+    }
+}

--- a/app/src/test/java/eu/kanade/presentation/theme/colorscheme/CustomAccentColorSchemeTest.kt
+++ b/app/src/test/java/eu/kanade/presentation/theme/colorscheme/CustomAccentColorSchemeTest.kt
@@ -1,0 +1,78 @@
+package eu.kanade.presentation.theme.colorscheme
+
+import android.content.Context
+import androidx.compose.ui.graphics.Color
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class CustomAccentColorSchemeTest {
+
+    private val context: Context = mockk(relaxed = true)
+
+    @Test
+    fun `same seed produces deterministic light scheme`() {
+        val first = CustomAccentColorScheme(context = context, seed = 0xFF4285F4.toInt()).lightScheme
+        val second = CustomAccentColorScheme(context = context, seed = 0xFF4285F4.toInt()).lightScheme
+
+        assertEquals(first.primary, second.primary)
+        assertEquals(first.onPrimary, second.onPrimary)
+        assertEquals(first.surface, second.surface)
+        assertEquals(first.onSurface, second.onSurface)
+    }
+
+    @Test
+    fun `seed alpha is normalized before generation`() {
+        val transparentSeed = CustomAccentColorScheme(context = context, seed = 0x004285F4).lightScheme
+        val opaqueSeed = CustomAccentColorScheme(context = context, seed = 0xFF4285F4.toInt()).lightScheme
+
+        assertEquals(transparentSeed.primary, opaqueSeed.primary)
+        assertEquals(transparentSeed.onPrimary, opaqueSeed.onPrimary)
+    }
+
+    @Test
+    fun `tertiary container uses container token`() {
+        val scheme = CustomAccentColorScheme(context = context, seed = 0xFF4285F4.toInt()).lightScheme
+
+        assertNotEquals(scheme.tertiary, scheme.tertiaryContainer)
+    }
+
+    @Test
+    fun `contrast resolver honors android 14 system contrast`() {
+        assertEquals(0.6, resolveCustomSchemeContrast(sdkInt = 34, uiModeContrast = 0.6f), 0.000001)
+        assertEquals(0.0, resolveCustomSchemeContrast(sdkInt = 34, uiModeContrast = null))
+        assertEquals(0.0, resolveCustomSchemeContrast(sdkInt = 33, uiModeContrast = 1.0f))
+    }
+
+    @Test
+    fun `contrast clamp improves low contrast pairs`() {
+        val source = TachiyomiColorScheme.lightScheme.copy(
+            primary = Color(0xFF777777),
+            onPrimary = Color(0xFF787878),
+        )
+
+        val before = contrastRatio(source.primary, source.onPrimary)
+        val clamped = clampOnColorsForContrast(source)
+        val after = contrastRatio(clamped.primary, clamped.onPrimary)
+
+        assertTrue(after > before)
+        assertTrue(after >= 4.5)
+    }
+
+    @Test
+    fun `fallback is used when scheme remains unreadable after clamp`() {
+        val unreadable = TachiyomiColorScheme.lightScheme.copy(
+            primary = Color(0x804285F4),
+            onPrimary = Color.White,
+        )
+
+        val resolved = ensureReadableOrFallback(
+            source = unreadable,
+            fallback = TachiyomiColorScheme.lightScheme,
+        )
+
+        assertEquals(TachiyomiColorScheme.lightScheme, resolved)
+    }
+}


### PR DESCRIPTION
## Ticket
- ID: R553
- Priority: P1
- Risk Tier: T2
- GitHub Issue: Closes #556

## Objective
- Implement deterministic app-wide Material 3 theming from a user-selected custom accent seed.

## Scope
- Add custom accent seed preference key + unset sentinel.
- Route `AppTheme.CUSTOM` through a dedicated dynamic scheme generator.
- Generate light/dark Material color schemes from accent seed with Android 14 contrast-awareness.
- Enforce readability guardrails with contrast clamp + fallback.
- Add unit tests for routing, preference persistence/default, determinism, token mapping, contrast resolver, and fallback/clamp behavior.

## Non-goals
- No settings UI picker/reset UX changes (covered by R554).
- No changes to dynamic entry cover theming behavior.

## Files Changed
- `app/src/main/java/eu/kanade/domain/ui/UiPreferences.kt`
- `app/src/main/java/eu/kanade/presentation/theme/TachiyomiTheme.kt`
- `app/src/main/java/eu/kanade/presentation/theme/colorscheme/CustomAccentColorScheme.kt`
- `app/src/test/java/eu/kanade/domain/ui/UiPreferencesTest.kt`
- `app/src/test/java/eu/kanade/presentation/theme/TachiyomiThemeRoutingTest.kt`
- `app/src/test/java/eu/kanade/presentation/theme/colorscheme/CustomAccentColorSchemeTest.kt`

## Verification
- Commands run:
  - `./gradlew :app:testDebugUnitTest --tests "eu.kanade.presentation.theme.colorscheme.CustomAccentColorSchemeTest" --tests "eu.kanade.presentation.theme.TachiyomiThemeRoutingTest" --tests "eu.kanade.domain.ui.UiPreferencesTest"`
  - `./gradlew spotlessCheck`
  - `./gradlew :app:compileDebugKotlin`
- Results:
  - All above passed.
  - Subagent code review run pre-PR; addressed findings (`tertiaryContainer` mapping fix and Android 14 contrast integration + tests).
- Not tested:
  - Manual visual QA on device/emulator for library/reader/player/settings (deferred to PR QA).

## Risk
- Main risk is tonal/contrast behavior differences on edge accent seeds.
- Mitigated by deterministic generation tests, contrast clamp tests, fallback tests, and Android 14 contrast branch test.

## SLO Impact
- No backend/runtime SLO impact expected.
- Minor client-only overhead at theme selection time from color-scheme generation.

## Rollback
- Revert this PR commit to restore prior `AppTheme.CUSTOM` behavior (default Tachiyomi scheme fallback path).

## Release Notes
- Added custom-accent Material 3 theme engine for `Custom` app theme mode with contrast-safe fallbacks.

## Checklist
- [x] Naming conventions followed (use "Rayniyomi" in user-facing text, see [naming conventions](../docs/governance/naming-conventions.md))
- [x] Branch rebased on latest main and verification re-run (see [rebase policy](../docs/governance/agent-workflow.md#rebase-before-merge-policy-r45))
- [x] New coroutine scopes have documented owner and cancellation path
- [x] No new `runBlocking` on UI/main thread paths

## Definition of Done (DoD)
- [x] Acceptance criteria met and non-goals respected
- [x] Verification matrix completed (Risk Tier: T2)
- [x] Self-review completed
- [x] Rebased on latest `main` and revalidated (mandatory for merge)
- [ ] Sprint board updated (branch, commit, checks, PR link)
- [x] Release notes drafted (if applicable)

## Fork Compliance Checklist (for new forks only)
- [x] Not applicable (existing fork)
