### PR TITLE
fix: guard invalid trusted manga extensions from crash (R623)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 
 ### Fixed
 
+- Invalid trusted manga extensions now fail closed, auto-revoke trust, and surface a one-shot uninstall prompt instead of crashing source loading
 - Invalid trusted anime extensions now fail closed, auto-revoke local trust, and surface a one-shot uninstall dialog instead of crashing source loading
 - Repaired macrobenchmark target wiring so benchmark startup tests and baseline profile generation point at the `xyz.rayniyomi.benchmark` app package instead of stale package IDs
 - Stable benchmark builds now skip Google Services application and Crashlytics symbol/mapping uploads that are invalid for the benchmark application ID, allowing `stableBenchmark` assembly and installation to complete

--- a/app/src/main/java/eu/kanade/domain/extension/manga/interactor/TrustMangaExtension.kt
+++ b/app/src/main/java/eu/kanade/domain/extension/manga/interactor/TrustMangaExtension.kt
@@ -26,7 +26,35 @@ class TrustMangaExtension(
         }
     }
 
+    fun revoke(pkgName: String) {
+        preferences.trustedExtensions().getAndSet { exts ->
+            exts.filterNot { it.startsWith("$pkgName:") }.toMutableSet()
+        }
+    }
+
+    suspend fun isInvalid(pkgName: String, versionCode: Long, signatureHash: String): Boolean {
+        return invalidKey(pkgName, versionCode, signatureHash) in preferences.invalidMangaExtensions().get()
+    }
+
+    fun markInvalid(pkgName: String, versionCode: Long, signatureHash: String) {
+        preferences.invalidMangaExtensions().getAndSet { exts ->
+            val removed = exts.filterNot { it.startsWith("$pkgName:") }.toMutableSet()
+
+            removed.also { it += invalidKey(pkgName, versionCode, signatureHash) }
+        }
+    }
+
+    fun clearInvalid(pkgName: String) {
+        preferences.invalidMangaExtensions().getAndSet { exts ->
+            exts.filterNot { it.startsWith("$pkgName:") }.toMutableSet()
+        }
+    }
+
     fun revokeAll() {
         preferences.trustedExtensions().delete()
+    }
+
+    private fun invalidKey(pkgName: String, versionCode: Long, signatureHash: String): String {
+        return "$pkgName:$versionCode:$signatureHash"
     }
 }

--- a/app/src/main/java/eu/kanade/domain/source/service/SourcePreferences.kt
+++ b/app/src/main/java/eu/kanade/domain/source/service/SourcePreferences.kt
@@ -51,6 +51,11 @@ class SourcePreferences(
         emptySet(),
     )
 
+    fun invalidMangaExtensions() = preferenceStore.getStringSet(
+        Preference.appStateKey("invalid_manga_extensions"),
+        emptySet(),
+    )
+
     fun globalSearchFilterState() = preferenceStore.getBoolean(
         Preference.appStateKey("has_filters_toggle_state"),
         false,

--- a/app/src/main/java/eu/kanade/tachiyomi/extension/manga/MangaExtensionManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/extension/manga/MangaExtensionManager.kt
@@ -19,9 +19,11 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.map
@@ -79,6 +81,12 @@ class MangaExtensionManager(
     private val untrustedExtensionsMapFlow = MutableStateFlow(emptyMap<String, MangaExtension.Untrusted>())
     val untrustedExtensionsFlow = untrustedExtensionsMapFlow.mapExtensions(scope)
 
+    private val invalidExtensionNoticesFlow = MutableSharedFlow<MangaLoadResult.Invalid>(
+        replay = 16,
+        extraBufferCapacity = 16,
+    )
+    val invalidExtensionNotices = invalidExtensionNoticesFlow.asSharedFlow()
+
     init {
         scope.launch(Dispatchers.IO) {
             initExtensions()
@@ -90,7 +98,7 @@ class MangaExtensionManager(
 
     fun getExtensionPackage(sourceId: Long): String? {
         return installedExtensionsFlow.value.find { extension ->
-            extension.sources.any { it.id == sourceId }
+            extension.hasSourceId(sourceId)
         }
             ?.pkgName
     }
@@ -98,7 +106,7 @@ class MangaExtensionManager(
     fun getExtensionPackageAsFlow(sourceId: Long): Flow<String?> {
         return installedExtensionsFlow.map { extensions ->
             extensions.find { extension ->
-                extension.sources.any { it.id == sourceId }
+                extension.hasSourceId(sourceId)
             }
                 ?.pkgName
         }
@@ -107,14 +115,16 @@ class MangaExtensionManager(
     fun getAppIconForSource(sourceId: Long): Drawable? {
         val pkgName = installedExtensionsMapFlow.value.values
             .find { ext ->
-                ext.sources.any { it.id == sourceId }
+                ext.hasSourceId(sourceId)
             }
             ?.pkgName
             ?: return null
 
+        val packageInfo = MangaExtensionLoader.getMangaExtensionPackageInfoFromPkgName(context, pkgName)
+            ?: return null
+        val appInfo = packageInfo.applicationInfo ?: return null
         return iconMap[pkgName] ?: iconMap.getOrPut(pkgName) {
-            MangaExtensionLoader.getMangaExtensionPackageInfoFromPkgName(context, pkgName)!!.applicationInfo!!
-                .loadIcon(context.packageManager)
+            appInfo.loadIcon(context.packageManager)
         }
     }
 
@@ -143,6 +153,9 @@ class MangaExtensionManager(
             untrustedExtensionsMapFlow.value = extensions
                 .filterIsInstance<MangaLoadResult.Untrusted>()
                 .associate { it.extension.pkgName to it.extension }
+
+            extensions.filterIsInstance<MangaLoadResult.Invalid>()
+                .forEach { invalidExtensionNoticesFlow.emit(it) }
         } finally {
             _isInitialized.value = true
         }
@@ -300,6 +313,10 @@ class MangaExtensionManager(
         installer.uninstallApk(extension.pkgName)
     }
 
+    fun uninstallExtension(pkgName: String) {
+        installer.uninstallApk(pkgName)
+    }
+
     /**
      * Adds the given extension to the list of trusted extensions. It also loads in background the
      * now trusted extensions.
@@ -369,8 +386,17 @@ class MangaExtensionManager(
             updatePendingUpdatesCount()
         }
 
+        override fun onExtensionInvalid(extension: MangaLoadResult.Invalid) {
+            unregisterExtension(extension.pkgName)
+            scope.launch {
+                invalidExtensionNoticesFlow.emit(extension)
+            }
+            updatePendingUpdatesCount()
+        }
+
         override fun onPackageUninstalled(pkgName: String) {
             MangaExtensionLoader.uninstallPrivateExtension(context, pkgName)
+            trustExtension.clearInvalid(pkgName)
             unregisterExtension(pkgName)
             updatePendingUpdatesCount()
         }
@@ -406,6 +432,10 @@ class MangaExtensionManager(
     }
 
     private operator fun <T : MangaExtension> Map<String, T>.plus(extension: T) = plus(extension.pkgName to extension)
+
+    private fun MangaExtension.Installed.hasSourceId(sourceId: Long): Boolean {
+        return sources.any { source -> runCatching { source.id }.getOrNull() == sourceId }
+    }
 
     private fun <T : MangaExtension> StateFlow<Map<String, T>>.mapExtensions(
         scope: CoroutineScope,

--- a/app/src/main/java/eu/kanade/tachiyomi/extension/manga/model/MangaLoadResult.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/extension/manga/model/MangaLoadResult.kt
@@ -3,5 +3,21 @@ package eu.kanade.tachiyomi.extension.manga.model
 sealed interface MangaLoadResult {
     data class Success(val extension: MangaExtension.Installed) : MangaLoadResult
     data class Untrusted(val extension: MangaExtension.Untrusted) : MangaLoadResult
+    data class Invalid(
+        val pkgName: String,
+        val name: String,
+        val versionName: String,
+        val versionCode: Long,
+        val signatureHash: String,
+        val reason: InvalidReason,
+        val debugDetail: String? = null,
+    ) : MangaLoadResult
     data object Error : MangaLoadResult
+}
+
+enum class InvalidReason {
+    DENYLISTED,
+    METADATA_INVALID,
+    SOURCE_FACTORY_THROW,
+    SOURCE_ID_THROW,
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/extension/manga/util/MangaExtensionInstallReceiver.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/extension/manga/util/MangaExtensionInstallReceiver.kt
@@ -54,6 +54,7 @@ internal class MangaExtensionInstallReceiver(private val listener: Listener) : B
                     when (val result = getExtensionFromIntent(context, intent)) {
                         is MangaLoadResult.Success -> listener.onExtensionInstalled(result.extension)
                         is MangaLoadResult.Untrusted -> listener.onExtensionUntrusted(result.extension)
+                        is MangaLoadResult.Invalid -> listener.onExtensionInvalid(result)
                         else -> {}
                     }
                 }
@@ -63,6 +64,7 @@ internal class MangaExtensionInstallReceiver(private val listener: Listener) : B
                     when (val result = getExtensionFromIntent(context, intent)) {
                         is MangaLoadResult.Success -> listener.onExtensionUpdated(result.extension)
                         is MangaLoadResult.Untrusted -> listener.onExtensionUntrusted(result.extension)
+                        is MangaLoadResult.Invalid -> listener.onExtensionInvalid(result)
                         else -> {}
                     }
                 }
@@ -116,6 +118,7 @@ internal class MangaExtensionInstallReceiver(private val listener: Listener) : B
         fun onExtensionInstalled(extension: MangaExtension.Installed)
         fun onExtensionUpdated(extension: MangaExtension.Installed)
         fun onExtensionUntrusted(extension: MangaExtension.Untrusted)
+        fun onExtensionInvalid(extension: MangaLoadResult.Invalid)
         fun onPackageUninstalled(pkgName: String)
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/extension/manga/util/MangaExtensionLoader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/extension/manga/util/MangaExtensionLoader.kt
@@ -10,6 +10,7 @@ import androidx.core.content.pm.PackageInfoCompat
 import dalvik.system.PathClassLoader
 import eu.kanade.domain.extension.manga.interactor.TrustMangaExtension
 import eu.kanade.domain.source.service.SourcePreferences
+import eu.kanade.tachiyomi.extension.manga.model.InvalidReason
 import eu.kanade.tachiyomi.extension.manga.model.MangaExtension
 import eu.kanade.tachiyomi.extension.manga.model.MangaLoadResult
 import eu.kanade.tachiyomi.source.CatalogueSource
@@ -273,6 +274,19 @@ internal object MangaExtensionLoader {
         if (signatures.isNullOrEmpty()) {
             logcat(LogPriority.WARN) { "Package $pkgName isn't signed" }
             return MangaLoadResult.Error
+        }
+        val signatureHash = signatures.first()
+        if (trustExtension.isInvalid(pkgName, versionCode, signatureHash)) {
+            logcat(LogPriority.WARN) { "Extension $pkgName is denylisted as invalid" }
+            return invalidResult(
+                pkgName = pkgName,
+                extName = extName,
+                versionName = versionName,
+                versionCode = versionCode,
+                signatureHash = signatureHash,
+                reason = InvalidReason.DENYLISTED,
+                debugDetail = "denylisted before trust check",
+            )
         } else if (!trustExtension.isTrusted(pkgInfo, signatures)) {
             val extension = MangaExtension.Untrusted(
                 extName,
@@ -280,7 +294,7 @@ internal object MangaExtensionLoader {
                 versionName,
                 versionCode,
                 libVersion,
-                signatures.first(),
+                signatureHash,
             )
             logcat(LogPriority.WARN) { "Extension $pkgName isn't trusted" }
             return MangaLoadResult.Untrusted(extension)
@@ -299,7 +313,20 @@ internal object MangaExtensionLoader {
             return MangaLoadResult.Error
         }
 
-        val sources = appInfo.metaData.getString(METADATA_SOURCE_CLASS)!!
+        val sourceClassMetadata = appInfo.metaData.getString(METADATA_SOURCE_CLASS)
+        if (sourceClassMetadata.isNullOrBlank()) {
+            return invalidResult(
+                pkgName = pkgName,
+                extName = extName,
+                versionName = versionName,
+                versionCode = versionCode,
+                signatureHash = signatureHash,
+                reason = InvalidReason.METADATA_INVALID,
+                debugDetail = METADATA_SOURCE_CLASS,
+            )
+        }
+
+        val sources = sourceClassMetadata
             .split(";")
             .map {
                 val sourceClass = it.trim()
@@ -333,14 +360,42 @@ internal object MangaExtensionLoader {
                             else -> throw Exception("Unknown source class type: ${obj.javaClass}")
                         }
                     } catch (e: Throwable) {
-                        logcat(LogPriority.ERROR, e) { "Extension load error: $extName ($it)" }
-                        return MangaLoadResult.Error
+                        return invalidResult(
+                            pkgName = pkgName,
+                            extName = extName,
+                            versionName = versionName,
+                            versionCode = versionCode,
+                            signatureHash = signatureHash,
+                            reason = InvalidReason.SOURCE_FACTORY_THROW,
+                            debugDetail = it,
+                            throwable = e,
+                        )
                     }
                 } catch (e: Throwable) {
-                    logcat(LogPriority.ERROR, e) { "Extension load error: $extName ($it)" }
-                    return MangaLoadResult.Error
+                    return invalidResult(
+                        pkgName = pkgName,
+                        extName = extName,
+                        versionName = versionName,
+                        versionCode = versionCode,
+                        signatureHash = signatureHash,
+                        reason = InvalidReason.SOURCE_FACTORY_THROW,
+                        debugDetail = it,
+                        throwable = e,
+                    )
                 }
             }
+
+        findInvalidSource(sources)?.let { invalidSource ->
+            return invalidResult(
+                pkgName = pkgName,
+                extName = extName,
+                versionName = versionName,
+                versionCode = versionCode,
+                signatureHash = signatureHash,
+                reason = InvalidReason.SOURCE_ID_THROW,
+                debugDetail = invalidSource.javaClass.name,
+            )
+        }
 
         val langs = sources.filterIsInstance<CatalogueSource>()
             .map { it.lang }
@@ -363,9 +418,49 @@ internal object MangaExtensionLoader {
             pkgFactory = appInfo.metaData.getString(METADATA_SOURCE_FACTORY),
             icon = appInfo.loadIcon(pkgManager),
             isShared = extensionInfo.isShared,
-            signatureHash = signatures.first(),
+            signatureHash = signatureHash,
         )
         return MangaLoadResult.Success(extension)
+    }
+
+    internal fun findInvalidSource(sources: List<MangaSource>): MangaSource? {
+        for (source in sources) {
+            runCatching {
+                source.id
+                source.lang
+                source.name
+            }
+                .getOrElse { return source }
+        }
+        return null
+    }
+
+    private suspend fun invalidResult(
+        pkgName: String,
+        extName: String,
+        versionName: String,
+        versionCode: Long,
+        signatureHash: String,
+        reason: InvalidReason,
+        debugDetail: String? = null,
+        throwable: Throwable? = null,
+    ): MangaLoadResult.Invalid {
+        if (throwable != null) {
+            logcat(LogPriority.ERROR, throwable) { "Invalid manga extension load: $extName ($pkgName)" }
+        } else {
+            logcat(LogPriority.ERROR) { "Invalid manga extension load: $extName ($pkgName)" }
+        }
+        trustExtension.markInvalid(pkgName, versionCode, signatureHash)
+        trustExtension.revoke(pkgName)
+        return MangaLoadResult.Invalid(
+            pkgName = pkgName,
+            name = extName,
+            versionName = versionName,
+            versionCode = versionCode,
+            signatureHash = signatureHash,
+            reason = reason,
+            debugDetail = debugDetail,
+        )
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/source/manga/AndroidMangaSourceManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/manga/AndroidMangaSourceManager.kt
@@ -62,9 +62,21 @@ class AndroidMangaSourceManager(
                         ),
                     )
                     extensions.forEach { extension ->
-                        extension.sources.forEach {
-                            mutableMap[it.id] = it
-                            registerStubSource(StubMangaSource.from(it))
+                        extension.sources.forEach { source ->
+                            val sourceId = runCatching { source.id }.getOrElse { throwable ->
+                                logcat(LogPriority.ERROR, throwable) {
+                                    "Skipping invalid manga source while building source map: ${source.javaClass.name}"
+                                }
+                                return@forEach
+                            }
+                            mutableMap[sourceId] = source
+                            registerStubSource(
+                                StubMangaSource(
+                                    id = sourceId,
+                                    lang = source.lang,
+                                    name = source.name,
+                                ),
+                            )
                         }
                     }
                     sourcesMapFlow.value = mutableMap
@@ -105,7 +117,7 @@ class AndroidMangaSourceManager(
     override fun getCatalogueSources() = sourcesMapFlow.value.values.filterIsInstance<CatalogueSource>()
 
     override fun getStubSources(): List<StubMangaSource> {
-        val onlineSourceIds = getOnlineSources().map { it.id }
+        val onlineSourceIds = getOnlineSources().mapNotNull { runCatching { it.id }.getOrNull() }
         return stubSourcesMap.values.filterNot { it.id in onlineSourceIds }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/manga/extension/MangaExtensionsScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/manga/extension/MangaExtensionsScreenModel.kt
@@ -12,8 +12,10 @@ import eu.kanade.presentation.components.SEARCH_DEBOUNCE_MILLIS
 import eu.kanade.tachiyomi.extension.InstallStep
 import eu.kanade.tachiyomi.extension.manga.MangaExtensionManager
 import eu.kanade.tachiyomi.extension.manga.model.MangaExtension
+import eu.kanade.tachiyomi.extension.manga.model.MangaLoadResult
 import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.util.system.LocaleHelper
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -26,6 +28,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import tachiyomi.core.common.util.lang.launchIO
@@ -39,12 +42,15 @@ class MangaExtensionsScreenModel(
     basePreferences: BasePreferences = Injekt.get(),
     private val extensionManager: MangaExtensionManager = Injekt.get(),
     private val getExtensions: GetMangaExtensionsByType = Injekt.get(),
+    private val application: Application = Injekt.get(),
 ) : StateScreenModel<MangaExtensionsScreenModel.State>(State()) {
 
     private val currentDownloads = MutableStateFlow<Map<String, InstallStep>>(hashMapOf())
+    private val invalidNoticeKeys = mutableSetOf<String>()
+    private val _events = Channel<Event>(Channel.BUFFERED)
+    val events = _events.receiveAsFlow()
 
     init {
-        val context = Injekt.get<Application>()
         val extensionMapper: (Map<String, InstallStep>) -> ((MangaExtension) -> MangaExtensionUiModel.Item) = { map ->
             {
                 MangaExtensionUiModel.Item(it, map[it.pkgName] ?: InstallStep.Idle)
@@ -122,7 +128,7 @@ class MangaExtensionsScreenModel(
                     .toSortedMap(LocaleHelper.comparator)
                     .map { (lang, exts) ->
                         MangaExtensionUiModel.Header.Text(
-                            LocaleHelper.getSourceDisplayName(lang, context),
+                            LocaleHelper.getSourceDisplayName(lang, application),
                         ) to exts.map(extensionMapper(downloads))
                     }
 
@@ -143,6 +149,14 @@ class MangaExtensionsScreenModel(
         }
 
         screenModelScope.launchIO { findAvailableExtensions() }
+
+        extensionManager.invalidExtensionNotices
+            .onEach { invalid ->
+                if (invalidNoticeKeys.add(invalid.noticeKey())) {
+                    _events.send(Event.InvalidExtensionRevoked(invalid))
+                }
+            }
+            .launchIn(screenModelScope)
 
         preferences.mangaExtensionUpdatesCount().changes()
             .onEach { mutableState.update { state -> state.copy(updates = it) } }
@@ -203,6 +217,10 @@ class MangaExtensionsScreenModel(
         extensionManager.uninstallExtension(extension)
     }
 
+    fun uninstallExtension(pkgName: String) {
+        extensionManager.uninstallExtension(pkgName)
+    }
+
     fun findAvailableExtensions() {
         screenModelScope.launchIO {
             mutableState.update { it.copy(isRefreshing = true) }
@@ -233,6 +251,10 @@ class MangaExtensionsScreenModel(
     ) {
         val isEmpty = items.isEmpty()
     }
+
+    sealed interface Event {
+        data class InvalidExtensionRevoked(val extension: MangaLoadResult.Invalid) : Event
+    }
 }
 
 typealias ItemGroups = MutableMap<MangaExtensionUiModel.Header, List<MangaExtensionUiModel.Item>>
@@ -247,4 +269,8 @@ object MangaExtensionUiModel {
         val extension: MangaExtension,
         val installStep: InstallStep,
     )
+}
+
+private fun MangaLoadResult.Invalid.noticeKey(): String {
+    return "$pkgName:$versionCode:$signatureHash"
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/manga/extension/MangaExtensionsTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/manga/extension/MangaExtensionsTab.kt
@@ -4,6 +4,7 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -17,6 +18,7 @@ import eu.kanade.presentation.components.AppBar
 import eu.kanade.presentation.components.TabContent
 import eu.kanade.presentation.more.settings.screen.browse.MangaExtensionReposScreen
 import eu.kanade.tachiyomi.extension.manga.model.MangaExtension
+import eu.kanade.tachiyomi.extension.manga.model.MangaLoadResult
 import eu.kanade.tachiyomi.ui.browse.manga.extension.details.MangaExtensionDetailsScreen
 import eu.kanade.tachiyomi.ui.webview.WebViewScreen
 import eu.kanade.tachiyomi.util.system.isPackageInstalled
@@ -34,6 +36,7 @@ fun mangaExtensionsTab(
 
     val state by extensionsScreenModel.state.collectAsStateWithLifecycle()
     var privateExtensionToUninstall by remember { mutableStateOf<MangaExtension?>(null) }
+    var invalidExtensionToUninstall by remember { mutableStateOf<MangaLoadResult.Invalid?>(null) }
 
     return TabContent(
         titleRes = AYMR.strings.label_manga_extensions,
@@ -50,6 +53,16 @@ fun mangaExtensionsTab(
             ),
         ),
         content = { contentPadding, _ ->
+            LaunchedEffect(Unit) {
+                extensionsScreenModel.events.collect { event ->
+                    when (event) {
+                        is MangaExtensionsScreenModel.Event.InvalidExtensionRevoked -> {
+                            invalidExtensionToUninstall = event.extension
+                        }
+                    }
+                }
+            }
+
             MangaExtensionScreen(
                 state = state,
                 contentPadding = contentPadding,
@@ -100,6 +113,18 @@ fun mangaExtensionsTab(
                     },
                 )
             }
+
+            invalidExtensionToUninstall?.let { invalidExtension ->
+                MangaInvalidExtensionConfirmation(
+                    extensionName = invalidExtension.name,
+                    onClickConfirm = {
+                        extensionsScreenModel.uninstallExtension(invalidExtension.pkgName)
+                    },
+                    onDismissRequest = {
+                        invalidExtensionToUninstall = null
+                    },
+                )
+            }
         },
     )
 }
@@ -125,6 +150,38 @@ private fun MangaExtensionUninstallConfirmation(
                 },
             ) {
                 Text(text = stringResource(MR.strings.ext_remove))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismissRequest) {
+                Text(text = stringResource(MR.strings.action_cancel))
+            }
+        },
+        onDismissRequest = onDismissRequest,
+    )
+}
+
+@Composable
+private fun MangaInvalidExtensionConfirmation(
+    extensionName: String,
+    onClickConfirm: () -> Unit,
+    onDismissRequest: () -> Unit,
+) {
+    AlertDialog(
+        title = {
+            Text(text = stringResource(MR.strings.ext_invalid_extension_title))
+        },
+        text = {
+            Text(text = stringResource(MR.strings.ext_invalid_extension_message, extensionName))
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    onClickConfirm()
+                    onDismissRequest()
+                },
+            ) {
+                Text(text = stringResource(MR.strings.ext_uninstall))
             }
         },
         dismissButton = {

--- a/app/src/test/java/eu/kanade/domain/extension/manga/interactor/TrustMangaExtensionTest.kt
+++ b/app/src/test/java/eu/kanade/domain/extension/manga/interactor/TrustMangaExtensionTest.kt
@@ -1,0 +1,134 @@
+package eu.kanade.domain.extension.manga.interactor
+
+import eu.kanade.domain.source.service.SourcePreferences
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.test.runTest
+import mihon.domain.extensionrepo.manga.repository.MangaExtensionRepoRepository
+import org.junit.jupiter.api.Test
+import tachiyomi.core.common.preference.Preference
+import tachiyomi.core.common.preference.PreferenceStore
+
+class TrustMangaExtensionTest {
+
+    @Test
+    fun `revoke removes only the target package trust entries`() = runTest {
+        val store = MutablePreferenceStore(
+            initialValues = mapOf(
+                "__APP_STATE_trusted_extensions" to setOf(
+                    "com.example.good:1:hash-a",
+                    "com.example.bad:2:hash-b",
+                    "com.example.other:3:hash-c",
+                ),
+            ),
+        )
+        val preferences = SourcePreferences(store)
+        val trust = createTrust(preferences)
+
+        trust.revoke("com.example.bad")
+
+        val trusted = preferences.trustedExtensions().get()
+        trusted.shouldContain("com.example.good:1:hash-a")
+        trusted.shouldContain("com.example.other:3:hash-c")
+        trusted.shouldNotContain("com.example.bad:2:hash-b")
+    }
+
+    @Test
+    fun `markInvalid and clearInvalid update the denylist`() = runTest {
+        val store = MutablePreferenceStore()
+        val preferences = SourcePreferences(store)
+        val trust = createTrust(preferences)
+
+        trust.markInvalid("com.example.bad", 42L, "hash-z")
+        trust.isInvalid("com.example.bad", 42L, "hash-z").shouldBeTrue()
+        trust.isInvalid("com.example.bad", 43L, "hash-z").shouldBe(false)
+
+        trust.clearInvalid("com.example.bad")
+        trust.isInvalid("com.example.bad", 42L, "hash-z").shouldBe(false)
+    }
+
+    private fun createTrust(preferences: SourcePreferences): TrustMangaExtension {
+        val repo = mockk<MangaExtensionRepoRepository>()
+        coEvery { repo.getAll() } returns emptyList()
+        return TrustMangaExtension(
+            mangaExtensionRepoRepository = repo,
+            preferences = preferences,
+        )
+    }
+
+    private class MutablePreferenceStore(initialValues: Map<String, Any?> = emptyMap()) : PreferenceStore {
+        private val data = initialValues.toMutableMap()
+
+        override fun getString(key: String, defaultValue: String): Preference<String> = MutablePreference(
+            key,
+            defaultValue,
+        )
+
+        override fun getLong(key: String, defaultValue: Long): Preference<Long> = MutablePreference(key, defaultValue)
+
+        override fun getInt(key: String, defaultValue: Int): Preference<Int> = MutablePreference(key, defaultValue)
+
+        override fun getFloat(key: String, defaultValue: Float): Preference<Float> = MutablePreference(
+            key,
+            defaultValue,
+        )
+
+        override fun getBoolean(key: String, defaultValue: Boolean): Preference<Boolean> = MutablePreference(
+            key,
+            defaultValue,
+        )
+
+        override fun getStringSet(key: String, defaultValue: Set<String>): Preference<Set<String>> =
+            MutablePreference(key, defaultValue)
+
+        override fun <T> getObject(
+            key: String,
+            defaultValue: T,
+            serializer: (T) -> String,
+            deserializer: (String) -> T,
+        ): Preference<T> = MutablePreference(key, defaultValue)
+
+        override fun getAll(): Map<String, *> = data
+
+        private inner class MutablePreference<T>(
+            private val key: String,
+            private val defaultValue: T,
+        ) : Preference<T> {
+            private val state = MutableStateFlow(get())
+
+            override fun key(): String = key
+
+            override fun get(): T {
+                @Suppress("UNCHECKED_CAST")
+                return (data[key] as T?) ?: defaultValue
+            }
+
+            override fun set(value: T) {
+                data[key] = value
+                state.value = value
+            }
+
+            override fun isSet(): Boolean = data.containsKey(key)
+
+            override fun delete() {
+                data.remove(key)
+                state.value = defaultValue
+            }
+
+            override fun defaultValue(): T = defaultValue
+
+            override fun changes(): Flow<T> = state.asStateFlow()
+
+            override fun stateIn(scope: CoroutineScope): StateFlow<T> = state.asStateFlow()
+        }
+    }
+}

--- a/app/src/test/java/eu/kanade/tachiyomi/extension/manga/util/MangaExtensionLoaderTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/extension/manga/util/MangaExtensionLoaderTest.kt
@@ -1,0 +1,66 @@
+package eu.kanade.tachiyomi.extension.manga.util
+
+import eu.kanade.tachiyomi.source.MangaSource
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+
+class MangaExtensionLoaderTest {
+
+    @Test
+    fun `findInvalidSource returns the first source whose id accessor throws`() {
+        val good = mockk<MangaSource>()
+        val bad = mockk<MangaSource>()
+
+        every { good.id } returns 1L
+        every { good.lang } returns "en"
+        every { good.name } returns "good"
+        every { bad.id } throws IllegalStateException("boom")
+        every { bad.lang } returns "en"
+        every { bad.name } returns "bad"
+
+        MangaExtensionLoader.findInvalidSource(listOf(good, bad)) shouldBe bad
+    }
+
+    @Test
+    fun `findInvalidSource returns the first source whose lang accessor throws`() {
+        val good = mockk<MangaSource>()
+        val bad = mockk<MangaSource>()
+
+        every { good.id } returns 1L
+        every { good.lang } returns "en"
+        every { good.name } returns "good"
+        every { bad.id } returns 2L
+        every { bad.lang } throws IllegalStateException("boom")
+        every { bad.name } returns "bad"
+
+        MangaExtensionLoader.findInvalidSource(listOf(good, bad)) shouldBe bad
+    }
+
+    @Test
+    fun `findInvalidSource returns the first source whose name accessor throws`() {
+        val good = mockk<MangaSource>()
+        val bad = mockk<MangaSource>()
+
+        every { good.id } returns 1L
+        every { good.lang } returns "en"
+        every { good.name } returns "good"
+        every { bad.id } returns 2L
+        every { bad.lang } returns "en"
+        every { bad.name } throws IllegalStateException("boom")
+
+        MangaExtensionLoader.findInvalidSource(listOf(good, bad)) shouldBe bad
+    }
+
+    @Test
+    fun `findInvalidSource returns null when all source ids are readable`() {
+        val good = mockk<MangaSource>()
+
+        every { good.id } returns 1L
+        every { good.lang } returns "en"
+        every { good.name } returns "good"
+
+        MangaExtensionLoader.findInvalidSource(listOf(good)) shouldBe null
+    }
+}

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/browse/manga/extension/MangaExtensionsScreenModelTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/browse/manga/extension/MangaExtensionsScreenModelTest.kt
@@ -1,0 +1,112 @@
+package eu.kanade.tachiyomi.ui.browse.manga.extension
+
+import android.app.Application
+import eu.kanade.domain.base.BasePreferences
+import eu.kanade.domain.base.ExtensionInstallerPreference
+import eu.kanade.domain.extension.manga.interactor.GetMangaExtensionsByType
+import eu.kanade.domain.extension.manga.model.MangaExtensions
+import eu.kanade.domain.source.service.SourcePreferences
+import eu.kanade.tachiyomi.extension.manga.MangaExtensionManager
+import eu.kanade.tachiyomi.extension.manga.model.InvalidReason
+import eu.kanade.tachiyomi.extension.manga.model.MangaLoadResult
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.withTimeout
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import tachiyomi.core.common.preference.InMemoryPreferenceStore
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MangaExtensionsScreenModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `invalid extension notice is emitted once and late collector receives it`() = runTest {
+        val invalid = MangaLoadResult.Invalid(
+            pkgName = "com.example.bad",
+            name = "Broken Extension",
+            versionName = "1.0.0",
+            versionCode = 1L,
+            signatureHash = "hash-z",
+            reason = InvalidReason.SOURCE_ID_THROW,
+        )
+        val invalidNotices = MutableSharedFlow<MangaLoadResult.Invalid>(replay = 2)
+        invalidNotices.tryEmit(invalid)
+        invalidNotices.tryEmit(invalid)
+        val model = createModel(invalidNotices)
+
+        advanceUntilIdle()
+
+        val event = model.events.first()
+        assertEquals(MangaExtensionsScreenModel.Event.InvalidExtensionRevoked(invalid), event)
+
+        assertThrows(TimeoutCancellationException::class.java) {
+            runBlocking {
+                withTimeout(250) {
+                    model.events.first()
+                }
+            }
+        }
+    }
+
+    private fun createModel(
+        invalidNotices: SharedFlow<MangaLoadResult.Invalid>,
+    ): MangaExtensionsScreenModel {
+        val preferences = SourcePreferences(InMemoryPreferenceStore())
+        val basePreferences = mockk<BasePreferences>()
+        val installerPreference = mockk<ExtensionInstallerPreference>()
+        every { basePreferences.extensionInstaller() } returns installerPreference
+        every { installerPreference.changes() } returns emptyFlow()
+
+        val extensionManager = mockk<MangaExtensionManager>()
+        every { extensionManager.invalidExtensionNotices } returns invalidNotices
+        coEvery { extensionManager.findAvailableExtensions() } returns Unit
+
+        val getExtensions = mockk<GetMangaExtensionsByType>()
+        every { getExtensions.subscribe() } returns flowOf(
+            MangaExtensions(
+                updates = emptyList(),
+                installed = emptyList(),
+                available = emptyList(),
+                untrusted = emptyList(),
+            ),
+        )
+
+        return MangaExtensionsScreenModel(
+            preferences = preferences,
+            basePreferences = basePreferences,
+            extensionManager = extensionManager,
+            getExtensions = getExtensions,
+            application = mockk<Application>(relaxed = true),
+        )
+    }
+}


### PR DESCRIPTION
## Objective
Prevent crashes when a trusted manga extension becomes invalid at runtime by failing closed, revoking trust defensively, and guiding the user to uninstall the offender.

## Scope
- Add invalid-trust denylist preference entries for manga extensions keyed by package/version/signature.
- Expand manga extension load result model to include explicit invalid reasons.
- Harden manga extension loading paths for metadata/source factory/source-id exceptions.
- Revoke trust and emit one-shot invalid-extension notices from manager -> screen model -> UI dialog.
- Add focused unit tests for trust invalidation behavior, invalid source detection, and one-shot event delivery.
- Add exactly one changelog bullet for this PR.

## Verification
- `./gradlew spotlessCheck`
- `./gradlew :app:compileStableDebugKotlin` (`:app:compileDebugKotlin` task is not present in this variant matrix)
- `./gradlew :app:testStableDebugUnitTest --tests "eu.kanade.domain.extension.manga.interactor.TrustMangaExtensionTest" --tests "eu.kanade.tachiyomi.extension.manga.util.MangaExtensionLoaderTest" --tests "eu.kanade.tachiyomi.ui.browse.manga.extension.MangaExtensionsScreenModelTest"`

## Risk
Low-to-moderate. Changes are constrained to manga extension trust/load handling and extension settings UI event surfacing. Main regression risk is over-filtering valid sources; mitigated with targeted tests and existing extension manager flow reuse.

Closes #640
