### PR TITLE
ci: automate changelog rollover during tagged release (R591)

### DIFF
--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -90,6 +90,14 @@ jobs:
         run: |
           set -ex
           echo "VERSION_TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+          echo "RELEASE_VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
+          echo "RELEASE_DATE=$(date -u +%F)" >> $GITHUB_ENV
+
+      - name: Finalize changelog for release notes
+        if: startsWith(github.ref, 'refs/tags/') && github.repository == 'ryacub/rayniyomi'
+        run: |
+          set -euxo pipefail
+          python3 scripts/finalize_changelog_release.py "$RELEASE_VERSION" --date "$RELEASE_DATE"
 
       - name: Sign APK
         if: startsWith(github.ref, 'refs/tags/') && github.repository == 'ryacub/rayniyomi'
@@ -168,3 +176,29 @@ jobs:
           prerelease: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout main for changelog sync
+        if: startsWith(github.ref, 'refs/tags/') && github.repository == 'ryacub/rayniyomi'
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: main
+          token: ${{ secrets.VERSION_BUMP_TOKEN }}
+          path: changelog-sync
+
+      - name: Persist changelog rollover to main
+        if: startsWith(github.ref, 'refs/tags/') && github.repository == 'ryacub/rayniyomi'
+        run: |
+          set -euxo pipefail
+          cd changelog-sync
+          python3 scripts/finalize_changelog_release.py "$RELEASE_VERSION" --date "$RELEASE_DATE"
+
+          if git diff --quiet -- CHANGELOG.md; then
+            echo "No changelog update needed."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          git commit -m "chore: finalize changelog for v${RELEASE_VERSION}"
+          git push origin main

--- a/scripts/finalize_changelog_release.py
+++ b/scripts/finalize_changelog_release.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""
+Finalize CHANGELOG.md for a tagged release by rolling Unreleased forward.
+
+Behavior:
+- If release section `## [<version>]` already exists: no-op.
+- Move the first `## Unreleased` section body into `## [<version>] - <date>`.
+- Recreate an empty `## Unreleased` template using existing subsection headings.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import re
+import sys
+from pathlib import Path
+
+
+DEFAULT_HEADINGS = [
+    "### Added",
+    "### Fixed",
+    "### Changed",
+    "### CI",
+    "### Other",
+]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("version", help="Release version, with or without leading 'v'")
+    parser.add_argument(
+        "--date",
+        default=dt.date.today().isoformat(),
+        help="Release date in YYYY-MM-DD format (default: today)",
+    )
+    parser.add_argument(
+        "--file",
+        default="CHANGELOG.md",
+        help="Path to changelog file (default: CHANGELOG.md)",
+    )
+    return parser.parse_args()
+
+
+def find_unreleased_bounds(lines: list[str]) -> tuple[int, int]:
+    start = -1
+    for i, line in enumerate(lines):
+        if line.strip() == "## Unreleased":
+            start = i
+            break
+    if start == -1:
+        raise ValueError("Could not find '## Unreleased' section.")
+
+    end = len(lines)
+    for i in range(start + 1, len(lines)):
+        if lines[i].startswith("## "):
+            end = i
+            break
+    return start, end
+
+
+def main() -> int:
+    args = parse_args()
+    version = args.version.lstrip("v")
+    changelog_path = Path(args.file)
+    text = changelog_path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+
+    if re.search(rf"^## \[{re.escape(version)}\](?:\s|$)", text, flags=re.MULTILINE):
+        print(f"Version section [{version}] already exists; no changes.")
+        return 0
+
+    start, end = find_unreleased_bounds(lines)
+    before = lines[:start]
+    unreleased_body = lines[start + 1 : end]
+    after = lines[end:]
+
+    headings = [line for line in unreleased_body if line.startswith("### ")]
+    if not headings:
+        headings = DEFAULT_HEADINGS
+
+    unreleased_text = "## Unreleased\n\n" + "\n\n".join(headings) + "\n"
+
+    release_body = "\n".join(unreleased_body).strip("\n")
+    if not release_body:
+        release_body = "### Other\n\n- No user-facing changes."
+    release_text = f"## [{version}] - {args.date}\n\n{release_body}\n"
+
+    before_text = "\n".join(before).rstrip("\n")
+    after_text = "\n".join(after).lstrip("\n")
+    pieces = [before_text, unreleased_text, release_text, after_text]
+    new_text = "\n\n".join(p for p in pieces if p.strip()) + "\n"
+
+    changelog_path.write_text(new_text, encoding="utf-8")
+    print(f"Updated {changelog_path} for release {version} ({args.date}).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Objective
Automate changelog finalization for tagged releases so `## Unreleased` is rolled into the released version and reset after release creation.

Closes #605

## Scope
- Add `scripts/finalize_changelog_release.py` to:
  - no-op if target release section already exists
  - move first `## Unreleased` content into `## [version] - YYYY-MM-DD`
  - recreate an empty `## Unreleased` section template
- Update `.github/workflows/build_push.yml` to:
  - finalize changelog in the tag workspace before extracting release notes
  - checkout `main` after release and persist the same changelog rollover commit
  - skip commit when no changelog diff exists (idempotent reruns)

## Verification
- `./gradlew spotlessCheck`
- `./gradlew :app:compileDebugKotlin`
- Script smoke/idempotency check:
  - run `scripts/finalize_changelog_release.py` twice on a temp changelog copy
  - confirm only one `## [<version>]` section is created

## Risk
T2. Changes release workflow behavior and writes back to `main` during tag releases. Risk mitigated by idempotent script behavior and no-op checks when version section already exists.

## Rollback
Revert this PR to restore prior release behavior (no automatic changelog rollover).
