### PR TITLE
ci: scope theme instrumentation gate to theme files only (R617)

### DIFF
--- a/.github/workflows/theme_instrumentation_pr.yml
+++ b/.github/workflows/theme_instrumentation_pr.yml
@@ -9,7 +9,9 @@ on:
       - 'app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsAppearanceScreen.kt'
       - 'app/src/main/java/eu/kanade/presentation/more/settings/widget/AppThemePreferenceWidget.kt'
       - 'app/src/main/java/eu/kanade/presentation/more/onboarding/ThemeStep.kt'
-      - 'app/src/androidTest/**'
+      - 'app/src/androidTest/java/eu/kanade/presentation/theme/**'
+      - 'app/src/androidTest/java/eu/kanade/presentation/more/settings/widget/CustomThemeAccentPreferenceWidgetAndroidTest.kt'
+      - 'app/src/androidTest/java/eu/kanade/presentation/more/settings/widget/ThemeAppearanceFlowAndroidTest.kt'
       - '.github/workflows/theme_instrumentation_pr.yml'
   workflow_dispatch:
 


### PR DESCRIPTION
## Objective
Prevent the theme instrumentation CI workflow from triggering on PRs that only add/edit unrelated androidTest files.

## Scope
`.github/workflows/theme_instrumentation_pr.yml` — paths filter only.

## Change
Replace broad `app/src/androidTest/**` path trigger with the three specific theme test files the workflow actually exercises:
- `app/src/androidTest/java/eu/kanade/presentation/theme/**`
- `CustomThemeAccentPreferenceWidgetAndroidTest.kt`
- `ThemeAppearanceFlowAndroidTest.kt`

## Verification
- Workflow still triggers on changes to any theme source file (paths unchanged)
- Workflow still triggers on changes to the theme test files themselves
- Workflow no longer triggers when unrelated androidTest files are added (e.g. R619 extension badge tests)

## Risk
Low — CI path filter only, no source changes.

Closes #623