### PR TITLE
fix: retry extension load on ACTION_PACKAGE_REPLACED timing race (R624)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Reader compose migration parity governance gate: added versioned parity baseline/schema artifacts, UTC-phased PASS/WARN/FAIL evaluator with dual-threshold checks and bypass guardrails, reader parity CI workflow (contract + a11y + benchmark smoke jobs), and migration contract documentation
 ### Fixed
 
+- Extension reinstalls and updates no longer silently fail when `ACTION_PACKAGE_REPLACED` fires before Android commits the new package info to the process cache; both anime and manga receivers now retry up to 3× with a 500ms delay before surfacing a final error
+
 ### Changed
 
 ### CI

--- a/app/src/main/java/eu/kanade/tachiyomi/extension/anime/util/AnimeExtensionInstallReceiver.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/extension/anime/util/AnimeExtensionInstallReceiver.kt
@@ -11,6 +11,7 @@ import eu.kanade.tachiyomi.extension.anime.model.AnimeExtension
 import eu.kanade.tachiyomi.extension.anime.model.AnimeLoadResult
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import logcat.LogPriority
 import tachiyomi.core.common.util.system.logcat
@@ -61,7 +62,7 @@ internal class AnimeExtensionInstallReceiver(private val listener: Listener) : B
             }
             Intent.ACTION_PACKAGE_REPLACED, ACTION_EXTENSION_REPLACED -> {
                 scope.launch {
-                    when (val result = getExtensionFromIntent(context, intent)) {
+                    when (val result = loadWithRetryOnReplace(context, intent)) {
                         is AnimeLoadResult.Success -> listener.onExtensionUpdated(result.extension)
                         is AnimeLoadResult.Untrusted -> listener.onExtensionUntrusted(result.extension)
                         is AnimeLoadResult.Invalid -> listener.onExtensionInvalid(result)
@@ -87,6 +88,25 @@ internal class AnimeExtensionInstallReceiver(private val listener: Listener) : B
      */
     private fun isReplacing(intent: Intent): Boolean {
         return intent.getBooleanExtra(Intent.EXTRA_REPLACING, false)
+    }
+
+    /**
+     * Loads an extension for a PACKAGE_REPLACED event, retrying on transient PackageManager
+     * unavailability. Android's ActivityThread can report the package as REMOVED mid-replace
+     * because app info isn't committed to the process cache yet; retrying after a short delay
+     * lets PM settle before we give up.
+     */
+    private suspend fun loadWithRetryOnReplace(context: Context, intent: Intent?): AnimeLoadResult {
+        repeat(REPLACE_RETRY_COUNT) { attempt ->
+            val result = getExtensionFromIntent(context, intent)
+            if (result !is AnimeLoadResult.Error) return result
+            val pkgName = getPackageNameFromIntent(intent) ?: return result
+            logcat(LogPriority.WARN) {
+                "Extension $pkgName not found after replace (attempt ${attempt + 1}/$REPLACE_RETRY_COUNT), retrying..."
+            }
+            delay(REPLACE_RETRY_DELAY_MS)
+        }
+        return getExtensionFromIntent(context, intent)
     }
 
     /**
@@ -123,6 +143,9 @@ internal class AnimeExtensionInstallReceiver(private val listener: Listener) : B
     }
 
     companion object {
+        private const val REPLACE_RETRY_COUNT = 3
+        private const val REPLACE_RETRY_DELAY_MS = 500L
+
         private const val ACTION_EXTENSION_ADDED = "${BuildConfig.APPLICATION_ID}.ACTION_EXTENSION_ADDED"
         private const val ACTION_EXTENSION_REPLACED = "${BuildConfig.APPLICATION_ID}.ACTION_EXTENSION_REPLACED"
         private const val ACTION_EXTENSION_REMOVED = "${BuildConfig.APPLICATION_ID}.ACTION_EXTENSION_REMOVED"

--- a/app/src/main/java/eu/kanade/tachiyomi/extension/manga/util/MangaExtensionInstallReceiver.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/extension/manga/util/MangaExtensionInstallReceiver.kt
@@ -11,6 +11,7 @@ import eu.kanade.tachiyomi.extension.manga.model.MangaExtension
 import eu.kanade.tachiyomi.extension.manga.model.MangaLoadResult
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import logcat.LogPriority
 import tachiyomi.core.common.util.system.logcat
@@ -61,7 +62,7 @@ internal class MangaExtensionInstallReceiver(private val listener: Listener) : B
             }
             Intent.ACTION_PACKAGE_REPLACED, ACTION_EXTENSION_REPLACED -> {
                 scope.launch {
-                    when (val result = getExtensionFromIntent(context, intent)) {
+                    when (val result = loadWithRetryOnReplace(context, intent)) {
                         is MangaLoadResult.Success -> listener.onExtensionUpdated(result.extension)
                         is MangaLoadResult.Untrusted -> listener.onExtensionUntrusted(result.extension)
                         is MangaLoadResult.Invalid -> listener.onExtensionInvalid(result)
@@ -87,6 +88,25 @@ internal class MangaExtensionInstallReceiver(private val listener: Listener) : B
      */
     private fun isReplacing(intent: Intent): Boolean {
         return intent.getBooleanExtra(Intent.EXTRA_REPLACING, false)
+    }
+
+    /**
+     * Loads an extension for a PACKAGE_REPLACED event, retrying on transient PackageManager
+     * unavailability. Android's ActivityThread can report the package as REMOVED mid-replace
+     * because app info isn't committed to the process cache yet; retrying after a short delay
+     * lets PM settle before we give up.
+     */
+    private suspend fun loadWithRetryOnReplace(context: Context, intent: Intent?): MangaLoadResult {
+        repeat(REPLACE_RETRY_COUNT) { attempt ->
+            val result = getExtensionFromIntent(context, intent)
+            if (result !is MangaLoadResult.Error) return result
+            val pkgName = getPackageNameFromIntent(intent) ?: return result
+            logcat(LogPriority.WARN) {
+                "Extension $pkgName not found after replace (attempt ${attempt + 1}/$REPLACE_RETRY_COUNT), retrying..."
+            }
+            delay(REPLACE_RETRY_DELAY_MS)
+        }
+        return getExtensionFromIntent(context, intent)
     }
 
     /**
@@ -123,6 +143,9 @@ internal class MangaExtensionInstallReceiver(private val listener: Listener) : B
     }
 
     companion object {
+        private const val REPLACE_RETRY_COUNT = 3
+        private const val REPLACE_RETRY_DELAY_MS = 500L
+
         private const val ACTION_EXTENSION_ADDED = "${BuildConfig.APPLICATION_ID}.ACTION_EXTENSION_ADDED"
         private const val ACTION_EXTENSION_REPLACED = "${BuildConfig.APPLICATION_ID}.ACTION_EXTENSION_REPLACED"
         private const val ACTION_EXTENSION_REMOVED = "${BuildConfig.APPLICATION_ID}.ACTION_EXTENSION_REMOVED"


### PR DESCRIPTION
## Objective

Fix a timing race in `AnimeExtensionInstallReceiver` and `MangaExtensionInstallReceiver` that causes extension reinstalls/updates to silently fail, leaving the extension in an unloaded/invalid state.

## Scope

- `app/.../anime/util/AnimeExtensionInstallReceiver.kt` — add `loadWithRetryOnReplace()`, restore `Invalid` handling
- `app/.../manga/util/MangaExtensionInstallReceiver.kt` — same

## Root Cause

When `ACTION_PACKAGE_REPLACED` fires, the receiver immediately calls `PackageManager.getPackageInfo()`. Android's `ActivityThread` hasn't committed the new app info to the process cache yet (visible as the `"reported as REPLACED, but missing application info. Assuming REMOVED"` log). This causes `NameNotFoundException` → `AnimeLoadResult.Error` → `else -> {}` → load silently dropped.

Aniyomi tolerates this window; Rayniyomi did not.

## Fix

`loadWithRetryOnReplace()` retries up to 3× with 500ms delay when `Error` is returned during a replace event. First non-Error result (Success/Untrusted/Invalid) returns immediately — only genuine final Error falls through.

## Verification

- Confirmed on emulator: animeonsen (v14.7) installed at OS level, but Rayniyomi showed invalid/unloaded state
- After patch: build clean, APK installs to emulator
- Logcat will show retry warn messages if the race window is hit, then succeed

## Risk

T2 — touches broadcast receiver load path for both extension types; retry logic is additive and doesn't affect non-replace events or non-Error results.

Closes #644