### PR TITLE
fix: suppress zero-result enrichment sync announcement noise (R652)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 ### Fixed
 
 - Tracker enrichment header/actions now adapt on narrow screens to prevent the recommendations refresh control from overlapping or clipping
+- Entry enrichment refresh no longer shows a `0 updated, 0 failed` announcement when there are no result changes
 - Manually-trusted extensions no longer lose their trusted status after an update; trust is now matched by package name and signature hash, ignoring the version code
 
 ### Changed

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/entries/common/EntryEnrichmentScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/entries/common/EntryEnrichmentScreenModel.kt
@@ -111,9 +111,11 @@ class EntryEnrichmentScreenModel(
                 )
             }
             if (manual) {
-                _announcements.tryEmit(
-                    "${entry.recommendations.size} updated, ${entry.failures.size} failed",
-                )
+                val updatedCount = entry.recommendations.size
+                val failedCount = entry.failures.size
+                if (updatedCount > 0 || failedCount > 0) {
+                    _announcements.tryEmit("$updatedCount updated, $failedCount failed")
+                }
             }
         }.onFailure {
             if (it is CancellationException) throw it


### PR DESCRIPTION
## Objective
- Prevent no-op tracker enrichment sync runs from announcing "0 updated, 0 failed" to users.

## Scope
- Suppress enrichment completion announcement when both updated and failed counts are zero.
- Keep existing announcement behavior for non-zero results and error scenarios.
- Add one changelog bullet for this ticket.

## Verification
- `./gradlew spotlessCheck`
- `./gradlew :app:compileStableDebugKotlin`

## Risk
- Low behavior risk isolated to enrichment completion announcement conditions.
- Mitigated by preserving existing non-zero and failure announcement paths.

Closes #652
