### PR TITLE
feat: reader host/error compose parity + leak guards (R572)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 ### Changed
 
 - Benchmark builds now skip the app's artificial splash minimum/maximum hold and exit animation so startup measurements reflect app work instead of benchmark-only delay
+- Reader host/error bridge now uses shared Compose error UI with UDF callbacks across pager/webtoon holders, includes explicit holder cleanup to prevent stale error overlay leaks, and removes `ReaderActivityBinding` host dependency while preserving viewer container insertion behavior
 
 ### CI
 

--- a/app/src/androidTest/java/eu/kanade/tachiyomi/ui/reader/viewer/ReaderErrorSurfaceAndroidTest.kt
+++ b/app/src/androidTest/java/eu/kanade/tachiyomi/ui/reader/viewer/ReaderErrorSurfaceAndroidTest.kt
@@ -1,0 +1,75 @@
+package eu.kanade.tachiyomi.ui.reader.viewer
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import tachiyomi.core.common.i18n.stringResource
+import tachiyomi.i18n.MR
+
+@RunWith(AndroidJUnit4::class)
+class ReaderErrorSurfaceAndroidTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun heading_and_retry_are_always_rendered() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        composeRule.setContent {
+            MaterialTheme {
+                ReaderErrorSurface(
+                    state = ReaderErrorUiState(showOpenInWebView = false),
+                    actions = ReaderErrorUiActions(
+                        onRetry = {},
+                        onOpenInWebView = {},
+                    ),
+                )
+            }
+        }
+
+        composeRule.onNodeWithText(context.stringResource(MR.strings.decode_image_error))
+            .assertExists()
+            .assert(
+                SemanticsMatcher("is heading") { node ->
+                    node.config.getOrNull(SemanticsProperties.Heading) != null
+                },
+            )
+        composeRule.onNodeWithText(context.stringResource(MR.strings.action_retry)).assertExists()
+        composeRule.onNodeWithText(context.stringResource(MR.strings.action_open_in_web_view)).assertDoesNotExist()
+    }
+
+    @Test
+    fun open_in_web_action_visibility_and_callbacks_follow_state() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        var retried = false
+        var opened = false
+        composeRule.setContent {
+            MaterialTheme {
+                ReaderErrorSurface(
+                    state = ReaderErrorUiState(showOpenInWebView = true),
+                    actions = ReaderErrorUiActions(
+                        onRetry = { retried = true },
+                        onOpenInWebView = { opened = true },
+                    ),
+                )
+            }
+        }
+
+        composeRule.onNodeWithText(context.stringResource(MR.strings.action_retry)).performClick()
+        composeRule.onNodeWithText(context.stringResource(MR.strings.action_open_in_web_view)).performClick()
+
+        assertTrue(retried)
+        assertTrue(opened)
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -14,6 +14,7 @@ import android.view.KeyEvent
 import android.view.MotionEvent
 import android.view.View.LAYER_TYPE_HARDWARE
 import android.view.WindowManager
+import android.widget.FrameLayout
 import android.widget.Toast
 import androidx.activity.viewModels
 import androidx.compose.foundation.layout.Arrangement
@@ -28,6 +29,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.unit.dp
 import androidx.core.content.getSystemService
 import androidx.core.graphics.ColorUtils
@@ -54,7 +56,6 @@ import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.core.common.Constants
 import eu.kanade.tachiyomi.data.notification.NotificationReceiver
 import eu.kanade.tachiyomi.data.notification.Notifications
-import eu.kanade.tachiyomi.databinding.ReaderActivityBinding
 import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.ui.base.activity.BaseActivity
 import eu.kanade.tachiyomi.ui.main.MainActivity
@@ -69,6 +70,7 @@ import eu.kanade.tachiyomi.ui.reader.setting.ReaderPreferences
 import eu.kanade.tachiyomi.ui.reader.setting.ReaderSettingsScreenModel
 import eu.kanade.tachiyomi.ui.reader.setting.ReadingMode
 import eu.kanade.tachiyomi.ui.reader.viewer.ReaderProgressIndicator
+import eu.kanade.tachiyomi.ui.reader.viewer.ViewerNavigation
 import eu.kanade.tachiyomi.ui.reader.viewer.webtoon.WebtoonViewer
 import eu.kanade.tachiyomi.ui.webview.WebViewActivity
 import eu.kanade.tachiyomi.util.system.hasDisplayCutout
@@ -116,7 +118,12 @@ class ReaderActivity : BaseActivity() {
     private val readerPreferences = Injekt.get<ReaderPreferences>()
     private val preferences = Injekt.get<BasePreferences>()
 
-    lateinit var binding: ReaderActivityBinding
+    private lateinit var rootView: FrameLayout
+    private lateinit var readerContainer: FrameLayout
+    private lateinit var viewerContainer: FrameLayout
+    private lateinit var pageNumber: ComposeView
+    private lateinit var dialogRoot: ComposeView
+    private lateinit var navigationOverlay: ReaderNavigationOverlayView
 
     val viewModel by viewModels<ReaderViewModel>()
 
@@ -131,7 +138,7 @@ class ReaderActivity : BaseActivity() {
     private var readingModeToast: Toast? = null
     private val displayRefreshHost = DisplayRefreshHost()
 
-    private val windowInsetsController by lazy { WindowInsetsControllerCompat(window, binding.root) }
+    private val windowInsetsController by lazy { WindowInsetsControllerCompat(window, rootView) }
 
     private var loadingIndicator: ReaderProgressIndicator? = null
 
@@ -159,8 +166,13 @@ class ReaderActivity : BaseActivity() {
 
         super.onCreate(savedInstanceState)
 
-        binding = ReaderActivityBinding.inflate(layoutInflater)
-        setContentView(binding.root)
+        setContentView(R.layout.reader_activity)
+        rootView = findViewById(android.R.id.content)
+        readerContainer = findViewById(R.id.reader_container)
+        viewerContainer = findViewById(R.id.viewer_container)
+        pageNumber = findViewById(R.id.page_number)
+        dialogRoot = findViewById(R.id.dialog_root)
+        navigationOverlay = findViewById(R.id.navigation_overlay)
         showAutoScrollPanel = savedInstanceState?.getBoolean(KEY_SHOW_AUTO_SCROLL_PANEL, false) ?: false
         isAutoScrollRunning = savedInstanceState?.getBoolean(KEY_IS_AUTO_SCROLL_RUNNING, false) ?: false
 
@@ -357,7 +369,7 @@ class ReaderActivity : BaseActivity() {
      * Initializes the reader menu. It sets up click listeners and the initial visibility.
      */
     private fun initializeMenu() {
-        binding.pageNumber.setComposeContent {
+        pageNumber.setComposeContent {
             val state by viewModel.state.collectAsState()
             val showPageNumber by viewModel.readerPreferences.showPageNumber().collectAsState()
 
@@ -369,7 +381,7 @@ class ReaderActivity : BaseActivity() {
             }
         }
 
-        binding.dialogRoot.setComposeContent {
+        dialogRoot.setComposeContent {
             val state by viewModel.state.collectAsState()
             val settingsScreenModel = remember {
                 ReaderSettingsScreenModel(
@@ -581,7 +593,7 @@ class ReaderActivity : BaseActivity() {
         // Destroy previous viewer if there was one
         if (prevViewer != null) {
             prevViewer.destroy()
-            binding.viewerContainer.removeAllViews()
+            viewerContainer.removeAllViews()
         }
         viewModel.onViewerLoaded(newViewer)
         if (newViewer is WebtoonViewer) {
@@ -595,14 +607,14 @@ class ReaderActivity : BaseActivity() {
             isAutoScrollRunning = false
         }
         updateViewerInset(readerPreferences.fullscreen().get())
-        binding.viewerContainer.addView(newViewer.getView())
+        viewerContainer.addView(newViewer.getView())
 
         if (readerPreferences.showReadingMode().get()) {
             showReadingModeToast(viewModel.getMangaReadingMode())
         }
 
         loadingIndicator = ReaderProgressIndicator(this)
-        binding.readerContainer.addView(loadingIndicator)
+        readerContainer.addView(loadingIndicator)
 
         startPostponedEnterTransition()
     }
@@ -668,7 +680,7 @@ class ReaderActivity : BaseActivity() {
      */
     @SuppressLint("RestrictedApi")
     private fun setChapters(viewerChapters: ViewerChapters) {
-        binding.readerContainer.removeView(loadingIndicator)
+        readerContainer.removeView(loadingIndicator)
         viewModel.state.value.viewer?.setChapters(viewerChapters)
     }
 
@@ -779,6 +791,10 @@ class ReaderActivity : BaseActivity() {
         }
     }
 
+    fun setNavigationOverlay(navigation: ViewerNavigation, showOnStart: Boolean) {
+        navigationOverlay.setNavigation(navigation, showOnStart)
+    }
+
     /**
      * Called from the presenter when a page is ready to be shared. It shows Android's default
      * sharing tool.
@@ -863,13 +879,13 @@ class ReaderActivity : BaseActivity() {
         init {
             viewModel.readerConfig.backgroundColor
                 .onEach { color ->
-                    binding.readerContainer.setBackgroundColor(color)
+                    readerContainer.setBackgroundColor(color)
                 }
                 .launchIn(lifecycleScope)
 
             viewModel.readerConfig.layerPaint
                 .onEach { paint ->
-                    binding.viewerContainer.setLayerType(LAYER_TYPE_HARDWARE, paint)
+                    viewerContainer.setLayerType(LAYER_TYPE_HARDWARE, paint)
                 }
                 .launchIn(lifecycleScope)
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/ReaderErrorUi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/ReaderErrorUi.kt
@@ -1,0 +1,108 @@
+package eu.kanade.tachiyomi.ui.reader.viewer
+
+import android.view.MotionEvent
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusProperties
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.input.pointer.pointerInteropFilter
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import tachiyomi.i18n.MR
+import tachiyomi.presentation.core.i18n.stringResource
+
+internal data class ReaderErrorUiState(
+    val showOpenInWebView: Boolean,
+)
+
+internal data class ReaderErrorUiActions(
+    val onRetry: () -> Unit,
+    val onOpenInWebView: () -> Unit,
+    val onActionPressChanged: (Boolean) -> Unit = {},
+)
+
+internal fun canOpenReaderPageInWebView(imageUrl: String?): Boolean {
+    return imageUrl?.startsWith("http", ignoreCase = true) == true
+}
+
+@Composable
+internal fun ReaderErrorSurface(
+    state: ReaderErrorUiState,
+    actions: ReaderErrorUiActions,
+) {
+    val headingFocusRequester = FocusRequester()
+    val retryFocusRequester = FocusRequester()
+    val openWebFocusRequester = FocusRequester()
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Text(
+            text = stringResource(MR.strings.decode_image_error),
+            modifier = Modifier
+                .semantics { heading() }
+                .focusRequester(headingFocusRequester)
+                .focusProperties {
+                    next = retryFocusRequester
+                }
+                .focusable(),
+        )
+        Button(
+            onClick = actions.onRetry,
+            modifier = Modifier
+                .padding(top = 8.dp)
+                .focusRequester(retryFocusRequester)
+                .focusProperties {
+                    previous = headingFocusRequester
+                    if (state.showOpenInWebView) {
+                        next = openWebFocusRequester
+                    }
+                }
+                .pointerInteropFilter { event ->
+                    when (event.actionMasked) {
+                        MotionEvent.ACTION_DOWN -> actions.onActionPressChanged(true)
+                        MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> actions.onActionPressChanged(false)
+                    }
+                    false
+                }
+                .focusable(),
+        ) {
+            Text(stringResource(MR.strings.action_retry))
+        }
+        if (state.showOpenInWebView) {
+            Button(
+                onClick = actions.onOpenInWebView,
+                modifier = Modifier
+                    .padding(top = 8.dp)
+                    .focusRequester(openWebFocusRequester)
+                    .focusProperties {
+                        previous = retryFocusRequester
+                    }
+                    .pointerInteropFilter { event ->
+                        when (event.actionMasked) {
+                            MotionEvent.ACTION_DOWN -> actions.onActionPressChanged(true)
+                            MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> actions.onActionPressChanged(false)
+                        }
+                        false
+                    }
+                    .focusable(),
+            ) {
+                Text(stringResource(MR.strings.action_open_in_web_view))
+            }
+        }
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
@@ -2,14 +2,18 @@ package eu.kanade.tachiyomi.ui.reader.viewer.pager
 
 import android.annotation.SuppressLint
 import android.content.Context
-import android.view.LayoutInflater
-import androidx.core.view.isVisible
-import eu.kanade.tachiyomi.databinding.ReaderErrorBinding
+import android.view.Gravity
+import android.widget.FrameLayout
+import androidx.compose.ui.platform.ComposeView
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.ui.reader.model.InsertPage
 import eu.kanade.tachiyomi.ui.reader.model.ReaderPage
+import eu.kanade.tachiyomi.ui.reader.viewer.ReaderErrorSurface
+import eu.kanade.tachiyomi.ui.reader.viewer.ReaderErrorUiActions
+import eu.kanade.tachiyomi.ui.reader.viewer.ReaderErrorUiState
 import eu.kanade.tachiyomi.ui.reader.viewer.ReaderPageImageView
 import eu.kanade.tachiyomi.ui.reader.viewer.ReaderProgressIndicator
+import eu.kanade.tachiyomi.ui.reader.viewer.canOpenReaderPageInWebView
 import eu.kanade.tachiyomi.ui.webview.WebViewActivity
 import eu.kanade.tachiyomi.widget.ViewPagerAdapter
 import kotlinx.coroutines.Job
@@ -51,7 +55,7 @@ class PagerPageHolder(
     /**
      * Error layout to show when the image fails to load.
      */
-    private var errorLayout: ReaderErrorBinding? = null
+    private var errorLayout: ComposeView? = null
 
     private val scope = MainScope()
 
@@ -70,6 +74,7 @@ class PagerPageHolder(
     @SuppressLint("ClickableViewAccessibility")
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
+        viewer.pager.setGestureDetectorEnabled(true)
         loadJob?.cancel()
         loadJob = null
         scope.cancel()
@@ -270,36 +275,65 @@ class PagerPageHolder(
         viewer.activity.hideMenu()
     }
 
-    private fun showErrorLayout(): ReaderErrorBinding {
+    private fun showErrorLayout(): ComposeView {
         if (errorLayout == null) {
-            errorLayout = ReaderErrorBinding.inflate(LayoutInflater.from(context), this, true)
-            errorLayout?.actionRetry?.viewer = viewer
-            errorLayout?.actionRetry?.setOnClickListener {
-                page.chapter.pageLoader?.retryPage(page)
+            errorLayout = ComposeView(context).also { errorView ->
+                addView(
+                    errorView,
+                    FrameLayout.LayoutParams(
+                        FrameLayout.LayoutParams.MATCH_PARENT,
+                        FrameLayout.LayoutParams.WRAP_CONTENT,
+                    ).apply {
+                        gravity = Gravity.CENTER
+                    },
+                )
             }
         }
 
         val imageUrl = page.imageUrl
-        errorLayout?.actionOpenInWebView?.isVisible = imageUrl != null
-        if (imageUrl != null) {
-            if (imageUrl.startsWith("http", true)) {
-                errorLayout?.actionOpenInWebView?.viewer = viewer
-                errorLayout?.actionOpenInWebView?.setOnClickListener {
-                    val intent = WebViewActivity.newIntent(context, imageUrl)
-                    context.startActivity(intent)
-                }
-            }
+        val openInWebView = canOpenReaderPageInWebView(imageUrl)
+        errorLayout?.setContent {
+            ReaderErrorSurface(
+                state = ReaderErrorUiState(
+                    showOpenInWebView = openInWebView,
+                ),
+                actions = ReaderErrorUiActions(
+                    onRetry = {
+                        page.chapter.pageLoader?.retryPage(page)
+                    },
+                    onOpenInWebView = {
+                        if (imageUrl != null) {
+                            val intent = WebViewActivity.newIntent(context, imageUrl)
+                            context.startActivity(intent)
+                        }
+                    },
+                    onActionPressChanged = { isPressed ->
+                        viewer.pager.setGestureDetectorEnabled(!isPressed)
+                    },
+                ),
+            )
         }
 
-        errorLayout?.root?.isVisible = true
-        return errorLayout!!
+        return checkNotNull(errorLayout)
     }
 
     /**
      * Removes the decode error layout from the holder, if found.
      */
     private fun removeErrorLayout() {
-        errorLayout?.root?.isVisible = false
-        errorLayout = null
+        errorLayout?.let { errorView ->
+            removeView(errorView)
+            errorLayout = null
+        }
+    }
+
+    internal fun errorOverlayCountForTest(): Int {
+        var count = 0
+        for (index in 0 until childCount) {
+            if (getChildAt(index) is ComposeView) {
+                count++
+            }
+        }
+        return count
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerViewer.kt
@@ -141,7 +141,7 @@ abstract class PagerViewer(val activity: ReaderActivity) : Viewer {
 
         config.navigationModeChangedListener = {
             val showOnStart = config.navigationOverlayOnStart || config.forceNavigationOverlay
-            activity.binding.navigationOverlay.setNavigation(config.navigator, showOnStart)
+            activity.setNavigationOverlay(config.navigator, showOnStart)
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonPageHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonPageHolder.kt
@@ -1,20 +1,23 @@
 package eu.kanade.tachiyomi.ui.reader.viewer.webtoon
 
 import android.content.res.Resources
-import android.view.LayoutInflater
 import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
 import android.widget.FrameLayout
+import androidx.compose.ui.platform.ComposeView
 import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
 import androidx.core.view.updateMargins
 import com.davemorrissey.labs.subscaleview.SubsamplingScaleImageView
-import eu.kanade.tachiyomi.databinding.ReaderErrorBinding
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.ui.reader.model.ReaderPage
+import eu.kanade.tachiyomi.ui.reader.viewer.ReaderErrorSurface
+import eu.kanade.tachiyomi.ui.reader.viewer.ReaderErrorUiActions
+import eu.kanade.tachiyomi.ui.reader.viewer.ReaderErrorUiState
 import eu.kanade.tachiyomi.ui.reader.viewer.ReaderPageImageView
 import eu.kanade.tachiyomi.ui.reader.viewer.ReaderProgressIndicator
+import eu.kanade.tachiyomi.ui.reader.viewer.canOpenReaderPageInWebView
 import eu.kanade.tachiyomi.ui.webview.WebViewActivity
 import eu.kanade.tachiyomi.util.system.dpToPx
 import kotlinx.coroutines.Job
@@ -58,7 +61,7 @@ class WebtoonPageHolder(
     /**
      * Error layout to show when the image fails to load.
      */
-    private var errorLayout: ReaderErrorBinding? = null
+    private var errorLayout: ComposeView? = null
 
     /**
      * Getter to retrieve the height of the recycler view.
@@ -282,30 +285,51 @@ class WebtoonPageHolder(
     /**
      * Initializes a button to retry pages.
      */
-    private fun initErrorLayout(): ReaderErrorBinding {
+    private fun initErrorLayout(): ComposeView {
         if (errorLayout == null) {
-            errorLayout = ReaderErrorBinding.inflate(LayoutInflater.from(context), frame, true)
-            errorLayout?.root?.layoutParams = FrameLayout.LayoutParams(
-                MATCH_PARENT,
-                (parentHeight * 0.8).toInt(),
-            )
-            errorLayout?.actionRetry?.setOnClickListener {
-                page?.let { it.chapter.pageLoader?.retryPage(it) }
+            errorLayout = ComposeView(context).also { errorView ->
+                errorView.layoutParams = FrameLayout.LayoutParams(
+                    MATCH_PARENT,
+                    (parentHeight * 0.8).toInt(),
+                )
+                frame.addView(errorView)
             }
         }
 
         val imageUrl = page?.imageUrl
-        errorLayout?.actionOpenInWebView?.isVisible = imageUrl != null
-        if (imageUrl != null) {
-            if (imageUrl.startsWith("http", true)) {
-                errorLayout?.actionOpenInWebView?.setOnClickListener {
-                    val intent = WebViewActivity.newIntent(context, imageUrl)
-                    context.startActivity(intent)
-                }
-            }
+        val openInWebView = canOpenReaderPageInWebView(imageUrl)
+        errorLayout?.setContent {
+            ReaderErrorSurface(
+                state = ReaderErrorUiState(
+                    showOpenInWebView = openInWebView,
+                ),
+                actions = ReaderErrorUiActions(
+                    onRetry = {
+                        page?.let { currentPage ->
+                            currentPage.chapter.pageLoader?.retryPage(currentPage)
+                        }
+                    },
+                    onOpenInWebView = {
+                        if (imageUrl != null) {
+                            val intent = WebViewActivity.newIntent(context, imageUrl)
+                            context.startActivity(intent)
+                        }
+                    },
+                ),
+            )
         }
 
-        return errorLayout!!
+        return checkNotNull(errorLayout)
+    }
+
+    internal fun errorOverlayCountForTest(): Int {
+        var count = 0
+        for (index in 0 until frame.childCount) {
+            if (frame.getChildAt(index) is ComposeView) {
+                count++
+            }
+        }
+        return count
     }
 
     /**
@@ -313,7 +337,7 @@ class WebtoonPageHolder(
      */
     private fun removeErrorLayout() {
         errorLayout?.let {
-            frame.removeView(it.root)
+            frame.removeView(it)
             errorLayout = null
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonViewer.kt
@@ -174,7 +174,7 @@ class WebtoonViewer(val activity: ReaderActivity, val isContinuous: Boolean = tr
 
         config.navigationModeChangedListener = {
             val showOnStart = config.navigationOverlayOnStart || config.forceNavigationOverlay
-            activity.binding.navigationOverlay.setNavigation(config.navigator, showOnStart)
+            activity.setNavigationOverlay(config.navigator, showOnStart)
         }
 
         frame.layoutParams = ViewGroup.LayoutParams(MATCH_PARENT, MATCH_PARENT)

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/reader/viewer/ReaderErrorUiContractTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/reader/viewer/ReaderErrorUiContractTest.kt
@@ -1,0 +1,43 @@
+package eu.kanade.tachiyomi.ui.reader.viewer
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class ReaderErrorUiContractTest {
+
+    @Test
+    fun `canOpenReaderPageInWebView returns true for http and https urls`() {
+        assertTrue(canOpenReaderPageInWebView("http://example.com/page.jpg"))
+        assertTrue(canOpenReaderPageInWebView("https://example.com/page.jpg"))
+    }
+
+    @Test
+    fun `canOpenReaderPageInWebView returns false for null and non-http urls`() {
+        assertFalse(canOpenReaderPageInWebView(null))
+        assertFalse(canOpenReaderPageInWebView("content://example/image"))
+        assertFalse(canOpenReaderPageInWebView("file:///tmp/image.jpg"))
+    }
+
+    @Test
+    fun `ReaderErrorUiActions are callback-only and executable`() {
+        var retried = false
+        var opened = false
+        var pressed: Boolean? = null
+
+        val actions = ReaderErrorUiActions(
+            onRetry = { retried = true },
+            onOpenInWebView = { opened = true },
+            onActionPressChanged = { pressed = it },
+        )
+
+        actions.onRetry()
+        actions.onOpenInWebView()
+        actions.onActionPressChanged(true)
+        actions.onActionPressChanged(false)
+
+        assertTrue(retried)
+        assertTrue(opened)
+        assertFalse(pressed ?: true)
+    }
+}


### PR DESCRIPTION
## Objective
Migrate reader host/error surfaces to a Compose-compatible bridge while preserving reader engine behavior parity, and add explicit leak guards plus UDF action contracts for error interactions.

## Scope
### In scope
- Replace pager/webtoon `ReaderErrorBinding` usage with shared Compose error surface.
- Keep `viewer_container` as concrete insertion point and remove direct `ReaderActivityBinding` host dependency where feasible.
- Preserve retry/open-web behavior and add leak cleanup for holder error hosts.
- Enforce UDF split (`ReaderErrorUiState` display-only + `ReaderErrorUiActions` callbacks).
- Add one changelog bullet for this PR.

### Out of scope
- Reader engine logic rewrites (gesture physics/chapter pipeline/viewer algorithm changes).
- Non-reader feature refactors.

## Summary of Changes
- Added shared reader error component and contracts in `ReaderErrorUi.kt`.
- Updated `ReaderActivity` to explicit bridge view references while preserving host behavior.
- Migrated pager/webtoon holders to Compose error host with reliable remove/dispose cleanup.
- Added parity fixes from independent review:
  - Pager gesture detector disable/enable around error button press lifecycle.
  - Pager error overlay centered to match legacy behavior.
  - Conditional focus routing when open-web action is absent.
- Added tests:
  - `ReaderErrorUiContractTest`
  - `ReaderErrorSurfaceAndroidTest`
- Added changelog bullet in `CHANGELOG.md` (Unreleased > Changed).

## Bridge Points Remaining
| Bridge Point | Status | Notes |
|---|---|---|
| `viewer_container` concrete ViewGroup host | Preserved | Viewer attach/detach unchanged at activity insertion point |
| Reader engine behavior (pager/webtoon/loader pipeline) | Preserved | No engine rewrite in this ticket |
| Navigation overlay bridge | Preserved | Viewer callbacks route via activity bridge method |

## Verification
### Required
- [x] `./gradlew spotlessCheck`
- [x] `./gradlew :app:compileStableDebugKotlin`

### Tests
- [x] `./gradlew :app:testStableDebugUnitTest --tests 'eu.kanade.tachiyomi.ui.reader.viewer.ReaderErrorUiContractTest'`
- [ ] `./gradlew :app:connectedStableDebugAndroidTest` *(fails in local env: no connected devices)*

## Risk
- Medium: touches reader host/holder UI bridge paths.
- Mitigation: constrained to host/error surface layer, no viewer engine rewrite, parity behavior validated with compile + unit + androidTest compile path.

## Rollback
Revert commit `f03f1878b` to restore previous binding-based reader error host flow.

Closes #575
