### PR TITLE
fix: prevent concurrent startDownloads() from cancelling enqueued job (R579)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 ### Fixed
 
 - Extension reinstalls and updates no longer silently fail when `ACTION_PACKAGE_REPLACED` fires before Android commits the new package info to the process cache; both anime and manga receivers now retry up to 3× with a 500ms delay before surfacing a final error
+- Concurrent calls to `startDownloads()` no longer cancel an already-enqueued download job; WorkManager policy changed from `REPLACE` to `KEEP` for both anime and manga downloaders
 
 ### Changed
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloadJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloadJob.kt
@@ -128,7 +128,7 @@ class AnimeDownloadJob(context: Context, workerParams: WorkerParameters) : Corou
                 .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
                 .build()
             WorkManager.getInstance(context)
-                .enqueueUniqueWork(TAG, ExistingWorkPolicy.REPLACE, request)
+                .enqueueUniqueWork(TAG, ExistingWorkPolicy.KEEP, request)
         }
 
         fun stop(context: Context) {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/manga/MangaDownloadJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/manga/MangaDownloadJob.kt
@@ -128,7 +128,7 @@ class MangaDownloadJob(context: Context, workerParams: WorkerParameters) : Corou
                 .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
                 .build()
             WorkManager.getInstance(context)
-                .enqueueUniqueWork(TAG, ExistingWorkPolicy.REPLACE, request)
+                .enqueueUniqueWork(TAG, ExistingWorkPolicy.KEEP, request)
         }
 
         fun stop(context: Context) {


### PR DESCRIPTION
## Objective

Fix a race condition where two concurrent callers to `startDownloads()` could both observe the WorkManager job as `ENQUEUED` (not yet `RUNNING`), causing the second caller to cancel the first via `ExistingWorkPolicy.REPLACE`.

## Scope

- `MangaDownloadJob.start()` — `ExistingWorkPolicy.REPLACE` → `KEEP`
- `AnimeDownloadJob.start()` — `ExistingWorkPolicy.REPLACE` → `KEEP`
- Changelog entry added

## Verification

Code-only change — the policy is visible in the diff. No unit test (WorkManager static mocking is incompatible with JVM unit tests without Robolectric; the one-line change is low enough risk to rely on code review).

## Risk

T1 — two single-line policy changes. `KEEP` is a no-op when no unique work exists (same net effect as `REPLACE`); only differs when the job is already `ENQUEUED`, which is exactly the race window being closed.

Closes #583