### PR TITLE
feat: complete theming hardening and custom accent controls (R558)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 ### Added
 
 - **Download crash notification** — notifies the user when the anime or manga download job crashes repeatedly (threshold: 3 consecutive crashes), with a tap-to-open link to the download manager
+- **Custom app theme accent controls** — custom app theme is now selectable in Appearance settings with curated accent swatches and one-tap reset to default palette
 - **LightNovelPluginManager unit tests** — 37 tests covering install flow, manifest validation, update policy, APK download/checksum verification, install launch, in-flight mutex deduplication, error recovery, and orphaned APK cleanup
 - **Persist dialog/form state across rotation** — PIN setup, PIN change (step/value/error), and enrichment chooser source selection now survive configuration changes via `rememberSaveable`
 - **PIN error feedback** — shows an error message when saving a new PIN fails (e.g., storage write error), instead of silently closing the dialog
@@ -43,6 +44,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 ### Other
 
 - Unit tests for `PlayerFileLoadedHandler` (29 tests) and `PlayerMpvInitializer` (16 tests); adds `MPVLibProxy` abstraction to both classes to enable JNI-safe unit testing
+- Documented theming migration and fallback behavior (custom accent unset fallback, custom mode night-mode mapping, enum fallback safety, and lowercase legacy migration normalization) in README and inline code comments
 - Compose stack upgrade: BOM → 2026.03.00, `activity-compose` → 1.13.0
 - AndroidX step-up: `core-ktx` → 1.18.0, Lifecycle → 2.10.0, Paging → 3.4.2, WorkManager → 2.11.1, media/mediarouter bumps
 - Core runtime dependency upgrade: jsoup → 1.22.1, Coil → 3.4.0, Material → 1.13.0, OkIO → 3.17.0

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Fork of Aniyomi with anime/manga/light novel tracking, reading, and watching.
 - **Library de-duplication** — detect and merge duplicate entries from different sources, preserving read progress, categories, history, and tracker data
 - **Source health badges** — see broken sources at a glance; broken sources hidden by default
 - **Dynamic cover theming** — entry screens tinted from cover art with contrast-checked fallbacks
+- **Custom app theme accents** — choose a curated accent swatch for the custom theme, with one-tap reset to default palette
 - **Discover feed** — aggregated tracker-based recommendations ranked by multi-tracker affinity, recent activity, and score
 - **Categories with search** — organize that 500-entry library
 
@@ -37,6 +38,13 @@ Fork of Aniyomi with anime/manga/light novel tracking, reading, and watching.
 - Cloud backups
 - Schedule library updates
 - Dark/light themes
+
+### Theming Notes
+
+- `ThemeMode.CUSTOM` uses the custom app palette while still following system day/night mode.
+- If custom accent seed is unset, the app falls back to the default Tachiyomi color scheme.
+- Legacy lowercase theme-mode values are normalized during preference split migration.
+- Invalid stored theme-mode enum values safely fall back to the default (`SYSTEM`).
 
 ## Contributing
 

--- a/app/src/main/java/eu/kanade/domain/ui/model/ThemeMode.kt
+++ b/app/src/main/java/eu/kanade/domain/ui/model/ThemeMode.kt
@@ -16,5 +16,6 @@ fun setAppCompatDelegateThemeMode(themeMode: ThemeMode) {
 fun ThemeMode.toAppCompatDelegateMode(): Int = when (this) {
     ThemeMode.LIGHT -> AppCompatDelegate.MODE_NIGHT_NO
     ThemeMode.DARK -> AppCompatDelegate.MODE_NIGHT_YES
+    // Custom app palette still follows the system day/night mode.
     ThemeMode.SYSTEM, ThemeMode.CUSTOM -> AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
 }

--- a/app/src/main/java/eu/kanade/presentation/more/onboarding/ThemeStep.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/onboarding/ThemeStep.kt
@@ -24,6 +24,8 @@ internal class ThemeStep : OnboardingStep {
 
         val appThemePref = uiPreferences.appTheme()
         val appTheme by appThemePref.collectAsState()
+        val customAccentSeedPref = uiPreferences.customThemeAccentSeed()
+        val customAccentSeed by customAccentSeedPref.collectAsState()
 
         val amoledPref = uiPreferences.themeDarkAmoled()
         val amoled by amoledPref.collectAsState()
@@ -40,7 +42,9 @@ internal class ThemeStep : OnboardingStep {
             AppThemePreferenceWidget(
                 value = appTheme,
                 amoled = amoled,
+                customAccentSeed = customAccentSeed,
                 onItemClick = { appThemePref.set(it) },
+                onCustomAccentSeedChange = { customAccentSeedPref.set(it) },
             )
         }
     }

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAppearanceScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAppearanceScreen.kt
@@ -70,6 +70,8 @@ object SettingsAppearanceScreen : SearchableSettings {
 
         val appThemePref = uiPreferences.appTheme()
         val appTheme by appThemePref.collectAsStateWithLifecycle()
+        val customAccentSeedPref = uiPreferences.customThemeAccentSeed()
+        val customAccentSeed by customAccentSeedPref.collectAsStateWithLifecycle()
 
         val customThemeAccentSeedPref = uiPreferences.customThemeAccentSeed()
         val customThemeAccentSeed by customThemeAccentSeedPref.collectAsStateWithLifecycle()
@@ -103,7 +105,9 @@ object SettingsAppearanceScreen : SearchableSettings {
                         AppThemePreferenceWidget(
                             value = appTheme,
                             amoled = amoled,
+                            customAccentSeed = customAccentSeed,
                             onItemClick = { appThemePref.set(it) },
+                            onCustomAccentSeedChange = { customAccentSeedPref.set(it) },
                         )
 
                         if (appTheme == AppTheme.CUSTOM) {

--- a/app/src/main/java/eu/kanade/presentation/more/settings/widget/AppThemePreferenceWidget.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/widget/AppThemePreferenceWidget.kt
@@ -28,6 +28,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -60,14 +61,18 @@ import uy.kohesive.injekt.api.fullType
 internal fun AppThemePreferenceWidget(
     value: AppTheme,
     amoled: Boolean,
+    customAccentSeed: Int,
     onItemClick: (AppTheme) -> Unit,
+    onCustomAccentSeedChange: (Int) -> Unit,
 ) {
     BasePreferenceWidget(
         subcomponent = {
             AppThemesList(
                 currentTheme = value,
                 amoled = amoled,
+                customAccentSeed = customAccentSeed,
                 onItemClick = onItemClick,
+                onCustomAccentSeedChange = onCustomAccentSeedChange,
             )
         },
     )
@@ -77,7 +82,9 @@ internal fun AppThemePreferenceWidget(
 private fun AppThemesList(
     currentTheme: AppTheme,
     amoled: Boolean,
+    customAccentSeed: Int,
     onItemClick: (AppTheme) -> Unit,
+    onCustomAccentSeedChange: (Int) -> Unit,
 ) {
     val context = LocalContext.current
     val appThemes = remember {
@@ -122,6 +129,97 @@ private fun AppThemesList(
                     style = MaterialTheme.typography.bodyMedium,
                 )
             }
+        }
+    }
+
+    if (currentTheme == AppTheme.CUSTOM) {
+        Text(
+            text = stringResource(MR.strings.pref_custom_theme_accent),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = PrefsHorizontalPadding, vertical = 8.dp),
+            style = MaterialTheme.typography.bodyLarge,
+        )
+        Text(
+            text = stringResource(MR.strings.pref_custom_theme_accent_summary),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = PrefsHorizontalPadding)
+                .secondaryItemAlpha(),
+            style = MaterialTheme.typography.bodyMedium,
+        )
+        LazyRow(
+            contentPadding = PaddingValues(horizontal = PrefsHorizontalPadding, vertical = 8.dp),
+            horizontalArrangement = Arrangement.spacedBy(MaterialTheme.padding.small),
+        ) {
+            items(
+                items = customThemeAccentSeeds,
+                key = { it },
+            ) { seed ->
+                CustomThemeAccentSwatch(
+                    seed = seed,
+                    selected = seed == customAccentSeed,
+                    onClick = {
+                        if (seed != customAccentSeed) {
+                            onCustomAccentSeedChange(seed)
+                            (context as? Activity)?.let { ActivityCompat.recreate(it) }
+                        }
+                    },
+                )
+            }
+        }
+        TextButton(
+            onClick = {
+                if (customAccentSeed != UiPreferences.CUSTOM_THEME_ACCENT_SEED_UNSET) {
+                    onCustomAccentSeedChange(UiPreferences.CUSTOM_THEME_ACCENT_SEED_UNSET)
+                    (context as? Activity)?.let { ActivityCompat.recreate(it) }
+                }
+            },
+            modifier = Modifier
+                .padding(start = PrefsHorizontalPadding),
+        ) {
+            Text(text = stringResource(MR.strings.action_reset))
+        }
+    }
+}
+
+internal val customThemeAccentSeeds = listOf(
+    0xFF4285F4.toInt(),
+    0xFFEF6C00.toInt(),
+    0xFF2E7D32.toInt(),
+    0xFF8E24AA.toInt(),
+    0xFFD81B60.toInt(),
+    0xFF00695C.toInt(),
+    0xFFF9A825.toInt(),
+    0xFF455A64.toInt(),
+)
+
+@Composable
+private fun CustomThemeAccentSwatch(
+    seed: Int,
+    selected: Boolean,
+    onClick: () -> Unit,
+) {
+    Box(
+        modifier = Modifier
+            .size(36.dp)
+            .clip(CircleShape)
+            .background(color = androidx.compose.ui.graphics.Color(seed))
+            .border(
+                width = if (selected) 3.dp else 1.dp,
+                color = if (selected) MaterialTheme.colorScheme.onSurface else DividerDefaults.color,
+                shape = CircleShape,
+            )
+            .clickable(onClick = onClick),
+        contentAlignment = Alignment.Center,
+    ) {
+        if (selected) {
+            Icon(
+                imageVector = Icons.Filled.CheckCircle,
+                contentDescription = stringResource(MR.strings.selected),
+                tint = MaterialTheme.colorScheme.surface,
+                modifier = Modifier.size(18.dp),
+            )
         }
     }
 }
@@ -271,7 +369,9 @@ private fun AppThemesListPreview() {
             AppThemesList(
                 currentTheme = appTheme,
                 amoled = false,
+                customAccentSeed = UiPreferences.CUSTOM_THEME_ACCENT_SEED_UNSET,
                 onItemClick = { appTheme = it },
+                onCustomAccentSeedChange = { },
             )
         }
     }

--- a/app/src/main/java/eu/kanade/presentation/theme/TachiyomiTheme.kt
+++ b/app/src/main/java/eu/kanade/presentation/theme/TachiyomiTheme.kt
@@ -95,6 +95,7 @@ internal fun resolveBaseColorScheme(
     return when (appTheme) {
         AppTheme.MONET -> MonetColorScheme(context)
         AppTheme.CUSTOM -> {
+            // Unset custom accent intentionally falls back to the baseline Tachiyomi palette.
             if (customAccentSeed == UiPreferences.CUSTOM_THEME_ACCENT_SEED_UNSET) {
                 TachiyomiColorScheme
             } else {

--- a/app/src/main/java/mihon/core/migration/migrations/SplitPreferencesMigration.kt
+++ b/app/src/main/java/mihon/core/migration/migrations/SplitPreferencesMigration.kt
@@ -6,6 +6,7 @@ import androidx.preference.PreferenceManager
 import eu.kanade.domain.ui.UiPreferences
 import mihon.core.migration.Migration
 import mihon.core.migration.MigrationContext
+import java.util.Locale
 
 class SplitPreferencesMigration : Migration {
     override val version = 86f
@@ -19,10 +20,15 @@ class SplitPreferencesMigration : Migration {
         if (uiPreferences.themeMode().isSet()) {
             prefs.edit {
                 val themeMode = prefs.getString(uiPreferences.themeMode().key(), null) ?: return@edit
-                putString(uiPreferences.themeMode().key(), themeMode.uppercase())
+                // Legacy installs may store lowercase enum values; normalize to current enum names.
+                putString(uiPreferences.themeMode().key(), normalizeThemeModeValue(themeMode))
             }
         }
 
         return true
     }
+}
+
+internal fun normalizeThemeModeValue(themeMode: String): String {
+    return themeMode.uppercase(Locale.ROOT)
 }

--- a/app/src/test/java/eu/kanade/domain/ui/UiPreferencesTest.kt
+++ b/app/src/test/java/eu/kanade/domain/ui/UiPreferencesTest.kt
@@ -1,6 +1,7 @@
 package eu.kanade.domain.ui
 
 import eu.kanade.domain.ui.model.AppTheme
+import eu.kanade.domain.ui.model.ThemeMode
 import eu.kanade.presentation.more.settings.widget.normalizeAccentSeed
 import eu.kanade.presentation.more.settings.widget.resolvePickerResultSeed
 import kotlinx.coroutines.CoroutineScope
@@ -83,6 +84,29 @@ class UiPreferencesTest {
         )
     }
 
+    @Test
+    fun `custom theme accent seed reset uses unset sentinel`() {
+        val preferences = UiPreferences(MutablePreferenceStore())
+
+        preferences.customThemeAccentSeed().set(0xFF4285F4.toInt())
+        preferences.customThemeAccentSeed().set(UiPreferences.CUSTOM_THEME_ACCENT_SEED_UNSET)
+
+        assertEquals(UiPreferences.CUSTOM_THEME_ACCENT_SEED_UNSET, preferences.customThemeAccentSeed().get())
+    }
+
+    @Test
+    fun `theme mode falls back to default when stored enum value is invalid`() {
+        val preferences = UiPreferences(
+            MutablePreferenceStore(
+                initialValues = mapOf(
+                    "pref_theme_mode_key" to "NOT_A_REAL_THEME_MODE",
+                ),
+            ),
+        )
+
+        assertEquals(ThemeMode.SYSTEM, preferences.themeMode().get())
+    }
+
     private class MutablePreferenceStore(initialValues: Map<String, Any?> = emptyMap()) : PreferenceStore {
         private val data = initialValues.toMutableMap()
 
@@ -115,7 +139,12 @@ class UiPreferencesTest {
             defaultValue: T,
             serializer: (T) -> String,
             deserializer: (String) -> T,
-        ): Preference<T> = MutablePreference(key, defaultValue)
+        ): Preference<T> = SerializedObjectPreference(
+            key = key,
+            defaultValue = defaultValue,
+            serializer = serializer,
+            deserializer = deserializer,
+        )
 
         override fun getAll(): Map<String, *> = data
 
@@ -134,6 +163,40 @@ class UiPreferencesTest {
 
             override fun set(value: T) {
                 data[key] = value
+                state.value = value
+            }
+
+            override fun isSet(): Boolean = data.containsKey(key)
+
+            override fun delete() {
+                data.remove(key)
+                state.value = defaultValue
+            }
+
+            override fun defaultValue(): T = defaultValue
+
+            override fun changes(): Flow<T> = state.asStateFlow()
+
+            override fun stateIn(scope: CoroutineScope): StateFlow<T> = state.asStateFlow()
+        }
+
+        private inner class SerializedObjectPreference<T>(
+            private val key: String,
+            private val defaultValue: T,
+            private val serializer: (T) -> String,
+            private val deserializer: (String) -> T,
+        ) : Preference<T> {
+            private val state = MutableStateFlow(get())
+
+            override fun key(): String = key
+
+            override fun get(): T {
+                val raw = data[key] as? String ?: return defaultValue
+                return deserializer(raw)
+            }
+
+            override fun set(value: T) {
+                data[key] = serializer(value)
                 state.value = value
             }
 

--- a/app/src/test/java/mihon/core/migration/migrations/SplitPreferencesMigrationTest.kt
+++ b/app/src/test/java/mihon/core/migration/migrations/SplitPreferencesMigrationTest.kt
@@ -1,0 +1,20 @@
+package mihon.core.migration.migrations
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.util.Locale
+
+class SplitPreferencesMigrationTest {
+
+    @Test
+    fun `normalizeThemeModeValue uses locale independent uppercase`() {
+        val previousLocale = Locale.getDefault()
+        Locale.setDefault(Locale.forLanguageTag("tr-TR"))
+        try {
+            assertEquals("LIGHT", normalizeThemeModeValue("light"))
+            assertEquals("SYSTEM", normalizeThemeModeValue("system"))
+        } finally {
+            Locale.setDefault(previousLocale)
+        }
+    }
+}

--- a/core/common/src/main/java/tachiyomi/core/common/preference/PreferenceStore.kt
+++ b/core/common/src/main/java/tachiyomi/core/common/preference/PreferenceStore.kt
@@ -36,6 +36,7 @@ inline fun <reified T : Enum<T>> PreferenceStore.getEnum(
             try {
                 enumValueOf(it)
             } catch (e: IllegalArgumentException) {
+                // Keep startup/settings resilient when persisted enum values are stale or invalid.
                 defaultValue
             }
         },

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -234,6 +234,8 @@
     <string name="theme_dark">Dark</string>
     <string name="theme_custom">Custom</string>
     <string name="theme_monet">Dynamic</string>
+    <string name="pref_custom_theme_accent">Custom accent color</string>
+    <string name="pref_custom_theme_accent_summary">Choose an accent for the custom app theme</string>
     <string name="theme_greenapple">Green Apple</string>
     <string name="theme_lavender">Lavender</string>
     <string name="theme_midnightdusk">Midnight Dusk</string>


### PR DESCRIPTION
## Objective
Finalize theming hardening by completing custom-theme accent UX, expanding fallback/migration test coverage, and documenting behavior.

## Scope
- Enable `AppTheme.CUSTOM` as a selectable app theme option.
- Add curated custom accent swatches + reset action in appearance/onboarding theme UI.
- Persist/reset custom accent seed with guarded recreate behavior (no-op when unchanged).
- Harden and document fallback/migration behavior:
  - invalid enum values fallback to default,
  - custom accent unset fallback to base Tachiyomi scheme,
  - `ThemeMode.CUSTOM` follows system day/night,
  - legacy lowercase theme mode normalized with locale-safe uppercase.
- Add tests for:
  - accent reset persistence,
  - invalid enum fallback,
  - locale-independent theme-mode normalization migration helper.
- Update README and changelog entries for the new theming capability and migration/fallback notes.

## Verification
- `./gradlew spotlessCheck`
- `./gradlew :app:compileDebugKotlin`
- `./gradlew :app:testDebugUnitTest --tests "*ThemeModeTest*" --tests "*UiPreferencesTest*" --tests "*TachiyomiThemeRoutingTest*" --tests "*SplitPreferencesMigrationTest*"`
- `./gradlew :app:testDebugUnitTest`

## Risk
T1/T2-low. Changes are localized to theme settings/prefs/docs with deterministic JVM test coverage and no public API changes.

## Review
- Separate-agent review pass completed; actionable findings were addressed (Locale.ROOT normalization and no-op recreate guards).

Closes #558
Closes #557
