### PR TITLE
feat: harden custom accent preference schema migration safety (R568)

### DIFF
--- a/app/src/main/java/eu/kanade/domain/ui/UiPreferences.kt
+++ b/app/src/main/java/eu/kanade/domain/ui/UiPreferences.kt
@@ -7,6 +7,15 @@ import eu.kanade.domain.ui.model.TabletUiMode
 import eu.kanade.domain.ui.model.ThemeMode
 import eu.kanade.tachiyomi.util.system.DeviceUtil
 import eu.kanade.tachiyomi.util.system.isDynamicColorAvailable
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.stateIn
+import tachiyomi.core.common.preference.Preference
 import tachiyomi.core.common.preference.PreferenceStore
 import tachiyomi.core.common.preference.getEnum
 import java.time.format.DateTimeFormatter
@@ -19,9 +28,12 @@ class UiPreferences(
 
     companion object {
         const val CUSTOM_THEME_ACCENT_SEED_UNSET = Int.MIN_VALUE
+        private const val PREF_CUSTOM_THEME_ACCENT_SEED = "pref_custom_theme_accent_seed"
+        private const val PREF_CUSTOM_THEME_ACCENT_SCHEMA = "pref_custom_theme_accent_schema"
         private const val PREF_CUSTOM_THEME_RECENT_ACCENT_SEEDS = "pref_custom_theme_recent_accent_seeds"
         private const val MAX_RECENT_CUSTOM_THEME_ACCENT_SEEDS = 5
         private const val OPAQUE_ALPHA_MASK = 0xFF000000.toInt()
+        private const val CUSTOM_THEME_ACCENT_SCHEMA_VERSION = 1
         fun dateFormat(format: String): DateTimeFormatter = when (format) {
             "" -> DateTimeFormatter.ofLocalizedDate(FormatStyle.SHORT)
             else -> DateTimeFormatter.ofPattern(format, Locale.getDefault())
@@ -37,6 +49,14 @@ class UiPreferences(
                 .toList()
         }
 
+        private fun normalizeAccentSeed(seed: Int): Int {
+            return if (seed == CUSTOM_THEME_ACCENT_SEED_UNSET) {
+                CUSTOM_THEME_ACCENT_SEED_UNSET
+            } else {
+                seed or OPAQUE_ALPHA_MASK
+            }
+        }
+
         internal fun upsertRecentAccentSeed(
             existing: List<Int>,
             appliedSeed: Int,
@@ -46,6 +66,8 @@ class UiPreferences(
             return normalizeRecentAccentSeeds(listOf(normalizedApplied) + existing)
         }
     }
+
+    private val customThemeAccentSeedPreference by lazy { CustomThemeAccentSeedPreference() }
 
     fun themeMode() = preferenceStore.getEnum("pref_theme_mode_key", ThemeMode.SYSTEM)
 
@@ -60,10 +82,7 @@ class UiPreferences(
 
     fun themeDarkAmoled() = preferenceStore.getBoolean("pref_theme_dark_amoled_key", false)
     fun dynamicEntryCoverTheming() = preferenceStore.getBoolean("pref_dynamic_entry_cover_theming", false)
-    fun customThemeAccentSeed() = preferenceStore.getInt(
-        "pref_custom_theme_accent_seed",
-        CUSTOM_THEME_ACCENT_SEED_UNSET,
-    )
+    fun customThemeAccentSeed(): Preference<Int> = customThemeAccentSeedPreference
 
     fun customThemeRecentAccentSeeds() = preferenceStore.getObject(
         key = PREF_CUSTOM_THEME_RECENT_ACCENT_SEEDS,
@@ -109,4 +128,158 @@ class UiPreferences(
     fun startScreen() = preferenceStore.getEnum("start_screen", StartScreen.ANIME)
 
     fun navStyle() = preferenceStore.getEnum("bottom_rail_nav_style", NavStyle.MOVE_HISTORY_TO_MORE)
+
+    private enum class AccentSchemaState {
+        VALID,
+        UNKNOWN_VERSION,
+        MALFORMED,
+    }
+
+    private data class CustomAccentSchemaPayload(
+        val state: AccentSchemaState,
+        val seed: Int?,
+    ) {
+        companion object {
+            fun fromPersisted(raw: String): CustomAccentSchemaPayload {
+                val trimmed = raw.trim()
+                val separator = trimmed.indexOf(':')
+                if (!trimmed.startsWith("v") || separator <= 1 || separator >= trimmed.lastIndex) {
+                    return CustomAccentSchemaPayload(
+                        state = AccentSchemaState.MALFORMED,
+                        seed = null,
+                    )
+                }
+
+                val version = trimmed.substring(1, separator).toIntOrNull()
+                    ?: return CustomAccentSchemaPayload(
+                        state = AccentSchemaState.MALFORMED,
+                        seed = null,
+                    )
+                val token = trimmed.substring(separator + 1).trim()
+                if (version != CUSTOM_THEME_ACCENT_SCHEMA_VERSION) {
+                    return CustomAccentSchemaPayload(
+                        state = AccentSchemaState.UNKNOWN_VERSION,
+                        seed = null,
+                    )
+                }
+
+                if (token.equals("unset", ignoreCase = true)) {
+                    return CustomAccentSchemaPayload(
+                        state = AccentSchemaState.VALID,
+                        seed = null,
+                    )
+                }
+
+                val parsed = token.toUIntOrNull(16)?.toInt()
+                    ?: return CustomAccentSchemaPayload(
+                        state = AccentSchemaState.MALFORMED,
+                        seed = null,
+                    )
+                val normalized = normalizeAccentSeed(parsed)
+                return CustomAccentSchemaPayload(
+                    state = AccentSchemaState.VALID,
+                    seed = normalized.takeUnless { it == CUSTOM_THEME_ACCENT_SEED_UNSET },
+                )
+            }
+
+            fun forSeed(seed: Int): CustomAccentSchemaPayload {
+                val normalized = normalizeAccentSeed(seed)
+                return CustomAccentSchemaPayload(
+                    state = AccentSchemaState.VALID,
+                    seed = normalized.takeUnless { it == CUSTOM_THEME_ACCENT_SEED_UNSET },
+                )
+            }
+        }
+    }
+
+    private inner class CustomThemeAccentSeedPreference : Preference<Int> {
+        private val legacyPreference = preferenceStore.getInt(
+            PREF_CUSTOM_THEME_ACCENT_SEED,
+            CUSTOM_THEME_ACCENT_SEED_UNSET,
+        )
+        private val schemaPreference = preferenceStore.getObject(
+            key = PREF_CUSTOM_THEME_ACCENT_SCHEMA,
+            defaultValue = CustomAccentSchemaPayload(
+                state = AccentSchemaState.MALFORMED,
+                seed = null,
+            ),
+            serializer = { payload ->
+                val version = if (payload.state == AccentSchemaState.VALID) {
+                    CUSTOM_THEME_ACCENT_SCHEMA_VERSION
+                } else {
+                    CUSTOM_THEME_ACCENT_SCHEMA_VERSION
+                }
+                val seedToken = payload.seed
+                    ?.let { normalized ->
+                        normalizeAccentSeed(normalized).toUInt().toString(16).padStart(8, '0')
+                    }
+                    ?: "unset"
+                "v$version:$seedToken"
+            },
+            deserializer = { encoded ->
+                CustomAccentSchemaPayload.fromPersisted(encoded)
+            },
+        )
+        private val derivedChanges = merge(
+            legacyPreference.changes().map { Unit },
+            schemaPreference.changes().map { Unit },
+        )
+            .map { resolveCurrentSeed(migrate = false) }
+            .distinctUntilChanged()
+
+        override fun key(): String = PREF_CUSTOM_THEME_ACCENT_SEED
+
+        override fun get(): Int {
+            return resolveCurrentSeed(migrate = true)
+        }
+
+        override fun set(value: Int) {
+            val normalized = normalizeAccentSeed(value)
+            legacyPreference.set(normalized)
+            schemaPreference.set(CustomAccentSchemaPayload.forSeed(normalized))
+        }
+
+        override fun isSet(): Boolean = legacyPreference.isSet() || schemaPreference.isSet()
+
+        override fun delete() {
+            legacyPreference.delete()
+            schemaPreference.delete()
+        }
+
+        override fun defaultValue(): Int = CUSTOM_THEME_ACCENT_SEED_UNSET
+
+        override fun changes(): Flow<Int> = derivedChanges
+
+        override fun stateIn(scope: CoroutineScope): StateFlow<Int> {
+            return changes().stateIn(
+                scope = scope,
+                started = SharingStarted.Eagerly,
+                initialValue = get(),
+            )
+        }
+
+        private fun resolveCurrentSeed(migrate: Boolean): Int {
+            val legacySeed = normalizeAccentSeed(legacyPreference.get())
+            val schemaSet = schemaPreference.isSet()
+            val schemaPayload = schemaPreference.get()
+            return when (schemaPayload.state) {
+                AccentSchemaState.VALID -> {
+                    val resolved = schemaPayload.seed ?: CUSTOM_THEME_ACCENT_SEED_UNSET
+                    if (migrate && legacySeed != resolved) {
+                        legacyPreference.set(resolved)
+                    }
+                    resolved
+                }
+                AccentSchemaState.UNKNOWN_VERSION -> legacySeed
+                AccentSchemaState.MALFORMED -> {
+                    if (migrate && schemaSet) {
+                        schemaPreference.set(CustomAccentSchemaPayload.forSeed(legacySeed))
+                    } else if (migrate && legacySeed != CUSTOM_THEME_ACCENT_SEED_UNSET) {
+                        schemaPreference.set(CustomAccentSchemaPayload.forSeed(legacySeed))
+                    }
+                    legacySeed
+                }
+            }
+        }
+    }
 }

--- a/app/src/test/java/eu/kanade/domain/ui/UiPreferencesTest.kt
+++ b/app/src/test/java/eu/kanade/domain/ui/UiPreferencesTest.kt
@@ -5,10 +5,14 @@ import eu.kanade.domain.ui.model.ThemeMode
 import eu.kanade.presentation.more.settings.widget.normalizeAccentSeed
 import eu.kanade.presentation.more.settings.widget.resolvePickerResultSeed
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import tachiyomi.core.common.preference.Preference
@@ -17,10 +21,111 @@ import tachiyomi.core.common.preference.PreferenceStore
 class UiPreferencesTest {
 
     @Test
+    fun `schema seed takes precedence over legacy seed`() {
+        val preferences = UiPreferences(
+            MutablePreferenceStore(
+                initialValues = mapOf(
+                    "pref_custom_theme_accent_seed" to 0xFF112233.toInt(),
+                    "pref_custom_theme_accent_schema" to "v1:80445566",
+                ),
+            ),
+        )
+
+        assertEquals(0xFF445566.toInt(), preferences.customThemeAccentSeed().get())
+    }
+
+    @Test
+    fun `invalid schema falls back to unset when legacy missing`() {
+        val preferences = UiPreferences(
+            MutablePreferenceStore(
+                initialValues = mapOf(
+                    "pref_custom_theme_accent_schema" to "v999:not-a-seed",
+                ),
+            ),
+        )
+
+        assertEquals(UiPreferences.CUSTOM_THEME_ACCENT_SEED_UNSET, preferences.customThemeAccentSeed().get())
+    }
+
+    @Test
+    fun `malformed schema falls back to legacy seed`() {
+        val preferences = UiPreferences(
+            MutablePreferenceStore(
+                initialValues = mapOf(
+                    "pref_custom_theme_accent_seed" to 0xFF336699.toInt(),
+                    "pref_custom_theme_accent_schema" to "broken",
+                ),
+            ),
+        )
+
+        assertEquals(0xFF336699.toInt(), preferences.customThemeAccentSeed().get())
+    }
+
+    @Test
+    fun `unknown schema version falls back to legacy seed`() {
+        val preferences = UiPreferences(
+            MutablePreferenceStore(
+                initialValues = mapOf(
+                    "pref_custom_theme_accent_seed" to 0xFF778899.toInt(),
+                    "pref_custom_theme_accent_schema" to "v2:ffaa5500",
+                ),
+            ),
+        )
+
+        assertEquals(0xFF778899.toInt(), preferences.customThemeAccentSeed().get())
+    }
+
+    @Test
+    fun `setting schema-backed preference keeps legacy key for downgrade safety`() {
+        val store = MutablePreferenceStore()
+        val preferences = UiPreferences(store)
+
+        preferences.customThemeAccentSeed().set(0x00224466)
+
+        assertEquals(0xFF224466.toInt(), store.getAll()["pref_custom_theme_accent_seed"])
+    }
+
+    @Test
+    fun `deleting schema-backed preference resets to unset sentinel`() {
+        val preferences = UiPreferences(MutablePreferenceStore())
+
+        preferences.customThemeAccentSeed().set(0xFF334455.toInt())
+        preferences.customThemeAccentSeed().delete()
+
+        assertEquals(UiPreferences.CUSTOM_THEME_ACCENT_SEED_UNSET, preferences.customThemeAccentSeed().get())
+        assertEquals(false, preferences.customThemeAccentSeed().isSet())
+    }
+
+    @Test
+    fun `active changes collector does not resurrect deleted accent value`() = runTest {
+        val store = MutablePreferenceStore()
+        val preferences = UiPreferences(store)
+        val preference = preferences.customThemeAccentSeed()
+
+        val collector = launch { preference.changes().collect {} }
+        preference.set(0xFF445566.toInt())
+        preference.delete()
+        advanceUntilIdle()
+        collector.cancelAndJoin()
+
+        assertEquals(false, preference.isSet())
+        assertEquals(null, store.getAll()["pref_custom_theme_accent_seed"])
+    }
+
+    @Test
     fun `custom theme accent seed defaults to unset sentinel`() {
         val preferences = UiPreferences(MutablePreferenceStore())
 
         assertEquals(UiPreferences.CUSTOM_THEME_ACCENT_SEED_UNSET, preferences.customThemeAccentSeed().get())
+    }
+
+    @Test
+    fun `custom theme accent seed is not marked as set on clean read`() {
+        val preferences = UiPreferences(MutablePreferenceStore())
+
+        preferences.customThemeAccentSeed().get()
+
+        assertEquals(false, preferences.customThemeAccentSeed().isSet())
     }
 
     @Test


### PR DESCRIPTION
## Objective
Harden custom accent preference persistence by introducing schema-aware parsing and migration-safe fallback behavior, while preserving downgrade safety.

Closes #570

## Scope
- Added schema constants and versioned payload handling for `customThemeAccentSeed`.
- Implemented schema-first read with safe fallback to legacy int when schema is malformed/unknown.
- Added dual-write behavior (legacy int + schema payload) for compatibility with downgrade paths.
- Ensured delete/isSet/changes semantics stay stable and side-effect free during reactive reads.
- Added unit coverage for precedence, malformed/unknown schema fallback, downgrade dual-write, delete semantics, and active collector behavior.

## Verification
- `./gradlew spotlessCheck`
- `./gradlew :app:compileDebugKotlin`
- `./gradlew :app:testDebugUnitTest --tests "eu.kanade.domain.ui.UiPreferencesTest"`
- `./gradlew :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=eu.kanade.presentation.theme.ThemePreferencesInstrumentationTest`

## Risk
Low-to-medium. Touches preference read/write path for custom theme accent seed. Main risk is behavioral regression in migration logic; mitigated by targeted unit tests and instrumentation verification.

## Rollback
Revert this PR commit(s) to restore previous `customThemeAccentSeed` preference behavior (legacy int-only path).
