### PR TITLE
feat: compose source preferences parity for anime and manga (R570)

### DIFF
--- a/app/src/androidTest/java/eu/kanade/tachiyomi/ui/browse/sourceprefs/SourcePreferencesContentAndroidTest.kt
+++ b/app/src/androidTest/java/eu/kanade/tachiyomi/ui/browse/sourceprefs/SourcePreferencesContentAndroidTest.kt
@@ -1,0 +1,81 @@
+package eu.kanade.tachiyomi.ui.browse.sourceprefs
+
+import android.content.Context
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.preference.ListPreference
+import androidx.preference.PreferenceScreen
+import androidx.preference.SwitchPreferenceCompat
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SourcePreferencesContentAndroidTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    private lateinit var context: Context
+    private val prefsName = "source_pref_content_android_test"
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        context.getSharedPreferences(prefsName, Context.MODE_PRIVATE).edit().clear().commit()
+    }
+
+    @After
+    fun tearDown() {
+        context.getSharedPreferences(prefsName, Context.MODE_PRIVATE).edit().clear().commit()
+    }
+
+    @Test
+    fun sourcePreferencesContent_switchAndListPersistChanges() {
+        val sharedPrefs = context.getSharedPreferences(prefsName, Context.MODE_PRIVATE)
+        val screen = buildSourcePreferenceScreen(
+            context = context,
+            sourcePreferences = sharedPrefs,
+        ) { preferenceScreen: PreferenceScreen ->
+            val switchPreference = SwitchPreferenceCompat(context).apply {
+                key = "switch_key"
+                title = "Switch Pref"
+                summary = "Enable toggle"
+                setDefaultValue(false)
+            }
+            val listPreference = ListPreference(context).apply {
+                key = "list_key"
+                title = "List Pref"
+                entries = arrayOf("First", "Second")
+                entryValues = arrayOf("first", "second")
+                setDefaultValue("first")
+            }
+
+            preferenceScreen.addPreference(switchPreference)
+            preferenceScreen.addPreference(listPreference)
+        }
+
+        composeRule.setContent {
+            SourcePreferencesContent(
+                preferenceScreen = screen,
+                sourcePreferences = sharedPrefs,
+                contentPadding = PaddingValues(),
+            )
+        }
+
+        composeRule.onNodeWithText("Switch Pref").assertIsDisplayed().performClick()
+        assertEquals(true, sharedPrefs.getBoolean("switch_key", false))
+
+        composeRule.onNodeWithText("List Pref").assertIsDisplayed().performClick()
+        composeRule.onNodeWithText("Second").assertIsDisplayed().performClick()
+        assertEquals("second", sharedPrefs.getString("list_key", null))
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/anime/extension/details/AnimeSourcePreferencesScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/anime/extension/details/AnimeSourcePreferencesScreen.kt
@@ -1,44 +1,17 @@
 package eu.kanade.tachiyomi.ui.browse.anime.extension.details
 
-import android.content.Context
-import android.os.Bundle
-import android.util.TypedValue
-import android.view.View
-import androidx.appcompat.view.ContextThemeWrapper
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Modifier
+import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.viewinterop.AndroidView
-import androidx.core.os.bundleOf
-import androidx.fragment.app.FragmentActivity
-import androidx.fragment.app.FragmentContainerView
-import androidx.fragment.app.FragmentManager
-import androidx.fragment.app.FragmentTransaction
-import androidx.fragment.app.commit
-import androidx.lifecycle.lifecycleScope
-import androidx.preference.DialogPreference
-import androidx.preference.EditTextPreference
-import androidx.preference.PreferenceFragmentCompat
-import androidx.preference.PreferenceScreen
-import androidx.preference.forEach
-import androidx.preference.getOnBindEditTextListener
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import eu.kanade.core.util.ifAnimeSourcesLoaded
 import eu.kanade.presentation.components.AppBar
 import eu.kanade.presentation.util.Screen
-import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.animesource.ConfigurableAnimeSource
 import eu.kanade.tachiyomi.animesource.sourcePreferences
-import eu.kanade.tachiyomi.data.preference.SharedPreferencesDataStore
-import eu.kanade.tachiyomi.widget.TachiyomiTextInputEditText.Companion.setIncognito
+import eu.kanade.tachiyomi.ui.browse.sourceprefs.SourcePreferencesContent
+import eu.kanade.tachiyomi.ui.browse.sourceprefs.buildSourcePreferenceScreen
 import tachiyomi.domain.source.anime.service.AnimeSourceManager
 import tachiyomi.presentation.core.components.material.Scaffold
 import tachiyomi.presentation.core.screens.LoadingScreen
@@ -56,119 +29,42 @@ class AnimeSourcePreferencesScreen(val sourceId: Long) : Screen() {
 
         val context = LocalContext.current
         val navigator = LocalNavigator.currentOrThrow
+        val source = remember(sourceId) {
+            Injekt.get<AnimeSourceManager>().getOrStub(sourceId)
+        }
+
+        val sourcePrefs = remember(sourceId, source) {
+            if (source is ConfigurableAnimeSource) {
+                source.sourcePreferences()
+            } else {
+                sourcePreferences("source_$sourceId")
+            }
+        }
+        val preferenceScreen = remember(sourceId, sourcePrefs) {
+            buildSourcePreferenceScreen(
+                context = context,
+                sourcePreferences = sourcePrefs,
+            ) { screen ->
+                if (source is ConfigurableAnimeSource) {
+                    source.setupPreferenceScreen(screen)
+                }
+            }
+        }
 
         Scaffold(
             topBar = {
                 AppBar(
-                    title = Injekt.get<AnimeSourceManager>().getOrStub(sourceId).toString(),
+                    title = source.toString(),
                     navigateUp = navigator::pop,
                     scrollBehavior = it,
                 )
             },
         ) { contentPadding ->
-            FragmentContainer(
-                fragmentManager = (context as FragmentActivity).supportFragmentManager,
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(contentPadding),
-            ) {
-                add(it, SourcePreferencesFragment.getInstance(sourceId), null)
-            }
-        }
-    }
-
-    /**
-     * From https://stackoverflow.com/questions/60520145/fragment-container-in-jetpack-compose/70817794#70817794
-     */
-    @Composable
-    private fun FragmentContainer(
-        fragmentManager: FragmentManager,
-        modifier: Modifier = Modifier,
-        commit: FragmentTransaction.(containerId: Int) -> Unit,
-    ) {
-        val containerId by rememberSaveable {
-            mutableIntStateOf(View.generateViewId())
-        }
-        var initialized by rememberSaveable { mutableStateOf(false) }
-        AndroidView(
-            modifier = modifier,
-            factory = { context ->
-                FragmentContainerView(context)
-                    .apply { id = containerId }
-            },
-            update = { view ->
-                if (!initialized) {
-                    fragmentManager.commit { commit(view.id) }
-                    initialized = true
-                } else {
-                    fragmentManager.onContainerAvailable(view)
-                }
-            },
-        )
-    }
-
-    /** Access to package-private method in FragmentManager through reflection */
-    private fun FragmentManager.onContainerAvailable(view: FragmentContainerView) {
-        val method = FragmentManager::class.java.getDeclaredMethod(
-            "onContainerAvailable",
-            FragmentContainerView::class.java,
-        )
-        method.isAccessible = true
-        method.invoke(this, view)
-    }
-}
-
-class SourcePreferencesFragment : PreferenceFragmentCompat() {
-
-    override fun getContext(): Context? {
-        val superCtx = super.getContext() ?: return null
-        val tv = TypedValue()
-        superCtx.theme.resolveAttribute(R.attr.preferenceTheme, tv, true)
-        return ContextThemeWrapper(superCtx, tv.resourceId)
-    }
-
-    override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
-        preferenceScreen = populateScreen()
-    }
-
-    private fun populateScreen(): PreferenceScreen {
-        val sourceId = requireArguments().getLong(SOURCE_ID)
-        val source = Injekt.get<AnimeSourceManager>().getOrStub(sourceId)
-        val sourceScreen = preferenceManager.createPreferenceScreen(requireContext())
-
-        if (source is ConfigurableAnimeSource) {
-            val dataStore = SharedPreferencesDataStore(source.sourcePreferences())
-            preferenceManager.preferenceDataStore = dataStore
-
-            source.setupPreferenceScreen(sourceScreen)
-            sourceScreen.forEach { pref ->
-                pref.isIconSpaceReserved = false
-                pref.isSingleLineTitle = false
-                if (pref is DialogPreference && pref.dialogTitle.isNullOrEmpty()) {
-                    pref.dialogTitle = pref.title
-                }
-
-                // Apply incognito IME for EditTextPreference
-                if (pref is EditTextPreference) {
-                    val setListener = pref.getOnBindEditTextListener()
-                    pref.setOnBindEditTextListener {
-                        setListener?.onBindEditText(it)
-                        it.setIncognito(lifecycleScope)
-                    }
-                }
-            }
-        }
-
-        return sourceScreen
-    }
-
-    companion object {
-        private const val SOURCE_ID = "source_id"
-
-        fun getInstance(sourceId: Long): SourcePreferencesFragment {
-            return SourcePreferencesFragment().apply {
-                arguments = bundleOf(SOURCE_ID to sourceId)
-            }
+            SourcePreferencesContent(
+                preferenceScreen = preferenceScreen,
+                sourcePreferences = sourcePrefs,
+                contentPadding = contentPadding,
+            )
         }
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/manga/extension/details/MangaSourcePreferencesScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/manga/extension/details/MangaSourcePreferencesScreen.kt
@@ -1,44 +1,17 @@
 package eu.kanade.tachiyomi.ui.browse.manga.extension.details
 
-import android.content.Context
-import android.os.Bundle
-import android.util.TypedValue
-import android.view.View
-import androidx.appcompat.view.ContextThemeWrapper
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Modifier
+import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.viewinterop.AndroidView
-import androidx.core.os.bundleOf
-import androidx.fragment.app.FragmentActivity
-import androidx.fragment.app.FragmentContainerView
-import androidx.fragment.app.FragmentManager
-import androidx.fragment.app.FragmentTransaction
-import androidx.fragment.app.commit
-import androidx.lifecycle.lifecycleScope
-import androidx.preference.DialogPreference
-import androidx.preference.EditTextPreference
-import androidx.preference.PreferenceFragmentCompat
-import androidx.preference.PreferenceScreen
-import androidx.preference.forEach
-import androidx.preference.getOnBindEditTextListener
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import eu.kanade.core.util.ifMangaSourcesLoaded
 import eu.kanade.presentation.components.AppBar
 import eu.kanade.presentation.util.Screen
-import eu.kanade.tachiyomi.R
-import eu.kanade.tachiyomi.data.preference.SharedPreferencesDataStore
 import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.source.sourcePreferences
-import eu.kanade.tachiyomi.widget.TachiyomiTextInputEditText.Companion.setIncognito
+import eu.kanade.tachiyomi.ui.browse.sourceprefs.SourcePreferencesContent
+import eu.kanade.tachiyomi.ui.browse.sourceprefs.buildSourcePreferenceScreen
 import tachiyomi.domain.source.manga.service.MangaSourceManager
 import tachiyomi.presentation.core.components.material.Scaffold
 import tachiyomi.presentation.core.screens.LoadingScreen
@@ -56,119 +29,42 @@ class MangaSourcePreferencesScreen(val sourceId: Long) : Screen() {
 
         val context = LocalContext.current
         val navigator = LocalNavigator.currentOrThrow
+        val source = remember(sourceId) {
+            Injekt.get<MangaSourceManager>().getOrStub(sourceId)
+        }
+
+        val sourcePrefs = remember(sourceId, source) {
+            if (source is ConfigurableSource) {
+                source.sourcePreferences()
+            } else {
+                sourcePreferences("source_$sourceId")
+            }
+        }
+        val preferenceScreen = remember(sourceId, sourcePrefs) {
+            buildSourcePreferenceScreen(
+                context = context,
+                sourcePreferences = sourcePrefs,
+            ) { screen ->
+                if (source is ConfigurableSource) {
+                    source.setupPreferenceScreen(screen)
+                }
+            }
+        }
 
         Scaffold(
             topBar = {
                 AppBar(
-                    title = Injekt.get<MangaSourceManager>().getOrStub(sourceId).toString(),
+                    title = source.toString(),
                     navigateUp = navigator::pop,
                     scrollBehavior = it,
                 )
             },
         ) { contentPadding ->
-            FragmentContainer(
-                fragmentManager = (context as FragmentActivity).supportFragmentManager,
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(contentPadding),
-            ) {
-                add(it, MangaSourcePreferencesFragment.getInstance(sourceId), null)
-            }
-        }
-    }
-
-    /**
-     * From https://stackoverflow.com/questions/60520145/fragment-container-in-jetpack-compose/70817794#70817794
-     */
-    @Composable
-    private fun FragmentContainer(
-        fragmentManager: FragmentManager,
-        modifier: Modifier = Modifier,
-        commit: FragmentTransaction.(containerId: Int) -> Unit,
-    ) {
-        val containerId by rememberSaveable {
-            mutableIntStateOf(View.generateViewId())
-        }
-        var initialized by rememberSaveable { mutableStateOf(false) }
-        AndroidView(
-            modifier = modifier,
-            factory = { context ->
-                FragmentContainerView(context)
-                    .apply { id = containerId }
-            },
-            update = { view ->
-                if (!initialized) {
-                    fragmentManager.commit { commit(view.id) }
-                    initialized = true
-                } else {
-                    fragmentManager.onContainerAvailable(view)
-                }
-            },
-        )
-    }
-
-    /** Access to package-private method in FragmentManager through reflection */
-    private fun FragmentManager.onContainerAvailable(view: FragmentContainerView) {
-        val method = FragmentManager::class.java.getDeclaredMethod(
-            "onContainerAvailable",
-            FragmentContainerView::class.java,
-        )
-        method.isAccessible = true
-        method.invoke(this, view)
-    }
-}
-
-class MangaSourcePreferencesFragment : PreferenceFragmentCompat() {
-
-    override fun getContext(): Context? {
-        val superCtx = super.getContext() ?: return null
-        val tv = TypedValue()
-        superCtx.theme.resolveAttribute(R.attr.preferenceTheme, tv, true)
-        return ContextThemeWrapper(superCtx, tv.resourceId)
-    }
-
-    override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
-        preferenceScreen = populateScreen()
-    }
-
-    private fun populateScreen(): PreferenceScreen {
-        val sourceId = requireArguments().getLong(SOURCE_ID)
-        val source = Injekt.get<MangaSourceManager>().getOrStub(sourceId)
-        val sourceScreen = preferenceManager.createPreferenceScreen(requireContext())
-
-        if (source is ConfigurableSource) {
-            val dataStore = SharedPreferencesDataStore(source.sourcePreferences())
-            preferenceManager.preferenceDataStore = dataStore
-
-            source.setupPreferenceScreen(sourceScreen)
-            sourceScreen.forEach { pref ->
-                pref.isIconSpaceReserved = false
-                pref.isSingleLineTitle = false
-                if (pref is DialogPreference && pref.dialogTitle.isNullOrEmpty()) {
-                    pref.dialogTitle = pref.title
-                }
-
-                // Apply incognito IME for EditTextPreference
-                if (pref is EditTextPreference) {
-                    val setListener = pref.getOnBindEditTextListener()
-                    pref.setOnBindEditTextListener {
-                        setListener?.onBindEditText(it)
-                        it.setIncognito(lifecycleScope)
-                    }
-                }
-            }
-        }
-
-        return sourceScreen
-    }
-
-    companion object {
-        private const val SOURCE_ID = "source_id"
-
-        fun getInstance(sourceId: Long): MangaSourcePreferencesFragment {
-            val fragment = MangaSourcePreferencesFragment()
-            fragment.arguments = bundleOf(SOURCE_ID to sourceId)
-            return fragment
+            SourcePreferencesContent(
+                preferenceScreen = preferenceScreen,
+                sourcePreferences = sourcePrefs,
+                contentPadding = contentPadding,
+            )
         }
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/sourceprefs/SourcePreferencesRenderer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/sourceprefs/SourcePreferencesRenderer.kt
@@ -1,0 +1,567 @@
+package eu.kanade.tachiyomi.ui.browse.sourceprefs
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.text.InputType
+import android.widget.EditText
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusProperties
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.disabled
+import androidx.compose.ui.semantics.error
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.widget.doAfterTextChanged
+import androidx.preference.DialogPreference
+import androidx.preference.EditTextPreference
+import androidx.preference.ListPreference
+import androidx.preference.MultiSelectListPreference
+import androidx.preference.Preference
+import androidx.preference.PreferenceCategory
+import androidx.preference.PreferenceGroup
+import androidx.preference.PreferenceManager
+import androidx.preference.PreferenceScreen
+import androidx.preference.TwoStatePreference
+import androidx.preference.getOnBindEditTextListener
+import eu.kanade.presentation.more.settings.widget.ListPreferenceWidget
+import eu.kanade.presentation.more.settings.widget.PreferenceGroupHeader
+import eu.kanade.presentation.more.settings.widget.SwitchPreferenceWidget
+import eu.kanade.presentation.more.settings.widget.TextPreferenceWidget
+import eu.kanade.tachiyomi.data.preference.SharedPreferencesDataStore
+import eu.kanade.tachiyomi.widget.TachiyomiTextInputEditText
+import eu.kanade.tachiyomi.widget.TachiyomiTextInputEditText.Companion.setIncognito
+import logcat.LogPriority
+import logcat.logcat
+import tachiyomi.i18n.MR
+import tachiyomi.presentation.core.components.LabeledCheckbox
+import tachiyomi.presentation.core.components.ScrollbarLazyColumn
+import tachiyomi.presentation.core.i18n.stringResource
+
+private data class PreferenceSection(
+    val title: String?,
+    val entries: List<Preference>,
+)
+
+fun buildSourcePreferenceScreen(
+    context: Context,
+    sourcePreferences: SharedPreferences,
+    setup: (PreferenceScreen) -> Unit,
+): PreferenceScreen {
+    val preferenceManager = PreferenceManager(context)
+    preferenceManager.preferenceDataStore = SharedPreferencesDataStore(sourcePreferences)
+
+    val screen = preferenceManager.createPreferenceScreen(context)
+    setup(screen)
+    normalizePreferenceTree(screen)
+    return screen
+}
+
+@Composable
+fun SourcePreferencesContent(
+    preferenceScreen: PreferenceScreen,
+    sourcePreferences: SharedPreferences,
+    contentPadding: PaddingValues,
+) {
+    val unavailableTemplate = stringResource(MR.strings.pref_source_preference_value_unavailable)
+    val unsupportedSubtitleTemplate = stringResource(MR.strings.pref_source_preference_unsupported_type)
+    val missingKey = stringResource(MR.strings.pref_source_preference_missing_key)
+    val emptyTitle = stringResource(MR.strings.pref_source_preference_empty_title)
+    val onText = stringResource(MR.strings.on)
+    val offText = stringResource(MR.strings.off)
+
+    var refreshSignal by rememberSaveable { mutableIntStateOf(0) }
+    val listener = remember {
+        SharedPreferences.OnSharedPreferenceChangeListener { _, _ ->
+            refreshSignal++
+        }
+    }
+
+    DisposableEffect(sourcePreferences) {
+        sourcePreferences.registerOnSharedPreferenceChangeListener(listener)
+        onDispose { sourcePreferences.unregisterOnSharedPreferenceChangeListener(listener) }
+    }
+
+    val sections = remember(preferenceScreen, refreshSignal) { preferenceScreen.toSections() }
+
+    ScrollbarLazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(contentPadding),
+    ) {
+        if (sections.none { it.entries.isNotEmpty() }) {
+            item {
+                TextPreferenceWidget(
+                    title = emptyTitle,
+                    onPreferenceClick = null,
+                )
+            }
+            return@ScrollbarLazyColumn
+        }
+
+        sections.forEach { section ->
+            if (!section.title.isNullOrBlank()) {
+                item(key = "header_${section.title}") {
+                    PreferenceGroupHeader(title = section.title)
+                }
+            }
+
+            items(
+                items = section.entries,
+                key = { it.key ?: "pref_${it.hashCode()}" },
+            ) { preference ->
+                val summary = preference.summary?.toString()?.takeUnless { it.isBlank() }
+                when (preference) {
+                    is TwoStatePreference -> {
+                        val checked = preference.isChecked
+                        val state = if (checked) onText else offText
+                        SwitchPreferenceWidget(
+                            modifier = Modifier.semantics {
+                                role = Role.Switch
+                                stateDescription = state
+                                contentDescription = buildString {
+                                    append(preference.title?.toString().orEmpty())
+                                    append(", ")
+                                    append(state)
+                                }
+                            },
+                            title = preference.title?.toString().orEmpty(),
+                            subtitle = summary,
+                            checked = checked,
+                            onCheckedChanged = { newValue ->
+                                if (preference.isEnabled && preference.callChangeListener(newValue)) {
+                                    preference.isChecked = newValue
+                                }
+                            },
+                        )
+                    }
+
+                    is ListPreference -> {
+                        val entryMap = preference.toEntryMap()
+                        val current = preference.value
+                        ListPreferenceWidget(
+                            value = current,
+                            title = preference.title?.toString().orEmpty(),
+                            subtitle = resolveListPreferenceSummary(
+                                summary = summary,
+                                currentValue = current,
+                                entries = entryMap,
+                                unavailableTemplate = unavailableTemplate,
+                            ),
+                            icon = null,
+                            entries = entryMap,
+                            onValueChange = { newValue ->
+                                if (preference.isEnabled && preference.callChangeListener(newValue)) {
+                                    preference.value = newValue
+                                }
+                            },
+                        )
+                    }
+
+                    is MultiSelectListPreference -> {
+                        MultiSelectPreferenceDialog(
+                            preference = preference,
+                            title = preference.title?.toString().orEmpty(),
+                            subtitle = summary,
+                        )
+                    }
+
+                    is EditTextPreference -> {
+                        ExtensionEditTextPreferenceDialog(
+                            preference = preference,
+                            title = preference.title?.toString().orEmpty(),
+                            subtitle = summary,
+                            enabled = preference.isEnabled,
+                        )
+                    }
+
+                    else -> {
+                        val isGenericClickable =
+                            preference.isSelectable || preference.intent != null ||
+                                preference.onPreferenceClickListener != null
+                        if (isGenericClickable) {
+                            TextPreferenceWidget(
+                                modifier = Modifier.semantics { role = Role.Button },
+                                title = preference.title?.toString(),
+                                subtitle = summary,
+                                onPreferenceClick = {
+                                    if (!preference.isEnabled) return@TextPreferenceWidget
+                                    dispatchPreferenceClick(preference)
+                                },
+                            )
+                        } else {
+                            val fallbackTitle = preference.title?.toString()
+                                ?.takeUnless { it.isBlank() }
+                                ?: preference.javaClass.simpleName
+                            TextPreferenceWidget(
+                                modifier = Modifier.semantics {
+                                    role = Role.Button
+                                    contentDescription = fallbackTitle
+                                },
+                                title = fallbackTitle,
+                                subtitle = formatUnsupportedTypeSubtitle(
+                                    template = unsupportedSubtitleTemplate,
+                                    typeName = preference.javaClass.simpleName,
+                                    key = preference.key,
+                                    keyFallback = missingKey,
+                                ),
+                                onPreferenceClick = null,
+                            )
+                            logcat(LogPriority.DEBUG) {
+                                "Unsupported source preference rendered as informational row: " +
+                                    "type=${preference.javaClass.name}, key=${preference.key ?: missingKey}"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun MultiSelectPreferenceDialog(
+    preference: MultiSelectListPreference,
+    title: String,
+    subtitle: String?,
+) {
+    var showDialog by rememberSaveable { mutableStateOf(false) }
+    val selected = remember(showDialog) { mutableStateListOf<String>() }
+    val entries = preference.toEntryMap()
+
+    val currentSummary = subtitle
+        ?: preference.values
+            .mapNotNull { entries[it] }
+            .joinToString()
+            .takeUnless { it.isBlank() }
+        ?: stringResource(MR.strings.none)
+
+    TextPreferenceWidget(
+        modifier = Modifier.semantics {
+            role = Role.Button
+            contentDescription = "$title, $currentSummary"
+        },
+        title = title,
+        subtitle = currentSummary,
+        onPreferenceClick = {
+            if (!preference.isEnabled) return@TextPreferenceWidget
+            selected.clear()
+            selected.addAll(preference.values)
+            showDialog = true
+        },
+    )
+
+    if (!showDialog) return
+
+    androidx.compose.material3.AlertDialog(
+        onDismissRequest = { showDialog = false },
+        title = { androidx.compose.material3.Text(text = title) },
+        text = {
+            ScrollbarLazyColumn {
+                items(entries.entries.toList(), key = { it.key }) { (key, value) ->
+                    LabeledCheckbox(
+                        label = value,
+                        checked = selected.contains(key),
+                        onCheckedChange = { checked ->
+                            if (checked) {
+                                if (!selected.contains(key)) selected.add(key)
+                            } else {
+                                selected.remove(key)
+                            }
+                        },
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            androidx.compose.material3.TextButton(
+                onClick = {
+                    val next = selected.toSet()
+                    if (preference.callChangeListener(next)) {
+                        preference.values = next
+                    }
+                    showDialog = false
+                },
+            ) {
+                androidx.compose.material3.Text(text = stringResource(MR.strings.action_ok))
+            }
+        },
+        dismissButton = {
+            androidx.compose.material3.TextButton(onClick = { showDialog = false }) {
+                androidx.compose.material3.Text(text = stringResource(MR.strings.action_cancel))
+            }
+        },
+    )
+}
+
+@Composable
+private fun ExtensionEditTextPreferenceDialog(
+    preference: EditTextPreference,
+    title: String,
+    subtitle: String?,
+    enabled: Boolean,
+) {
+    var showDialog by rememberSaveable { mutableStateOf(false) }
+    var validationError by rememberSaveable { mutableStateOf<String?>(null) }
+    val clearDescription = stringResource(MR.strings.pref_source_preference_clear_text)
+    val inputDescriptionFormat = stringResource(MR.strings.pref_source_preference_input_a11y)
+    val dialogTitleFallback = stringResource(MR.strings.pref_source_preference_dialog_title_fallback)
+    val invalidInputMessage = stringResource(MR.strings.pref_source_preference_invalid_input)
+    val noneText = stringResource(MR.strings.none)
+    val scope = rememberCoroutineScope()
+
+    TextPreferenceWidget(
+        modifier = Modifier.semantics {
+            role = Role.Button
+            contentDescription = buildString {
+                append(title)
+                append(", ")
+                append(subtitle ?: preference.text.orEmpty())
+            }
+        },
+        title = title,
+        subtitle = subtitle,
+        onPreferenceClick = {
+            if (enabled) {
+                validationError = null
+                showDialog = true
+            }
+        },
+    )
+
+    if (!showDialog) return
+
+    val inputFocus = remember { FocusRequester() }
+    val clearFocus = remember { FocusRequester() }
+    val confirmFocus = remember { FocusRequester() }
+    val cancelFocus = remember { FocusRequester() }
+    var editTextRef by remember { mutableStateOf<EditText?>(null) }
+    var draft by rememberSaveable { mutableStateOf(preference.text.orEmpty()) }
+    val dialogTitle = preference.dialogTitle?.toString()
+        ?.takeUnless { it.isBlank() }
+        ?: title.takeUnless { it.isBlank() }
+        ?: dialogTitleFallback
+
+    androidx.compose.material3.AlertDialog(
+        onDismissRequest = { showDialog = false },
+        title = { androidx.compose.material3.Text(text = dialogTitle) },
+        text = {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                AndroidView(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .focusRequester(inputFocus)
+                        .focusProperties {
+                            next = clearFocus
+                            down = clearFocus
+                        }
+                        .semantics {
+                            contentDescription = inputDescriptionFormat.format(title, draft)
+                            stateDescription = draft.ifBlank { noneText }
+                            if (!enabled) disabled()
+                            validationError?.let { error(it) }
+                        },
+                    factory = { context ->
+                        TachiyomiTextInputEditText(context).apply {
+                            inputType = InputType.TYPE_CLASS_TEXT
+                            setIncognito(scope)
+                            preference.getOnBindEditTextListener()?.onBindEditText(this)
+                            setText(preference.text.orEmpty())
+                            setSelection(text?.length ?: 0)
+                            doAfterTextChanged {
+                                draft = it?.toString().orEmpty()
+                                validationError = null
+                            }
+                            editTextRef = this
+                        }
+                    },
+                    update = { editText ->
+                        editTextRef = editText
+                        if (editText.text?.toString() != draft) {
+                            editText.setText(draft)
+                            editText.setSelection(editText.text?.length ?: 0)
+                        }
+                    },
+                )
+                androidx.compose.material3.TextButton(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .focusRequester(clearFocus)
+                        .focusProperties {
+                            next = confirmFocus
+                            down = confirmFocus
+                        }
+                        .semantics { contentDescription = clearDescription },
+                    onClick = {
+                        editTextRef?.setText("")
+                        draft = ""
+                        validationError = null
+                    },
+                ) {
+                    androidx.compose.material3.Text(text = clearDescription)
+                }
+                validationError?.let {
+                    androidx.compose.material3.Text(
+                        text = it,
+                        color = androidx.compose.material3.MaterialTheme.colorScheme.error,
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            androidx.compose.material3.TextButton(
+                modifier = Modifier
+                    .focusRequester(confirmFocus)
+                    .focusProperties {
+                        next = cancelFocus
+                        down = cancelFocus
+                    },
+                onClick = {
+                    val candidate = editTextRef?.text?.toString().orEmpty()
+                    if (preference.callChangeListener(candidate)) {
+                        preference.text = candidate
+                        validationError = null
+                        showDialog = false
+                    } else {
+                        validationError = invalidInputMessage
+                    }
+                },
+            ) {
+                androidx.compose.material3.Text(text = stringResource(MR.strings.action_ok))
+            }
+        },
+        dismissButton = {
+            androidx.compose.material3.TextButton(
+                modifier = Modifier.focusRequester(cancelFocus),
+                onClick = {
+                    validationError = null
+                    showDialog = false
+                },
+            ) {
+                androidx.compose.material3.Text(text = stringResource(MR.strings.action_cancel))
+            }
+        },
+    )
+
+    LaunchedEffect(showDialog) {
+        if (showDialog) inputFocus.requestFocus()
+    }
+}
+
+internal fun resolveListPreferenceSummary(
+    summary: String?,
+    currentValue: String?,
+    entries: Map<String, String>,
+    unavailableTemplate: String,
+): String? {
+    if (!summary.isNullOrBlank()) return summary
+    if (currentValue.isNullOrBlank()) return null
+    return entries[currentValue] ?: unavailableTemplate.format(currentValue)
+}
+
+internal fun formatUnsupportedTypeSubtitle(
+    template: String,
+    typeName: String,
+    key: String?,
+    keyFallback: String,
+): String {
+    val keyOrUnknown = key ?: keyFallback
+    return template.format(typeName, keyOrUnknown)
+}
+
+private fun ListPreference.toEntryMap(): Map<String, String> {
+    val entries = entries ?: emptyArray()
+    val values = entryValues ?: emptyArray()
+    return buildMap {
+        val size = minOf(entries.size, values.size)
+        repeat(size) { index ->
+            put(values[index].toString(), entries[index].toString())
+        }
+    }
+}
+
+private fun MultiSelectListPreference.toEntryMap(): Map<String, String> {
+    val entries = entries ?: emptyArray()
+    val values = entryValues ?: emptyArray()
+    return buildMap {
+        val size = minOf(entries.size, values.size)
+        repeat(size) { index ->
+            put(values[index].toString(), entries[index].toString())
+        }
+    }
+}
+
+private fun normalizePreferenceTree(group: PreferenceGroup) {
+    repeat(group.preferenceCount) { index ->
+        val pref = group.getPreference(index)
+        pref.isIconSpaceReserved = false
+        pref.isSingleLineTitle = false
+        if (pref is DialogPreference && pref.dialogTitle.isNullOrBlank()) {
+            pref.dialogTitle = pref.title
+        }
+
+        if (pref is PreferenceGroup) {
+            normalizePreferenceTree(pref)
+        }
+    }
+}
+
+private fun dispatchPreferenceClick(preference: Preference) {
+    preference.performClick()
+}
+
+private fun PreferenceScreen.toSections(): List<PreferenceSection> {
+    val sections = mutableListOf<PreferenceSection>()
+
+    fun collect(group: PreferenceGroup, title: String?) {
+        val entries = mutableListOf<Preference>()
+        repeat(group.preferenceCount) { index ->
+            val pref = group.getPreference(index)
+            if (!pref.isVisible) return@repeat
+
+            if (pref is PreferenceCategory) {
+                if (entries.isNotEmpty()) {
+                    sections += PreferenceSection(title = title, entries = entries.toList())
+                    entries.clear()
+                }
+                collect(pref, pref.title?.toString())
+            } else if (pref is PreferenceGroup) {
+                collect(pref, pref.title?.toString())
+            } else {
+                entries += pref
+            }
+        }
+
+        if (entries.isNotEmpty()) {
+            sections += PreferenceSection(title = title, entries = entries.toList())
+        }
+    }
+
+    collect(this, null)
+    return sections
+}

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/browse/sourceprefs/SourcePreferencesRendererTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/browse/sourceprefs/SourcePreferencesRendererTest.kt
@@ -1,0 +1,67 @@
+package eu.kanade.tachiyomi.ui.browse.sourceprefs
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class SourcePreferencesRendererTest {
+
+    @Test
+    fun `resolveListPreferenceSummary uses summary when provided`() {
+        val result = resolveListPreferenceSummary(
+            summary = "Provided summary",
+            currentValue = "a",
+            entries = mapOf("a" to "Alpha"),
+            unavailableTemplate = "Unavailable (%s)",
+        )
+
+        assertEquals("Provided summary", result)
+    }
+
+    @Test
+    fun `resolveListPreferenceSummary uses mapped entry when available`() {
+        val result = resolveListPreferenceSummary(
+            summary = null,
+            currentValue = "a",
+            entries = mapOf("a" to "Alpha"),
+            unavailableTemplate = "Unavailable (%s)",
+        )
+
+        assertEquals("Alpha", result)
+    }
+
+    @Test
+    fun `resolveListPreferenceSummary falls back for stale value`() {
+        val result = resolveListPreferenceSummary(
+            summary = null,
+            currentValue = "stale",
+            entries = mapOf("a" to "Alpha"),
+            unavailableTemplate = "Unavailable (%s)",
+        )
+
+        assertEquals("Unavailable (stale)", result)
+    }
+
+    @Test
+    fun `formatUnsupportedTypeSubtitle uses key when present`() {
+        val result = formatUnsupportedTypeSubtitle(
+            template = "Unsupported preference type: %1\$s (%2\$s)",
+            typeName = "FooPreference",
+            key = "foo_key",
+            keyFallback = "no key",
+        )
+
+        assertEquals("Unsupported preference type: FooPreference (foo_key)", result)
+    }
+
+    @Test
+    fun `formatUnsupportedTypeSubtitle falls back when key is absent`() {
+        val result = formatUnsupportedTypeSubtitle(
+            template = "Unsupported preference type: %1\$s (%2\$s)",
+            typeName = "FooPreference",
+            key = null,
+            keyFallback = "no key",
+        )
+
+        assertEquals("Unsupported preference type: FooPreference (no key)", result)
+    }
+}

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -864,6 +864,14 @@
     <string name="track_type">Type</string>
     <string name="myanimelist_relogin">Please login to MAL again</string>
     <string name="source_unsupported">Source is not supported</string>
+    <string name="pref_source_preference_empty_title">No source preferences available</string>
+    <string name="pref_source_preference_value_unavailable">Unavailable (%s)</string>
+    <string name="pref_source_preference_unsupported_type">Unsupported preference type: %1$s (%2$s)</string>
+    <string name="pref_source_preference_missing_key">no key</string>
+    <string name="pref_source_preference_clear_text">Clear text</string>
+    <string name="pref_source_preference_dialog_title_fallback">Edit source preference</string>
+    <string name="pref_source_preference_invalid_input">Invalid value. Please update and try again.</string>
+    <string name="pref_source_preference_input_a11y">%1$s input, current value: %2$s</string>
     <string name="error_no_match">No match found</string>
     <string name="track_error">%1$s error: %2$s</string>
     <string name="track_remove_date_conf_title">Remove date?</string>


### PR DESCRIPTION
## Ticket
- ID: R570
- Priority: P1
- Risk Tier: T2
- GitHub Issue: Closes #573

## Objective
- Replace fragment-hosted anime/manga source preference screens with Compose rendering while preserving AndroidX Preference behavior and persistence parity.

## Scope
- Migrate `AnimeSourcePreferencesScreen` and `MangaSourcePreferencesScreen` to shared Compose preference rendering.
- Add shared internal source preference builder/renderer that keeps AndroidX `Preference` objects as behavior source-of-truth.
- Add reusable custom Compose edit-text dialog component for extension-backed preferences, including extension bind hooks and incognito IME parity.
- Add unsupported-type fallback rendering + stale list-value fallback.
- Add unit and android instrumentation coverage for renderer basics.
- Add resource-backed strings for source-preference dialog/fallback messaging.

## Non-goals
- No route signature changes for source preference navigation.
- No preference key/default schema migrations.
- No broader settings UI refactor outside source preference surfaces.

## Files Changed
- `app/src/main/java/eu/kanade/tachiyomi/ui/browse/anime/extension/details/AnimeSourcePreferencesScreen.kt`
- `app/src/main/java/eu/kanade/tachiyomi/ui/browse/manga/extension/details/MangaSourcePreferencesScreen.kt`
- `app/src/main/java/eu/kanade/tachiyomi/ui/browse/sourceprefs/SourcePreferencesRenderer.kt`
- `app/src/test/java/eu/kanade/tachiyomi/ui/browse/sourceprefs/SourcePreferencesRendererTest.kt`
- `app/src/androidTest/java/eu/kanade/tachiyomi/ui/browse/sourceprefs/SourcePreferencesContentAndroidTest.kt`
- `i18n/src/commonMain/moko-resources/base/strings.xml`

## Verification
- Commands run:
  - `./gradlew spotlessCheck`
  - `./gradlew :app:compileStableDebugKotlin`
  - `./gradlew :app:testStableDebugUnitTest --tests eu.kanade.tachiyomi.ui.browse.sourceprefs.SourcePreferencesRendererTest`
  - `./gradlew :app:compileStableDebugAndroidTestKotlin`
  - `./gradlew :app:connectedStableDebugAndroidTest`
- Results:
  - All commands passed.
  - Connected instrumentation suite executed on emulator (`Pixel_9_Pro_XL(AVD) - 16`) with 21 tests passing.
- Not tested:
  - Manual fresh-install vs upgraded-install parity checks.
  - Manual TalkBack/DPAD walkthrough on anime/manga source preference screens.

## Risk
- Risk: behavioral divergence from AndroidX `PreferenceFragmentCompat` handling for extension-custom preference subclasses.
- Mitigation: keep AndroidX `Preference` objects as source-of-truth, use `callChangeListener` before persistence, fallback render unsupported types with debug logs, and maintain coverage for stale/list summary behavior.

## SLO Impact
- No expected runtime SLO impact; changes are limited to settings/source preference UI paths.

## Rollback
- Revert this PR commit to restore previous fragment-based source preference host flow.

## Release Notes
- Source-specific anime/manga preference screens now render via Compose with parity-preserving behavior, including extension edit-text dialogs and fallback handling for unsupported preference types.

## Checklist
- [x] Naming conventions followed (use "Rayniyomi" in user-facing text, see [naming conventions](../docs/governance/naming-conventions.md))
- [x] Branch rebased on latest main and verification re-run (see [rebase policy](../docs/governance/agent-workflow.md#rebase-before-merge-policy-r45))
- [x] New coroutine scopes have documented owner and cancellation path
- [x] No new `runBlocking` on UI/main thread paths

## Definition of Done (DoD)
- [x] Acceptance criteria met and non-goals respected
- [x] Verification matrix completed (Risk Tier: T2)
- [x] Self-review completed
- [x] Rebased on latest `main` and revalidated (mandatory for merge)
- [ ] Sprint board updated (branch, commit, checks, PR link)
- [x] Release notes drafted (if applicable)

## Fork Compliance Checklist (for new forks only)
If you are creating a new fork of this project, ensure the following:
- [x] **App Identity**: Changed app name from "Aniyomi" to your fork name
- [x] **App Icon**: Replaced launcher icon assets with fork-specific icons
- [x] **Application ID**: Changed `applicationId` in `app/build.gradle.kts` from `xyz.rayniyomi` to your unique ID
- [x] **Update Checker**: Configured `AppUpdateChecker.kt` to point to your fork's repository
- [x] **Analytics**: Either disabled Firebase Analytics or configured with your own `google-services.json`
- [x] **Crash Reporting**: Either disabled ACRA crash reporting or configured with your own endpoint credentials
