### PR TITLE
feat: add custom theme accent controls (R554)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -246,6 +246,7 @@ dependencies {
     implementation(compose.animation)
     implementation(compose.animation.graphics)
     debugImplementation(compose.ui.tooling)
+    debugImplementation("androidx.compose.ui:ui-test-manifest")
     implementation(compose.ui.tooling.preview)
     implementation(compose.ui.util)
 
@@ -346,6 +347,9 @@ dependencies {
     // Tests
     testImplementation(libs.bundles.test)
     testImplementation("androidx.lifecycle:lifecycle-runtime-testing:2.8.7")
+    androidTestImplementation(platform(compose.bom))
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4")
+    androidTestImplementation("androidx.test.ext:junit:1.2.1")
 
     // For detecting memory leaks; see https://square.github.io/leakcanary/
     // debugImplementation(libs.leakcanary.android)

--- a/app/src/androidTest/java/eu/kanade/presentation/more/settings/widget/CustomThemeAccentPreferenceWidgetAndroidTest.kt
+++ b/app/src/androidTest/java/eu/kanade/presentation/more/settings/widget/CustomThemeAccentPreferenceWidgetAndroidTest.kt
@@ -1,0 +1,86 @@
+package eu.kanade.presentation.more.settings.widget
+
+import androidx.activity.ComponentActivity
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performSemanticsAction
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import eu.kanade.domain.ui.UiPreferences
+import eu.kanade.presentation.more.settings.screen.nextCustomAccentPickerSession
+import eu.kanade.presentation.more.settings.screen.resolveInitialCustomAccentPickerSeed
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class CustomThemeAccentPreferenceWidgetAndroidTest {
+
+    @get:Rule
+    val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun customAccentFlow_swatch_pickerCancel_pickerApply_reset_reopen() {
+        composeRule.setContent {
+            var selectedAccentSeed by mutableIntStateOf(UiPreferences.CUSTOM_THEME_ACCENT_SEED_UNSET)
+            var showPicker by mutableStateOf(false)
+            var pickerSession by mutableIntStateOf(0)
+            var pickerSeed by mutableIntStateOf(
+                resolveInitialCustomAccentPickerSeed(selectedAccentSeed),
+            )
+
+            MaterialTheme {
+                CustomThemeAccentPreferenceWidget(
+                    selectedAccentSeed = selectedAccentSeed,
+                    onSwatchClick = { selectedAccentSeed = normalizeAccentSeed(it) },
+                    onOpenPicker = {
+                        pickerSeed = resolveInitialCustomAccentPickerSeed(selectedAccentSeed)
+                        pickerSession = nextCustomAccentPickerSession(pickerSession)
+                        showPicker = true
+                    },
+                    onReset = { selectedAccentSeed = UiPreferences.CUSTOM_THEME_ACCENT_SEED_UNSET },
+                )
+                if (showPicker) {
+                    CustomThemeColorPickerDialog(
+                        sessionKey = pickerSession,
+                        initialSeed = pickerSeed,
+                        onDismiss = { showPicker = false },
+                        onApply = { selectedAccentSeed = normalizeAccentSeed(it) },
+                    )
+                }
+            }
+        }
+
+        composeRule.onNodeWithContentDescription("Accent swatch #E53935").performClick()
+        composeRule.onNodeWithText("Selected accent: #E53935").assertExists()
+
+        composeRule.onNodeWithText("Custom color…").performClick()
+        composeRule.onNodeWithContentDescription("Hue").performSemanticsAction(SemanticsActions.SetProgress) {
+            it(240f)
+        }
+        composeRule.onNodeWithText("Cancel").performClick()
+        composeRule.onNodeWithText("Selected accent: #E53935").assertExists()
+
+        composeRule.onNodeWithText("Custom color…").performClick()
+        composeRule.onNodeWithContentDescription("Saturation").performSemanticsAction(SemanticsActions.SetProgress) {
+            it(0f)
+        }
+        composeRule.onNodeWithText("Apply").performClick()
+        composeRule.onNodeWithText("Selected accent: #E53935").assertDoesNotExist()
+        composeRule.onNodeWithText("Selected accent: #FFFFFF").assertExists()
+
+        composeRule.onNodeWithText("Reset accent").performClick()
+        composeRule.onNodeWithText("Using default accent fallback").assertExists()
+
+        composeRule.onNodeWithText("Custom color…").performClick()
+        composeRule.onNodeWithText("Cancel").performClick()
+        composeRule.onNodeWithText("Using default accent fallback").assertExists()
+    }
+}

--- a/app/src/androidTest/java/eu/kanade/presentation/more/settings/widget/ThemeAppearanceFlowAndroidTest.kt
+++ b/app/src/androidTest/java/eu/kanade/presentation/more/settings/widget/ThemeAppearanceFlowAndroidTest.kt
@@ -1,0 +1,102 @@
+package eu.kanade.presentation.more.settings.widget
+
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performSemanticsAction
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import eu.kanade.domain.ui.UiPreferences
+import eu.kanade.domain.ui.model.AppTheme
+import eu.kanade.presentation.more.settings.screen.nextCustomAccentPickerSession
+import eu.kanade.presentation.more.settings.screen.resolveInitialCustomAccentPickerSeed
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ThemeAppearanceFlowAndroidTest {
+
+    @get:Rule
+    val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun themeSection_customThemeFlow_endToEnd() {
+        composeRule.setContent {
+            var appTheme by mutableStateOf(AppTheme.DEFAULT)
+            var selectedAccentSeed by mutableIntStateOf(UiPreferences.CUSTOM_THEME_ACCENT_SEED_UNSET)
+            var showPicker by mutableStateOf(false)
+            var pickerSession by mutableIntStateOf(0)
+            var pickerSeed by mutableIntStateOf(resolveInitialCustomAccentPickerSeed(selectedAccentSeed))
+
+            MaterialTheme {
+                Column {
+                    AppThemePreferenceWidget(
+                        value = appTheme,
+                        amoled = false,
+                        onItemClick = { appTheme = it },
+                    )
+
+                    if (appTheme == AppTheme.CUSTOM) {
+                        CustomThemeAccentPreferenceWidget(
+                            selectedAccentSeed = selectedAccentSeed,
+                            onSwatchClick = { selectedAccentSeed = normalizeAccentSeed(it) },
+                            onOpenPicker = {
+                                pickerSeed = resolveInitialCustomAccentPickerSeed(selectedAccentSeed)
+                                pickerSession = nextCustomAccentPickerSession(pickerSession)
+                                showPicker = true
+                            },
+                            onReset = { selectedAccentSeed = UiPreferences.CUSTOM_THEME_ACCENT_SEED_UNSET },
+                        )
+                    }
+
+                    if (showPicker) {
+                        CustomThemeColorPickerDialog(
+                            sessionKey = pickerSession,
+                            initialSeed = pickerSeed,
+                            onDismiss = { showPicker = false },
+                            onApply = { selectedAccentSeed = normalizeAccentSeed(it) },
+                        )
+                    }
+                }
+            }
+        }
+
+        composeRule.onNodeWithText("Custom accent").assertDoesNotExist()
+
+        composeRule.onNodeWithText("Custom").performClick()
+        composeRule.onNodeWithText("Custom accent").assertExists()
+
+        composeRule.onNodeWithContentDescription("Accent swatch #E53935").performClick()
+        composeRule.onNodeWithText("Selected accent: #E53935").assertExists()
+
+        composeRule.onNodeWithText("Custom color…").performClick()
+        composeRule.onNodeWithContentDescription("Hue").performSemanticsAction(SemanticsActions.SetProgress) {
+            it(240f)
+        }
+        composeRule.onNodeWithText("Cancel").performClick()
+        composeRule.onNodeWithText("Selected accent: #E53935").assertExists()
+
+        composeRule.onNodeWithText("Custom color…").performClick()
+        composeRule.onNodeWithContentDescription("Saturation").performSemanticsAction(SemanticsActions.SetProgress) {
+            it(0f)
+        }
+        composeRule.onNodeWithText("Apply").performClick()
+        composeRule.onNodeWithText("Selected accent: #FFFFFF").assertExists()
+
+        composeRule.onNodeWithText("Reset accent").performClick()
+        composeRule.onNodeWithText("Using default accent fallback").assertExists()
+
+        composeRule.onNodeWithText("Custom color…").performClick()
+        composeRule.onNodeWithText("Cancel").performClick()
+        composeRule.onNodeWithText("Using default accent fallback").assertExists()
+    }
+}

--- a/app/src/main/java/eu/kanade/domain/ui/model/AppTheme.kt
+++ b/app/src/main/java/eu/kanade/domain/ui/model/AppTheme.kt
@@ -6,7 +6,7 @@ import tachiyomi.i18n.aniyomi.AYMR
 
 enum class AppTheme(val titleRes: StringResource?) {
     DEFAULT(MR.strings.label_default),
-    CUSTOM(null),
+    CUSTOM(MR.strings.theme_custom),
     MONET(MR.strings.theme_monet),
     CLOUDFLARE(AYMR.strings.theme_cloudflare),
     COTTONCANDY(AYMR.strings.theme_cottoncandy),

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAppearanceScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAppearanceScreen.kt
@@ -5,13 +5,18 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.core.app.ActivityCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import eu.kanade.domain.ui.UiPreferences
+import eu.kanade.domain.ui.model.AppTheme
 import eu.kanade.domain.ui.model.NavStyle
 import eu.kanade.domain.ui.model.StartScreen
 import eu.kanade.domain.ui.model.TabletUiMode
@@ -21,6 +26,9 @@ import eu.kanade.presentation.more.settings.Preference
 import eu.kanade.presentation.more.settings.screen.appearance.AppLanguageScreen
 import eu.kanade.presentation.more.settings.widget.AppThemeModePreferenceWidget
 import eu.kanade.presentation.more.settings.widget.AppThemePreferenceWidget
+import eu.kanade.presentation.more.settings.widget.CustomThemeAccentPreferenceWidget
+import eu.kanade.presentation.more.settings.widget.CustomThemeColorPickerDialog
+import eu.kanade.presentation.more.settings.widget.normalizeAccentSeed
 import eu.kanade.tachiyomi.util.system.toast
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableMap
@@ -34,6 +42,8 @@ import uy.kohesive.injekt.api.get
 import java.time.LocalDate
 
 object SettingsAppearanceScreen : SearchableSettings {
+
+    internal const val DEFAULT_CUSTOM_ACCENT_PICKER_SEED = 0xFF1E88E5.toInt()
 
     @ReadOnlyComposable
     @Composable
@@ -61,8 +71,19 @@ object SettingsAppearanceScreen : SearchableSettings {
         val appThemePref = uiPreferences.appTheme()
         val appTheme by appThemePref.collectAsStateWithLifecycle()
 
+        val customThemeAccentSeedPref = uiPreferences.customThemeAccentSeed()
+        val customThemeAccentSeed by customThemeAccentSeedPref.collectAsStateWithLifecycle()
+
         val amoledPref = uiPreferences.themeDarkAmoled()
         val amoled by amoledPref.collectAsStateWithLifecycle()
+
+        var showCustomAccentPicker by rememberSaveable { mutableStateOf(false) }
+        var customAccentPickerSeed by rememberSaveable { mutableIntStateOf(DEFAULT_CUSTOM_ACCENT_PICKER_SEED) }
+        var customAccentPickerSession by rememberSaveable { mutableIntStateOf(0) }
+
+        fun recreateForThemeChange() {
+            (context as? Activity)?.let { ActivityCompat.recreate(it) }
+        }
 
         return Preference.PreferenceGroup(
             title = stringResource(MR.strings.pref_category_theme),
@@ -84,6 +105,37 @@ object SettingsAppearanceScreen : SearchableSettings {
                             amoled = amoled,
                             onItemClick = { appThemePref.set(it) },
                         )
+
+                        if (appTheme == AppTheme.CUSTOM) {
+                            CustomThemeAccentPreferenceWidget(
+                                selectedAccentSeed = customThemeAccentSeed,
+                                onSwatchClick = { selectedSeed ->
+                                    customThemeAccentSeedPref.set(normalizeAccentSeed(selectedSeed))
+                                    recreateForThemeChange()
+                                },
+                                onOpenPicker = {
+                                    customAccentPickerSeed = resolveInitialCustomAccentPickerSeed(customThemeAccentSeed)
+                                    customAccentPickerSession = nextCustomAccentPickerSession(customAccentPickerSession)
+                                    showCustomAccentPicker = true
+                                },
+                                onReset = {
+                                    customThemeAccentSeedPref.set(UiPreferences.CUSTOM_THEME_ACCENT_SEED_UNSET)
+                                    recreateForThemeChange()
+                                },
+                            )
+                        }
+
+                        if (showCustomAccentPicker) {
+                            CustomThemeColorPickerDialog(
+                                sessionKey = customAccentPickerSession,
+                                initialSeed = customAccentPickerSeed,
+                                onDismiss = { showCustomAccentPicker = false },
+                                onApply = { pickedSeed ->
+                                    customThemeAccentSeedPref.set(normalizeAccentSeed(pickedSeed))
+                                    recreateForThemeChange()
+                                },
+                            )
+                        }
                     }
                 },
                 Preference.PreferenceItem.SwitchPreference(
@@ -178,6 +230,16 @@ object SettingsAppearanceScreen : SearchableSettings {
         )
     }
 }
+
+internal fun resolveInitialCustomAccentPickerSeed(currentAccentSeed: Int): Int {
+    return if (currentAccentSeed == UiPreferences.CUSTOM_THEME_ACCENT_SEED_UNSET) {
+        SettingsAppearanceScreen.DEFAULT_CUSTOM_ACCENT_PICKER_SEED
+    } else {
+        normalizeAccentSeed(currentAccentSeed)
+    }
+}
+
+internal fun nextCustomAccentPickerSession(currentSession: Int): Int = currentSession + 1
 
 private val DateFormats = listOf(
     "", // Default

--- a/app/src/main/java/eu/kanade/presentation/more/settings/widget/AppThemePreferenceWidget.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/widget/AppThemePreferenceWidget.kt
@@ -81,8 +81,7 @@ private fun AppThemesList(
 ) {
     val context = LocalContext.current
     val appThemes = remember {
-        AppTheme.entries
-            .filterNot { it.titleRes == null || (it == AppTheme.MONET && !DeviceUtil.isDynamicColorAvailable) }
+        availableAppThemes(DeviceUtil.isDynamicColorAvailable)
     }
     LazyRow(
         contentPadding = PaddingValues(horizontal = PrefsHorizontalPadding),
@@ -125,6 +124,11 @@ private fun AppThemesList(
             }
         }
     }
+}
+
+internal fun availableAppThemes(isDynamicColorAvailable: Boolean): List<AppTheme> {
+    return AppTheme.entries
+        .filterNot { it.titleRes == null || (it == AppTheme.MONET && !isDynamicColorAvailable) }
 }
 
 @Composable

--- a/app/src/main/java/eu/kanade/presentation/more/settings/widget/CustomThemeAccentPreferenceWidget.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/widget/CustomThemeAccentPreferenceWidget.kt
@@ -1,0 +1,296 @@
+package eu.kanade.presentation.more.settings.widget
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.minimumInteractiveComponentSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
+import androidx.compose.ui.unit.dp
+import eu.kanade.domain.ui.UiPreferences
+import tachiyomi.i18n.MR
+import tachiyomi.presentation.core.i18n.stringResource
+import android.graphics.Color as AndroidColor
+
+private const val OPAQUE_ALPHA_MASK = -0x1000000
+private const val HUE_MAX = 360f
+private const val SATURATION_MAX = 1f
+private const val VALUE_MAX = 1f
+
+internal val customAccentSwatches = listOf(
+    0xFFE53935.toInt(), // Red
+    0xFF8E24AA.toInt(), // Purple
+    0xFF3949AB.toInt(), // Indigo
+    0xFF1E88E5.toInt(), // Blue
+    0xFF00897B.toInt(), // Teal
+    0xFF43A047.toInt(), // Green
+    0xFFFDD835.toInt(), // Yellow
+    0xFFFB8C00.toInt(), // Orange
+)
+
+@Composable
+internal fun CustomThemeAccentPreferenceWidget(
+    selectedAccentSeed: Int,
+    onSwatchClick: (Int) -> Unit,
+    onOpenPicker: () -> Unit,
+    onReset: () -> Unit,
+) {
+    BasePreferenceWidget(
+        title = stringResource(MR.strings.pref_custom_theme_accent),
+        subcomponent = {
+            val selectedStateString = stringResource(MR.strings.selected)
+            val notSelectedStateString = stringResource(MR.strings.not_selected)
+            val chooseColorDescription = stringResource(MR.strings.pref_custom_theme_choose_color)
+            val resetAccentDescription = stringResource(MR.strings.pref_custom_theme_reset_accent)
+            Text(
+                text = if (selectedAccentSeed == UiPreferences.CUSTOM_THEME_ACCENT_SEED_UNSET) {
+                    stringResource(MR.strings.pref_custom_theme_accent_using_default)
+                } else {
+                    stringResource(
+                        MR.strings.pref_custom_theme_accent_using,
+                        accentSeedToHex(selectedAccentSeed),
+                    )
+                },
+                modifier = Modifier.padding(horizontal = PrefsHorizontalPadding),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            LazyRow(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = PrefsHorizontalPadding),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                items(customAccentSwatches) { swatchSeed ->
+                    val selected = normalizeAccentSeed(selectedAccentSeed) == normalizeAccentSeed(swatchSeed)
+                    val swatchHex = accentSeedToHex(swatchSeed)
+                    val swatchContentDescription = stringResource(
+                        MR.strings.pref_custom_theme_accent_swatch_content_description,
+                        swatchHex,
+                    )
+                    val swatchStateDescription = if (selected) selectedStateString else notSelectedStateString
+                    FilterChip(
+                        selected = selected,
+                        onClick = { onSwatchClick(swatchSeed) },
+                        label = {
+                            Row(
+                                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                            ) {
+                                Text(
+                                    text = swatchHex,
+                                    style = MaterialTheme.typography.labelMedium,
+                                )
+                            }
+                        },
+                        leadingIcon = {
+                            Row(
+                                modifier = Modifier
+                                    .size(16.dp)
+                                    .background(
+                                        color = androidx.compose.ui.graphics.Color(normalizeAccentSeed(swatchSeed)),
+                                        shape = CircleShape,
+                                    ),
+                            ) {}
+                        },
+                        modifier = Modifier
+                            .minimumInteractiveComponentSize()
+                            .semantics {
+                                contentDescription = swatchContentDescription
+                                stateDescription = swatchStateDescription
+                            },
+                    )
+                }
+            }
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = PrefsHorizontalPadding),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Button(
+                    onClick = onOpenPicker,
+                    modifier = Modifier
+                        .weight(1f)
+                        .minimumInteractiveComponentSize()
+                        .semantics {
+                            contentDescription = chooseColorDescription
+                        },
+                ) {
+                    Text(text = stringResource(MR.strings.pref_custom_theme_choose_color))
+                }
+                TextButton(
+                    onClick = onReset,
+                    modifier = Modifier
+                        .weight(1f)
+                        .minimumInteractiveComponentSize()
+                        .semantics {
+                            contentDescription = resetAccentDescription
+                        },
+                ) {
+                    Text(text = stringResource(MR.strings.pref_custom_theme_reset_accent))
+                }
+            }
+        },
+    )
+}
+
+@Composable
+internal fun CustomThemeColorPickerDialog(
+    sessionKey: Int,
+    initialSeed: Int,
+    onDismiss: () -> Unit,
+    onApply: (Int) -> Unit,
+) {
+    val initialHsv = seedToHsv(initialSeed)
+    var hue by rememberSaveable(sessionKey, initialSeed) { mutableFloatStateOf(initialHsv.hue) }
+    var saturation by rememberSaveable(sessionKey, initialSeed) { mutableFloatStateOf(initialHsv.saturation) }
+    var value by rememberSaveable(sessionKey, initialSeed) { mutableFloatStateOf(initialHsv.value) }
+
+    val previewSeed = hsvToAccentSeed(hue, saturation, value)
+    val previewHex = accentSeedToHex(previewSeed)
+    val previewDescription = stringResource(
+        MR.strings.pref_custom_theme_picker_preview_content_description,
+        previewHex,
+    )
+    val hueDescription = stringResource(MR.strings.pref_custom_theme_picker_hue)
+    val saturationDescription = stringResource(MR.strings.pref_custom_theme_picker_saturation)
+    val valueDescription = stringResource(MR.strings.pref_custom_theme_picker_value)
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(text = stringResource(MR.strings.pref_custom_theme_picker_title)) },
+        text = {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                Text(
+                    text = stringResource(MR.strings.pref_custom_theme_accent_using, previewHex),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(56.dp)
+                        .background(
+                            color = androidx.compose.ui.graphics.Color(previewSeed),
+                            shape = MaterialTheme.shapes.medium,
+                        )
+                        .semantics {
+                            contentDescription = previewDescription
+                        },
+                ) {}
+
+                Text(text = stringResource(MR.strings.pref_custom_theme_picker_hue))
+                Slider(
+                    value = hue,
+                    onValueChange = { hue = it.coerceIn(0f, HUE_MAX) },
+                    valueRange = 0f..HUE_MAX,
+                    modifier = Modifier.semantics {
+                        contentDescription = hueDescription
+                    },
+                )
+
+                Text(text = stringResource(MR.strings.pref_custom_theme_picker_saturation))
+                Slider(
+                    value = saturation,
+                    onValueChange = { saturation = it.coerceIn(0f, SATURATION_MAX) },
+                    valueRange = 0f..SATURATION_MAX,
+                    modifier = Modifier.semantics {
+                        contentDescription = saturationDescription
+                    },
+                )
+
+                Text(text = stringResource(MR.strings.pref_custom_theme_picker_value))
+                Slider(
+                    value = value,
+                    onValueChange = { value = it.coerceIn(0f, VALUE_MAX) },
+                    valueRange = 0f..VALUE_MAX,
+                    modifier = Modifier.semantics {
+                        contentDescription = valueDescription
+                    },
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    onApply(previewSeed)
+                    onDismiss()
+                },
+            ) {
+                Text(text = stringResource(MR.strings.action_apply))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(text = stringResource(MR.strings.action_cancel))
+            }
+        },
+    )
+}
+
+internal fun normalizeAccentSeed(seed: Int): Int = seed or OPAQUE_ALPHA_MASK
+
+internal fun resolvePickerResultSeed(
+    confirmSelection: Boolean,
+    currentSeed: Int,
+    draftSeed: Int,
+): Int {
+    return if (confirmSelection) normalizeAccentSeed(draftSeed) else currentSeed
+}
+
+internal data class AccentHsv(
+    val hue: Float,
+    val saturation: Float,
+    val value: Float,
+)
+
+internal fun seedToHsv(seed: Int): AccentHsv {
+    val hsv = FloatArray(3)
+    AndroidColor.colorToHSV(normalizeAccentSeed(seed), hsv)
+    return AccentHsv(
+        hue = hsv[0].coerceIn(0f, HUE_MAX),
+        saturation = hsv[1].coerceIn(0f, SATURATION_MAX),
+        value = hsv[2].coerceIn(0f, VALUE_MAX),
+    )
+}
+
+internal fun hsvToAccentSeed(
+    hue: Float,
+    saturation: Float,
+    value: Float,
+): Int {
+    return AndroidColor.HSVToColor(
+        floatArrayOf(
+            hue.coerceIn(0f, HUE_MAX),
+            saturation.coerceIn(0f, SATURATION_MAX),
+            value.coerceIn(0f, VALUE_MAX),
+        ),
+    ).let(::normalizeAccentSeed)
+}
+
+internal fun accentSeedToHex(seed: Int): String {
+    val rgb = normalizeAccentSeed(seed) and 0x00FFFFFF
+    return "#%06X".format(rgb)
+}

--- a/app/src/test/java/eu/kanade/domain/ui/UiPreferencesTest.kt
+++ b/app/src/test/java/eu/kanade/domain/ui/UiPreferencesTest.kt
@@ -1,5 +1,8 @@
 package eu.kanade.domain.ui
 
+import eu.kanade.domain.ui.model.AppTheme
+import eu.kanade.presentation.more.settings.widget.normalizeAccentSeed
+import eu.kanade.presentation.more.settings.widget.resolvePickerResultSeed
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -26,6 +29,58 @@ class UiPreferencesTest {
         preferences.customThemeAccentSeed().set(0xFF4285F4.toInt())
 
         assertEquals(0xFF4285F4.toInt(), preferences.customThemeAccentSeed().get())
+    }
+
+    @Test
+    fun `custom accent updates do not change dynamic entry cover theming preference`() {
+        val preferences = UiPreferences(MutablePreferenceStore())
+
+        preferences.dynamicEntryCoverTheming().set(true)
+        preferences.customThemeAccentSeed().set(0xFF1E88E5.toInt())
+
+        assertEquals(true, preferences.dynamicEntryCoverTheming().get())
+    }
+
+    @Test
+    fun `custom accent flow supports swatch cancel apply reset and reopen`() {
+        val store = MutablePreferenceStore()
+        val preferences = UiPreferences(store)
+        val appTheme = preferences.appTheme()
+        val customAccent = preferences.customThemeAccentSeed()
+
+        appTheme.set(AppTheme.CUSTOM)
+        val swatchSelection = normalizeAccentSeed(0x004285F4)
+        customAccent.set(swatchSelection)
+        assertEquals(0xFF4285F4.toInt(), customAccent.get())
+
+        val cancelledSelection = resolvePickerResultSeed(
+            confirmSelection = false,
+            currentSeed = customAccent.get(),
+            draftSeed = 0x00000000,
+        )
+        assertEquals(0xFF4285F4.toInt(), cancelledSelection)
+        assertEquals(0xFF4285F4.toInt(), customAccent.get())
+
+        val appliedSelection = resolvePickerResultSeed(
+            confirmSelection = true,
+            currentSeed = customAccent.get(),
+            draftSeed = 0x00010203,
+        )
+        customAccent.set(appliedSelection)
+        assertEquals(0xFF010203.toInt(), customAccent.get())
+
+        appTheme.set(AppTheme.DEFAULT)
+        appTheme.set(AppTheme.CUSTOM)
+        assertEquals(0xFF010203.toInt(), customAccent.get())
+
+        customAccent.set(UiPreferences.CUSTOM_THEME_ACCENT_SEED_UNSET)
+        assertEquals(UiPreferences.CUSTOM_THEME_ACCENT_SEED_UNSET, customAccent.get())
+
+        val reopenedPreferences = UiPreferences(store)
+        assertEquals(
+            UiPreferences.CUSTOM_THEME_ACCENT_SEED_UNSET,
+            reopenedPreferences.customThemeAccentSeed().get(),
+        )
     }
 
     private class MutablePreferenceStore(initialValues: Map<String, Any?> = emptyMap()) : PreferenceStore {

--- a/app/src/test/java/eu/kanade/presentation/more/settings/screen/SettingsAppearanceScreenThemeFlowTest.kt
+++ b/app/src/test/java/eu/kanade/presentation/more/settings/screen/SettingsAppearanceScreenThemeFlowTest.kt
@@ -1,0 +1,28 @@
+package eu.kanade.presentation.more.settings.screen
+
+import eu.kanade.domain.ui.UiPreferences
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class SettingsAppearanceScreenThemeFlowTest {
+
+    @Test
+    fun `picker seed falls back to default when accent is unset`() {
+        val resolved = resolveInitialCustomAccentPickerSeed(UiPreferences.CUSTOM_THEME_ACCENT_SEED_UNSET)
+
+        assertEquals(SettingsAppearanceScreen.DEFAULT_CUSTOM_ACCENT_PICKER_SEED, resolved)
+    }
+
+    @Test
+    fun `picker seed normalizes opaque alpha for persisted accents`() {
+        val resolved = resolveInitialCustomAccentPickerSeed(0x00123456)
+
+        assertEquals(0xFF123456.toInt(), resolved)
+    }
+
+    @Test
+    fun `picker session increments deterministically`() {
+        assertEquals(1, nextCustomAccentPickerSession(0))
+        assertEquals(11, nextCustomAccentPickerSession(10))
+    }
+}

--- a/app/src/test/java/eu/kanade/presentation/more/settings/widget/AppThemePreferenceWidgetTest.kt
+++ b/app/src/test/java/eu/kanade/presentation/more/settings/widget/AppThemePreferenceWidgetTest.kt
@@ -1,0 +1,23 @@
+package eu.kanade.presentation.more.settings.widget
+
+import eu.kanade.domain.ui.model.AppTheme
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class AppThemePreferenceWidgetTest {
+
+    @Test
+    fun `custom theme is visible in app theme options`() {
+        val themes = availableAppThemes(isDynamicColorAvailable = true)
+
+        assertTrue(themes.contains(AppTheme.CUSTOM))
+    }
+
+    @Test
+    fun `monet is hidden when dynamic color is unavailable`() {
+        val themes = availableAppThemes(isDynamicColorAvailable = false)
+
+        assertFalse(themes.contains(AppTheme.MONET))
+    }
+}

--- a/app/src/test/java/eu/kanade/presentation/more/settings/widget/CustomThemeAccentPreferenceWidgetTest.kt
+++ b/app/src/test/java/eu/kanade/presentation/more/settings/widget/CustomThemeAccentPreferenceWidgetTest.kt
@@ -1,0 +1,69 @@
+package eu.kanade.presentation.more.settings.widget
+
+import eu.kanade.domain.ui.UiPreferences
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class CustomThemeAccentPreferenceWidgetTest {
+
+    @Test
+    fun `normalize accent seed enforces opaque alpha`() {
+        val normalized = normalizeAccentSeed(0x004285F4)
+
+        assertEquals(0xFF4285F4.toInt(), normalized)
+    }
+
+    @Test
+    fun `picker apply returns normalized draft seed`() {
+        val resolved = resolvePickerResultSeed(
+            confirmSelection = true,
+            currentSeed = UiPreferences.CUSTOM_THEME_ACCENT_SEED_UNSET,
+            draftSeed = 0x0000FF00,
+        )
+
+        assertEquals(0xFF00FF00.toInt(), resolved)
+    }
+
+    @Test
+    fun `picker cancel keeps existing seed unchanged`() {
+        val current = 0xFF1E88E5.toInt()
+        val resolved = resolvePickerResultSeed(
+            confirmSelection = false,
+            currentSeed = current,
+            draftSeed = 0x0000FF00,
+        )
+
+        assertEquals(current, resolved)
+    }
+
+    @Test
+    fun `hsv conversion returns opaque seed and valid hsv bounds`() {
+        val green = hsvToAccentSeed(hue = 120f, saturation = 1f, value = 1f)
+        val redHsv = seedToHsv(0xFFFF0000.toInt())
+
+        val alpha = (green ushr 24) and 0xFF
+        assertEquals(0xFF, alpha)
+        assertTrue(redHsv.hue in 0f..360f)
+        assertTrue(redHsv.saturation in 0f..1f)
+        assertTrue(redHsv.value in 0f..1f)
+    }
+
+    @Test
+    fun `hsv conversion clamps invalid values to safe range`() {
+        val clamped = hsvToAccentSeed(hue = 999f, saturation = -2f, value = 4f)
+        val hsv = seedToHsv(clamped)
+
+        assertTrue(hsv.hue in 0f..360f)
+        assertTrue(hsv.saturation in 0f..1f)
+        assertTrue(hsv.value in 0f..1f)
+    }
+
+    @Test
+    fun `custom swatches contain unique colors`() {
+        assertEquals(customAccentSwatches.size, customAccentSwatches.distinct().size)
+        assertTrue(customAccentSwatches.isNotEmpty())
+        assertNotEquals(UiPreferences.CUSTOM_THEME_ACCENT_SEED_UNSET, customAccentSwatches.first())
+    }
+}

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -232,6 +232,7 @@
     <string name="theme_system">System</string>
     <string name="theme_light">Light</string>
     <string name="theme_dark">Dark</string>
+    <string name="theme_custom">Custom</string>
     <string name="theme_monet">Dynamic</string>
     <string name="theme_greenapple">Green Apple</string>
     <string name="theme_lavender">Lavender</string>
@@ -247,6 +248,17 @@
     <string name="pref_dark_theme_pure_black">Pure black dark mode</string>
     <string name="pref_dynamic_entry_cover_theming">Dynamic entry cover theming</string>
     <string name="pref_dynamic_entry_cover_theming_summary">Use entry cover colors for accents on entry screens when contrast is safe</string>
+    <string name="pref_custom_theme_accent">Custom accent</string>
+    <string name="pref_custom_theme_accent_using">Selected accent: %1$s</string>
+    <string name="pref_custom_theme_accent_using_default">Using default accent fallback</string>
+    <string name="pref_custom_theme_choose_color">Custom color…</string>
+    <string name="pref_custom_theme_reset_accent">Reset accent</string>
+    <string name="pref_custom_theme_picker_title">Pick accent color</string>
+    <string name="pref_custom_theme_picker_preview_content_description">Accent preview %1$s</string>
+    <string name="pref_custom_theme_picker_hue">Hue</string>
+    <string name="pref_custom_theme_picker_saturation">Saturation</string>
+    <string name="pref_custom_theme_picker_value">Value</string>
+    <string name="pref_custom_theme_accent_swatch_content_description">Accent swatch %1$s</string>
     <string name="pref_relative_format">Relative timestamps</string>
     <!-- "Today" instead of "2023-12-31" -->
     <string name="pref_relative_format_summary">\"%1$s\" instead of \"%2$s\"</string>


### PR DESCRIPTION
## Ticket
- ID: R554
- Priority: P2
- Risk Tier: T2
- GitHub Issue: Closes #557

## Objective
- Add custom theme accent controls (swatches + picker) for `AppTheme.CUSTOM` with safe persistence, clear reset behavior, and immediate theme refresh.

## Scope
- Make `AppTheme.CUSTOM` visible/selectable in appearance theme options.
- Add custom accent controls shown only when custom theme is selected:
  - curated swatches
  - custom color picker dialog
  - reset accent action
- Persist accent via `customThemeAccentSeed` with opaque-alpha normalization.
- Ensure picker apply/cancel semantics and session handling avoid stale canceled state on reopen.
- Add test coverage for theme visibility, normalization, picker semantics, reset, flow persistence, and integration-style Android UI flow.

## Non-goals
- No third-party color picker dependency.
- No docs/migration scope expansion beyond PR notes.

## Files Changed
- `app/src/main/java/eu/kanade/domain/ui/model/AppTheme.kt`
- `app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAppearanceScreen.kt`
- `app/src/main/java/eu/kanade/presentation/more/settings/widget/AppThemePreferenceWidget.kt`
- `app/src/main/java/eu/kanade/presentation/more/settings/widget/CustomThemeAccentPreferenceWidget.kt`
- `i18n/src/commonMain/moko-resources/base/strings.xml`
- `app/src/test/java/eu/kanade/domain/ui/UiPreferencesTest.kt`
- `app/src/test/java/eu/kanade/presentation/more/settings/widget/AppThemePreferenceWidgetTest.kt`
- `app/src/test/java/eu/kanade/presentation/more/settings/widget/CustomThemeAccentPreferenceWidgetTest.kt`
- `app/src/test/java/eu/kanade/presentation/more/settings/screen/SettingsAppearanceScreenThemeFlowTest.kt`
- `app/src/androidTest/java/eu/kanade/presentation/more/settings/widget/CustomThemeAccentPreferenceWidgetAndroidTest.kt`
- `app/src/androidTest/java/eu/kanade/presentation/more/settings/widget/ThemeAppearanceFlowAndroidTest.kt`
- `app/build.gradle.kts`

## Verification
- Commands run:
  - `./gradlew spotlessCheck`
  - `./gradlew :app:compileDebugKotlin`
  - `./gradlew :app:testDebugUnitTest --tests "eu.kanade.presentation.more.settings.widget.AppThemePreferenceWidgetTest" --tests "eu.kanade.presentation.more.settings.widget.CustomThemeAccentPreferenceWidgetTest" --tests "eu.kanade.domain.ui.UiPreferencesTest" --tests "eu.kanade.presentation.more.settings.screen.SettingsAppearanceScreenThemeFlowTest"`
  - `./gradlew :app:compileDebugAndroidTestKotlin`
- Results:
  - All listed commands pass locally.
- Not tested:
  - Instrumentation execution on emulator/device (`connectedDebugAndroidTest`) was not run in this environment.

## Risk
- Primary risk is UI behavior drift in appearance settings; mitigated by unit tests + Android test coverage for theme section flow and picker semantics.

## SLO Impact
- No expected runtime SLO impact.

## Rollback
- Revert commit `df549a05e` to restore previous appearance-settings behavior and remove custom accent controls.

## Release Notes
- Added custom theme accent controls in Appearance settings with swatches, a custom color picker, and reset behavior.

## Checklist
- [x] Naming conventions followed (use "Rayniyomi" in user-facing text, see [naming conventions](../docs/governance/naming-conventions.md))
- [x] Branch rebased on latest main and verification re-run (see [rebase policy](../docs/governance/agent-workflow.md#rebase-before-merge-policy-r45))
- [x] New coroutine scopes have documented owner and cancellation path
- [x] No new `runBlocking` on UI/main thread paths

## Definition of Done (DoD)
- [x] Acceptance criteria met and non-goals respected
- [x] Verification matrix completed (Risk Tier: T2)
- [x] Self-review completed
- [x] Rebased on latest `main` and revalidated (mandatory for merge)
- [ ] Sprint board updated (branch, commit, checks, PR link)
- [x] Release notes drafted (if applicable)
