### PR TITLE
chore: extract source preference dialog composables (R570)

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/sourceprefs/SourcePreferenceEditTextDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/sourceprefs/SourcePreferenceEditTextDialog.kt
@@ -29,23 +29,30 @@ import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.widget.doAfterTextChanged
-import androidx.preference.EditTextPreference
-import androidx.preference.getOnBindEditTextListener
 import eu.kanade.presentation.more.settings.widget.TextPreferenceWidget
 import eu.kanade.tachiyomi.widget.TachiyomiTextInputEditText
 import eu.kanade.tachiyomi.widget.TachiyomiTextInputEditText.Companion.setIncognito
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.i18n.stringResource
 
+internal data class SourcePreferenceEditTextUiModel(
+    val title: String,
+    val subtitle: String?,
+    val dialogTitle: String?,
+    val currentValue: String,
+    val enabled: Boolean,
+    val onBindEditText: ((EditText) -> Unit)? = null,
+)
+
 @Composable
 internal fun SourcePreferenceEditTextDialog(
-    preference: EditTextPreference,
-    title: String,
-    subtitle: String?,
-    enabled: Boolean,
+    model: SourcePreferenceEditTextUiModel,
+    onValueConfirmed: (String) -> Boolean,
 ) {
     var showDialog by rememberSaveable { mutableStateOf(false) }
     var validationError by rememberSaveable { mutableStateOf<String?>(null) }
+    var draft by rememberSaveable { mutableStateOf(model.currentValue) }
+
     val clearDescription = stringResource(MR.strings.pref_source_preference_clear_text)
     val inputDescriptionFormat = stringResource(MR.strings.pref_source_preference_input_a11y)
     val dialogTitleFallback = stringResource(MR.strings.pref_source_preference_dialog_title_fallback)
@@ -56,15 +63,16 @@ internal fun SourcePreferenceEditTextDialog(
     TextPreferenceWidget(
         modifier = Modifier.semantics {
             contentDescription = buildString {
-                append(title)
+                append(model.title)
                 append(", ")
-                append(subtitle ?: preference.text.orEmpty())
+                append(model.subtitle ?: model.currentValue)
             }
         },
-        title = title,
-        subtitle = subtitle,
+        title = model.title,
+        subtitle = model.subtitle,
         onPreferenceClick = {
-            if (enabled) {
+            if (model.enabled) {
+                draft = model.currentValue
                 validationError = null
                 showDialog = true
             }
@@ -78,10 +86,9 @@ internal fun SourcePreferenceEditTextDialog(
     val confirmFocus = remember { FocusRequester() }
     val cancelFocus = remember { FocusRequester() }
     var editTextRef by remember { mutableStateOf<EditText?>(null) }
-    var draft by rememberSaveable { mutableStateOf(preference.text.orEmpty()) }
-    val dialogTitle = preference.dialogTitle?.toString()
+    val dialogTitle = model.dialogTitle
         ?.takeUnless { it.isBlank() }
-        ?: title.takeUnless { it.isBlank() }
+        ?: model.title.takeUnless { it.isBlank() }
         ?: dialogTitleFallback
 
     AlertDialog(
@@ -100,17 +107,17 @@ internal fun SourcePreferenceEditTextDialog(
                             down = clearFocus
                         }
                         .semantics {
-                            contentDescription = inputDescriptionFormat.format(title, draft)
+                            contentDescription = inputDescriptionFormat.format(model.title, draft)
                             stateDescription = draft.ifBlank { noneText }
-                            if (!enabled) disabled()
+                            if (!model.enabled) disabled()
                             validationError?.let { error(it) }
                         },
                     factory = { context ->
                         TachiyomiTextInputEditText(context).apply {
                             inputType = InputType.TYPE_CLASS_TEXT
                             setIncognito(scope)
-                            preference.getOnBindEditTextListener()?.onBindEditText(this)
-                            setText(preference.text.orEmpty())
+                            model.onBindEditText?.invoke(this)
+                            setText(model.currentValue)
                             setSelection(text?.length ?: 0)
                             doAfterTextChanged {
                                 draft = it?.toString().orEmpty()
@@ -162,8 +169,7 @@ internal fun SourcePreferenceEditTextDialog(
                     },
                 onClick = {
                     val candidate = editTextRef?.text?.toString().orEmpty()
-                    if (preference.callChangeListener(candidate)) {
-                        preference.text = candidate
+                    if (onValueConfirmed(candidate)) {
                         validationError = null
                         showDialog = false
                     } else {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/sourceprefs/SourcePreferenceMultiSelectDialog.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/sourceprefs/SourcePreferenceMultiSelectDialog.kt
@@ -16,26 +16,31 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
-import androidx.preference.MultiSelectListPreference
 import eu.kanade.presentation.more.settings.widget.TextPreferenceWidget
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.components.LabeledCheckbox
 import tachiyomi.presentation.core.components.ScrollbarLazyColumn
 import tachiyomi.presentation.core.i18n.stringResource
 
+internal data class SourcePreferenceMultiSelectUiModel(
+    val title: String,
+    val subtitle: String?,
+    val entries: Map<String, String>,
+    val selectedValues: Set<String>,
+    val enabled: Boolean,
+)
+
 @Composable
 internal fun SourcePreferenceMultiSelectDialog(
-    preference: MultiSelectListPreference,
-    title: String,
-    subtitle: String?,
+    model: SourcePreferenceMultiSelectUiModel,
+    onValuesConfirmed: (Set<String>) -> Unit,
 ) {
     var showDialog by rememberSaveable { mutableStateOf(false) }
     val selected = remember(showDialog) { mutableStateListOf<String>() }
-    val entries = preference.toEntryMap()
 
-    val currentSummary = subtitle
-        ?: preference.values
-            .mapNotNull { entries[it] }
+    val currentSummary = model.subtitle
+        ?: model.selectedValues
+            .mapNotNull { model.entries[it] }
             .joinToString()
             .takeUnless { it.isBlank() }
         ?: stringResource(MR.strings.none)
@@ -43,14 +48,14 @@ internal fun SourcePreferenceMultiSelectDialog(
     TextPreferenceWidget(
         modifier = Modifier.semantics {
             role = Role.Button
-            contentDescription = "$title, $currentSummary"
+            contentDescription = "${model.title}, $currentSummary"
         },
-        title = title,
+        title = model.title,
         subtitle = currentSummary,
         onPreferenceClick = {
-            if (!preference.isEnabled) return@TextPreferenceWidget
+            if (!model.enabled) return@TextPreferenceWidget
             selected.clear()
-            selected.addAll(preference.values)
+            selected.addAll(model.selectedValues)
             showDialog = true
         },
     )
@@ -59,10 +64,10 @@ internal fun SourcePreferenceMultiSelectDialog(
 
     AlertDialog(
         onDismissRequest = { showDialog = false },
-        title = { Text(text = title) },
+        title = { Text(text = model.title) },
         text = {
             ScrollbarLazyColumn {
-                items(entries.entries.toList(), key = { it.key }) { (key, value) ->
+                items(model.entries.entries.toList(), key = { it.key }) { (key, value) ->
                     LabeledCheckbox(
                         label = value,
                         checked = selected.contains(key),
@@ -80,10 +85,7 @@ internal fun SourcePreferenceMultiSelectDialog(
         confirmButton = {
             TextButton(
                 onClick = {
-                    val next = selected.toSet()
-                    if (preference.callChangeListener(next)) {
-                        preference.values = next
-                    }
+                    onValuesConfirmed(selected.toSet())
                     showDialog = false
                 },
             ) {
@@ -96,15 +98,4 @@ internal fun SourcePreferenceMultiSelectDialog(
             }
         },
     )
-}
-
-private fun MultiSelectListPreference.toEntryMap(): Map<String, String> {
-    val entries = entries ?: emptyArray()
-    val values = entryValues ?: emptyArray()
-    return buildMap {
-        val size = minOf(entries.size, values.size)
-        repeat(size) { index ->
-            put(values[index].toString(), entries[index].toString())
-        }
-    }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/sourceprefs/SourcePreferencesRenderer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/sourceprefs/SourcePreferencesRenderer.kt
@@ -29,6 +29,7 @@ import androidx.preference.PreferenceGroup
 import androidx.preference.PreferenceManager
 import androidx.preference.PreferenceScreen
 import androidx.preference.TwoStatePreference
+import androidx.preference.getOnBindEditTextListener
 import eu.kanade.presentation.more.settings.widget.ListPreferenceWidget
 import eu.kanade.presentation.more.settings.widget.PreferenceGroupHeader
 import eu.kanade.presentation.more.settings.widget.SwitchPreferenceWidget
@@ -161,19 +162,43 @@ fun SourcePreferencesContent(
                     }
 
                     is MultiSelectListPreference -> {
+                        val entryMap = preference.toEntryMap()
                         SourcePreferenceMultiSelectDialog(
-                            preference = preference,
-                            title = preference.title?.toString().orEmpty(),
-                            subtitle = summary,
+                            model = SourcePreferenceMultiSelectUiModel(
+                                title = preference.title?.toString().orEmpty(),
+                                subtitle = summary,
+                                entries = entryMap,
+                                selectedValues = preference.values,
+                                enabled = preference.isEnabled,
+                            ),
+                            onValuesConfirmed = { next ->
+                                if (preference.callChangeListener(next)) {
+                                    preference.values = next
+                                }
+                            },
                         )
                     }
 
                     is EditTextPreference -> {
                         SourcePreferenceEditTextDialog(
-                            preference = preference,
-                            title = preference.title?.toString().orEmpty(),
-                            subtitle = summary,
-                            enabled = preference.isEnabled,
+                            model = SourcePreferenceEditTextUiModel(
+                                title = preference.title?.toString().orEmpty(),
+                                subtitle = summary,
+                                dialogTitle = preference.dialogTitle?.toString(),
+                                currentValue = preference.text.orEmpty(),
+                                enabled = preference.isEnabled,
+                                onBindEditText = { editText ->
+                                    preference.getOnBindEditTextListener()?.onBindEditText(editText)
+                                },
+                            ),
+                            onValueConfirmed = { candidate ->
+                                if (preference.callChangeListener(candidate)) {
+                                    preference.text = candidate
+                                    true
+                                } else {
+                                    false
+                                }
+                            },
                         )
                     }
 
@@ -243,6 +268,17 @@ internal fun formatUnsupportedTypeSubtitle(
 }
 
 private fun ListPreference.toEntryMap(): Map<String, String> {
+    val entries = entries ?: emptyArray()
+    val values = entryValues ?: emptyArray()
+    return buildMap {
+        val size = minOf(entries.size, values.size)
+        repeat(size) { index ->
+            put(values[index].toString(), entries[index].toString())
+        }
+    }
+}
+
+private fun MultiSelectListPreference.toEntryMap(): Map<String, String> {
     val entries = entries ?: emptyArray()
     val values = entryValues ?: emptyArray()
     return buildMap {


### PR DESCRIPTION
## Ticket
- ID: R570
- Priority: P1
- Risk Tier: T1
- GitHub Issue: Closes #573

## Objective
- Follow-up cleanup to improve maintainability/readability of the already-merged compose source preferences work.

## Scope
- Extract custom edit-text dialog composable out of `SourcePreferencesRenderer.kt` into dedicated internal component.
- Extract multi-select dialog composable out of `SourcePreferencesRenderer.kt` into dedicated internal component.
- Remove inline fully-qualified Material3 usage by using standard imports in extracted components.
- Keep behavior and contracts unchanged.

## Non-goals
- No behavioral changes to source preference persistence or change-listener gating.
- No route/navigation changes.
- No string or schema changes.

## Files Changed
- `app/src/main/java/eu/kanade/tachiyomi/ui/browse/sourceprefs/SourcePreferencesRenderer.kt`
- `app/src/main/java/eu/kanade/tachiyomi/ui/browse/sourceprefs/SourcePreferenceEditTextDialog.kt`
- `app/src/main/java/eu/kanade/tachiyomi/ui/browse/sourceprefs/SourcePreferenceMultiSelectDialog.kt`

## Verification
- Commands run:
  - `./gradlew :app:spotlessApply :app:compileStableDebugKotlin :app:testStableDebugUnitTest --tests eu.kanade.tachiyomi.ui.browse.sourceprefs.SourcePreferencesRendererTest :app:compileStableDebugAndroidTestKotlin`
  - `./gradlew spotlessCheck`
  - `./gradlew :app:compileStableDebugKotlin`
- Results:
  - All commands passed.
- Not tested:
  - No additional runtime/manual flow changes expected (refactor-only).

## Risk
- Low risk: internal file extraction/refactor only.
- Mitigation: compile + existing renderer tests kept green.

## SLO Impact
- None expected.

## Rollback
- Revert this PR commit.

## Release Notes
- Internal refactor only; no user-facing behavior change.

## Checklist
- [x] Naming conventions followed (use "Rayniyomi" in user-facing text, see [naming conventions](../docs/governance/naming-conventions.md))
- [x] Branch rebased on latest main and verification re-run (see [rebase policy](../docs/governance/agent-workflow.md#rebase-before-merge-policy-r45))
- [x] New coroutine scopes have documented owner and cancellation path
- [x] No new `runBlocking` on UI/main thread paths

## Definition of Done (DoD)
- [x] Acceptance criteria met and non-goals respected
- [x] Verification matrix completed (Risk Tier: T1)
- [x] Self-review completed
- [x] Rebased on latest `main` and revalidated (mandatory for merge)
- [ ] Sprint board updated (branch, commit, checks, PR link)
- [x] Release notes drafted (if applicable)

## Fork Compliance Checklist (for new forks only)
If you are creating a new fork of this project, ensure the following:
- [x] **App Identity**: Changed app name from "Aniyomi" to your fork name
- [x] **App Icon**: Replaced launcher icon assets with fork-specific icons
- [x] **Application ID**: Changed `applicationId` in `app/build.gradle.kts` from `xyz.rayniyomi` to your unique ID
- [x] **Update Checker**: Configured `AppUpdateChecker.kt` to point to your fork's repository
- [x] **Analytics**: Either disabled Firebase Analytics or configured with your own `google-services.json`
- [x] **Crash Reporting**: Either disabled ACRA crash reporting or configured with your own endpoint credentials
