### PR TITLE
fix: make isTrusted version-independent for manually trusted extensions (R648)

### DIFF
--- a/app/src/main/java/eu/kanade/domain/extension/anime/interactor/TrustAnimeExtension.kt
+++ b/app/src/main/java/eu/kanade/domain/extension/anime/interactor/TrustAnimeExtension.kt
@@ -1,7 +1,6 @@
 package eu.kanade.domain.extension.anime.interactor
 
 import android.content.pm.PackageInfo
-import androidx.core.content.pm.PackageInfoCompat
 import eu.kanade.domain.source.service.SourcePreferences
 import mihon.domain.extensionrepo.anime.repository.AnimeExtensionRepoRepository
 import tachiyomi.core.common.preference.getAndSet
@@ -13,8 +12,11 @@ class TrustAnimeExtension(
 
     suspend fun isTrusted(pkgInfo: PackageInfo, fingerprints: List<String>): Boolean {
         val trustedFingerprints = animeExtensionRepoRepository.getAll().map { it.signingKeyFingerprint }.toHashSet()
-        val key = "${pkgInfo.packageName}:${PackageInfoCompat.getLongVersionCode(pkgInfo)}:${fingerprints.last()}"
-        return trustedFingerprints.any { fingerprints.contains(it) } || key in preferences.trustedExtensions().get()
+        return trustedFingerprints.any { fingerprints.contains(it) } ||
+            preferences.trustedExtensions().get().any { key ->
+                val parts = key.split(":")
+                parts.size == 3 && parts[0] == pkgInfo.packageName && fingerprints.contains(parts[2])
+            }
     }
 
     fun trust(pkgName: String, versionCode: Long, signatureHash: String) {

--- a/app/src/main/java/eu/kanade/domain/extension/manga/interactor/TrustMangaExtension.kt
+++ b/app/src/main/java/eu/kanade/domain/extension/manga/interactor/TrustMangaExtension.kt
@@ -1,7 +1,6 @@
 package eu.kanade.domain.extension.manga.interactor
 
 import android.content.pm.PackageInfo
-import androidx.core.content.pm.PackageInfoCompat
 import eu.kanade.domain.source.service.SourcePreferences
 import mihon.domain.extensionrepo.manga.repository.MangaExtensionRepoRepository
 import tachiyomi.core.common.preference.getAndSet
@@ -13,8 +12,11 @@ class TrustMangaExtension(
 
     suspend fun isTrusted(pkgInfo: PackageInfo, fingerprints: List<String>): Boolean {
         val trustedFingerprints = mangaExtensionRepoRepository.getAll().map { it.signingKeyFingerprint }.toHashSet()
-        val key = "${pkgInfo.packageName}:${PackageInfoCompat.getLongVersionCode(pkgInfo)}:${fingerprints.last()}"
-        return trustedFingerprints.any { fingerprints.contains(it) } || key in preferences.trustedExtensions().get()
+        return trustedFingerprints.any { fingerprints.contains(it) } ||
+            preferences.trustedExtensions().get().any { key ->
+                val parts = key.split(":")
+                parts.size == 3 && parts[0] == pkgInfo.packageName && fingerprints.contains(parts[2])
+            }
     }
 
     fun trust(pkgName: String, versionCode: Long, signatureHash: String) {


### PR DESCRIPTION
## Objective

Fix extension trust check to survive version updates. When an extension is updated (new `versionCode`), its manually-trusted status was lost because `isTrusted()` matched on `pkgName:versionCode:signatureHash` — the version component caused the stored key to no longer match.

## Scope

- `TrustMangaExtension.isTrusted()` — match by package name + signature hash only, ignore stored version
- `TrustAnimeExtension.isTrusted()` — same fix
- Remove unused `PackageInfoCompat` import from both files

## Root Cause

`isTrusted()` built a key `"$pkgName:$versionCode:$signatureHash"` and checked exact membership in `trustedExtensions`. After an extension update, the new `versionCode` produced a different key → lookup missed → `MangaLoadResult.Untrusted` → `onExtensionUntrusted()` called → sources removed from source manager → Browse/Sources tab shows no sources.

## Verification

- Manually trust an extension
- Update that extension (simulate by installing a newer APK)
- Verify extension remains trusted and sources appear in Browse tab without requiring re-trust

## Risk

Low — narrows trust comparison to `pkgName + signatureHash`. The stored key format (`pkgName:versionCode:signatureHash`) is unchanged; existing stored keys are still parsed correctly. The `versionCode` part (`parts[1]`) is simply ignored during the trust check.

Closes #648