### PR TITLE
fix: dismiss stale crash-threshold notification after successful downloader start (R576)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 
 ### Fixed
 
+- Manga downloader now dismisses the stale crash-threshold notification when a subsequent successful start resets the crash counter
 ### Changed
 
 ### CI

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/manga/MangaDownloadManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/manga/MangaDownloadManager.kt
@@ -138,11 +138,15 @@ class MangaDownloadManager(
 
     // For use by DownloadService only
     fun downloaderStart(): Boolean {
-        // Reset crash count on successful start
+        val started = downloader.start()
+        if (!started) return false
+
+        // Reset stale crash state after successful downloader start.
         if (downloadPreferences.mangaDownloadJobCrashCount().get() > 0) {
             downloadPreferences.mangaDownloadJobCrashCount().set(0)
+            notifier.cancelCrashNotification()
         }
-        return downloader.start()
+        return true
     }
     fun downloaderStop(
         reason: String? = null,

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/manga/MangaDownloadNotifier.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/manga/MangaDownloadNotifier.kt
@@ -67,6 +67,10 @@ internal class MangaDownloadNotifier(private val context: Context) {
         context.cancelNotification(Notifications.ID_DOWNLOAD_CHAPTER_PROGRESS)
     }
 
+    fun cancelCrashNotification() {
+        context.cancelNotification(Notifications.ID_DOWNLOAD_CHAPTER_CRASH_THRESHOLD)
+    }
+
     /**
      * Called when download progress changes.
      *

--- a/app/src/test/java/eu/kanade/tachiyomi/data/download/manga/MangaDownloadManagerTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/data/download/manga/MangaDownloadManagerTest.kt
@@ -12,12 +12,14 @@ import tachiyomi.domain.download.service.DownloadPreferences
 class MangaDownloadManagerTest {
 
     private lateinit var context: Context
+    private lateinit var mockDownloader: MangaDownloader
     private lateinit var mockNotifier: MangaDownloadNotifier
     private lateinit var manager: MangaDownloadManager
 
     @BeforeEach
     fun setUp() {
         context = mockk(relaxed = true)
+        mockDownloader = mockk(relaxed = true)
         mockNotifier = mockk(relaxed = true)
 
         // InMemoryPreferenceStore creates a new Preference object each call, so set() doesn't
@@ -39,6 +41,7 @@ class MangaDownloadManagerTest {
             getCategories = mockk(relaxed = true),
             sourceManager = mockk(relaxed = true),
             downloadPreferences = downloadPreferences,
+            downloaderForTesting = mockDownloader,
         )
         manager.notifier = mockNotifier
     }
@@ -71,5 +74,40 @@ class MangaDownloadManagerTest {
         manager.incrementJobCrashCount()
 
         verify(atLeast = 2) { mockNotifier.onCrashThresholdExceeded() }
+    }
+
+    @Test
+    fun `downloaderStart clears crash state and notification when start succeeds`() {
+        every { mockDownloader.start() } returns true
+
+        manager.incrementJobCrashCount()
+        manager.incrementJobCrashCount()
+        manager.incrementJobCrashCount()
+
+        manager.downloaderStart()
+
+        verify(exactly = 1) { mockNotifier.cancelCrashNotification() }
+    }
+
+    @Test
+    fun `downloaderStart does not cancel crash notification when crash count is zero`() {
+        every { mockDownloader.start() } returns true
+
+        manager.downloaderStart()
+
+        verify(exactly = 0) { mockNotifier.cancelCrashNotification() }
+    }
+
+    @Test
+    fun `downloaderStart does not clear crash state when downloader fails to start`() {
+        every { mockDownloader.start() } returns false
+
+        manager.incrementJobCrashCount()
+        manager.incrementJobCrashCount()
+        manager.incrementJobCrashCount()
+
+        manager.downloaderStart()
+
+        verify(exactly = 0) { mockNotifier.cancelCrashNotification() }
     }
 }


### PR DESCRIPTION
## Ticket
- ID: R576
- Priority: P1
- Risk Tier: T2
- GitHub Issue: Closes #580

## Objective
- Dismiss stale downloader crash-threshold notifications once the manga downloader successfully starts again.

## Scope
- Update manga downloader start flow to reset crash state only on successful start.
- Clear the crash-threshold notification when that reset occurs.
- Add unit tests for successful start, failed start, and zero-crash-count behavior.
- Add one changelog bullet for user-facing behavior.

## Non-goals
- No changes to crash threshold value or notification copy.
- No changes to downloader retry strategy.

## Files Changed
- `app/src/main/java/eu/kanade/tachiyomi/data/download/manga/MangaDownloadManager.kt`
- `app/src/main/java/eu/kanade/tachiyomi/data/download/manga/MangaDownloadNotifier.kt`
- `app/src/test/java/eu/kanade/tachiyomi/data/download/manga/MangaDownloadManagerTest.kt`
- `CHANGELOG.md`

## Verification
- Commands run:
  - `./gradlew -Dkotlin.daemon.jvmargs=-Xmx4096m :app:testStableDebugUnitTest --tests "*MangaDownloadManagerTest*"`
  - `./gradlew -Dkotlin.daemon.jvmargs=-Xmx4096m :app:testStableDebugUnitTest --tests "*MangaDownloadNotifierTest*"`
  - `./gradlew spotlessCheck`
  - `./gradlew :app:compileStableDebugKotlin`
- Results:
  - All commands passed.
- Not tested:
  - End-to-end device/manual download flow.

## Risk
- Low risk; logic change is constrained to downloader start path.
- Main regression risk is missing notification clear on edge paths; covered by unit tests.

## SLO Impact
- None expected.

## Rollback
- Revert this PR commit to restore previous behavior.

## Release Notes
- Manga downloader now dismisses stale crash-threshold notification after a subsequent successful start.

## Checklist
- [x] Naming conventions followed (use "Rayniyomi" in user-facing text, see [naming conventions](../docs/governance/naming-conventions.md))
- [x] Branch rebased on latest main and verification re-run (see [rebase policy](../docs/governance/agent-workflow.md#rebase-before-merge-policy-r45))
- [x] New coroutine scopes have documented owner and cancellation path
- [x] No new `runBlocking` on UI/main thread paths

## Definition of Done (DoD)
- [x] Acceptance criteria met and non-goals respected
- [x] Verification matrix completed (Risk Tier: T2)
- [x] Self-review completed
- [x] Rebased on latest `main` and revalidated (mandatory for merge)
- [x] Sprint board updated (branch, commit, checks, PR link)
- [x] Release notes drafted (if applicable)
