### PR TITLE
fix: serialize queue mutations to prevent removed-item resurrection (R577)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Manga battery optimization prompt check is now mutex-serialized so concurrent 10+ chapter queue actions cannot emit the prompt twice in one app session
 
 - Manga downloader now dismisses the stale crash-threshold notification when a subsequent successful start resets the crash counter
+- Download queue reorder and add-to-start operations are now mutex-serialized with removals to prevent canceled items from being restored by concurrent queue mutations
 ### Changed
 
 ### CI

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloadManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloadManager.kt
@@ -198,7 +198,7 @@ class AnimeDownloadManager(
      *
      * @param downloads value to set the download queue to
      */
-    fun reorderQueue(downloads: List<AnimeDownload>) {
+    suspend fun reorderQueue(downloads: List<AnimeDownload>) {
         queueMutations.reorderQueue(downloads)
     }
 
@@ -230,7 +230,7 @@ class AnimeDownloadManager(
      *
      * @param downloads the list of downloads to enqueue.
      */
-    fun addDownloadsToStartOfQueue(downloads: List<AnimeDownload>) {
+    suspend fun addDownloadsToStartOfQueue(downloads: List<AnimeDownload>) {
         queueMutations.addDownloadsToStart(downloads) {
             if (!AnimeDownloadJob.isRunning(context)) startDownloads()
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloadManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloadManager.kt
@@ -237,6 +237,17 @@ class AnimeDownloadManager(
     }
 
     /**
+     * Enqueues downloads to the front of the queue using manager-owned structured scope.
+     * Use this for call sites where no suspend scope is available (e.g., lifecycle teardown hooks).
+     */
+    fun addDownloadsToStartOfQueueAsync(downloads: List<AnimeDownload>) {
+        if (downloads.isEmpty()) return
+        scope.launch {
+            addDownloadsToStartOfQueue(downloads)
+        }
+    }
+
+    /**
      * Builds the page list of a downloaded episode.
      *
      * @param source the source of the episode.

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/core/DownloadQueueMutations.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/core/DownloadQueueMutations.kt
@@ -76,12 +76,21 @@ class DownloadQueueMutations<D : Any, I : Any>(
      *
      * @param downloads The new queue order
      */
-    fun reorderQueue(downloads: List<D>) {
-        try {
-            updateQueue(downloads)
-        } catch (e: Exception) {
-            logcat(LogPriority.ERROR) { "Failed to reorder queue: ${e.message}" }
-            throw e
+    suspend fun reorderQueue(downloads: List<D>) {
+        queueMutex.withLock {
+            try {
+                val currentQueue = queueState.value
+                val currentById = currentQueue.associateBy(itemId)
+                val normalizedOrder = downloads
+                    .mapNotNull { currentById[itemId(it)] }
+                val normalizedIds = normalizedOrder.map(itemId).toSet()
+                val remaining = currentQueue.filterNot { itemId(it) in normalizedIds }
+
+                updateQueue(normalizedOrder + remaining)
+            } catch (e: Exception) {
+                logcat(LogPriority.ERROR) { "Failed to reorder queue: ${e.message}" }
+                throw e
+            }
         }
     }
 
@@ -91,14 +100,16 @@ class DownloadQueueMutations<D : Any, I : Any>(
      * @param downloads The downloads to add
      * @param startIfNeeded Callback to start the downloader if needed (e.g., check if job is running)
      */
-    fun addDownloadsToStart(downloads: List<D>, startIfNeeded: () -> Unit) {
+    suspend fun addDownloadsToStart(downloads: List<D>, startIfNeeded: () -> Unit) {
         if (downloads.isEmpty()) return
-        try {
-            addToStart(downloads)
-            startIfNeeded()
-        } catch (e: Exception) {
-            logcat(LogPriority.ERROR) { "Failed to add downloads to start: ${e.message}" }
-            throw e
+        queueMutex.withLock {
+            try {
+                addToStart(downloads)
+                startIfNeeded()
+            } catch (e: Exception) {
+                logcat(LogPriority.ERROR) { "Failed to add downloads to start: ${e.message}" }
+                throw e
+            }
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/manga/MangaDownloadManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/manga/MangaDownloadManager.kt
@@ -245,6 +245,17 @@ class MangaDownloadManager(
     }
 
     /**
+     * Enqueues downloads to the front of the queue using manager-owned structured scope.
+     * Use this for call sites where no suspend scope is available (e.g., lifecycle teardown hooks).
+     */
+    fun addDownloadsToStartOfQueueAsync(downloads: List<MangaDownload>) {
+        if (downloads.isEmpty()) return
+        scope.launch {
+            addDownloadsToStartOfQueue(downloads)
+        }
+    }
+
+    /**
      * Builds the page list of a downloaded chapter.
      *
      * @param source the source of the chapter.

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/manga/MangaDownloadManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/manga/MangaDownloadManager.kt
@@ -205,7 +205,7 @@ class MangaDownloadManager(
      *
      * @param downloads value to set the download queue to
      */
-    fun reorderQueue(downloads: List<MangaDownload>) {
+    suspend fun reorderQueue(downloads: List<MangaDownload>) {
         queueMutations.reorderQueue(downloads)
     }
 
@@ -238,7 +238,7 @@ class MangaDownloadManager(
      *
      * @param downloads the list of downloads to enqueue.
      */
-    fun addDownloadsToStartOfQueue(downloads: List<MangaDownload>) {
+    suspend fun addDownloadsToStartOfQueue(downloads: List<MangaDownload>) {
         queueMutations.addDownloadsToStart(downloads) {
             if (!MangaDownloadJob.isRunning(context)) startDownloads()
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/download/anime/AnimeDownloadQueueScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/download/anime/AnimeDownloadQueueScreenModel.kt
@@ -145,7 +145,9 @@ class AnimeDownloadQueueScreenModel(
     }
 
     fun reorder(downloads: List<AnimeDownload>) {
-        downloadManager.reorderQueue(downloads)
+        screenModelScope.launch {
+            downloadManager.reorderQueue(downloads)
+        }
     }
 
     fun cancel(downloads: List<AnimeDownload>) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/download/manga/MangaDownloadQueueScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/download/manga/MangaDownloadQueueScreenModel.kt
@@ -145,7 +145,9 @@ class MangaDownloadQueueScreenModel(
     }
 
     fun reorder(downloads: List<MangaDownload>) {
-        downloadManager.reorderQueue(downloads)
+        screenModelScope.launch {
+            downloadManager.reorderQueue(downloads)
+        }
     }
 
     fun cancel(downloads: List<MangaDownload>) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerViewModel.kt
@@ -90,6 +90,8 @@ import eu.kanade.tachiyomi.util.system.toast
 import `is`.xyz.mpv.MPVLib
 import `is`.xyz.mpv.Utils
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.channels.Channel
@@ -1013,7 +1015,9 @@ class PlayerViewModel @JvmOverloads constructor(
         if (currentEpisode.value != null) {
             saveWatchingProgress(currentEpisode.value!!)
             episodeToDownload?.let {
-                downloadManager.addDownloadsToStartOfQueue(listOf(it))
+                CoroutineScope(Dispatchers.IO).launch {
+                    downloadManager.addDownloadsToStartOfQueue(listOf(it))
+                }
             }
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerViewModel.kt
@@ -90,8 +90,6 @@ import eu.kanade.tachiyomi.util.system.toast
 import `is`.xyz.mpv.MPVLib
 import `is`.xyz.mpv.Utils
 import kotlinx.collections.immutable.toImmutableList
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.channels.Channel
@@ -1015,9 +1013,7 @@ class PlayerViewModel @JvmOverloads constructor(
         if (currentEpisode.value != null) {
             saveWatchingProgress(currentEpisode.value!!)
             episodeToDownload?.let {
-                CoroutineScope(Dispatchers.IO).launch {
-                    downloadManager.addDownloadsToStartOfQueue(listOf(it))
-                }
+                downloadManager.addDownloadsToStartOfQueueAsync(listOf(it))
             }
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -42,8 +42,6 @@ import eu.kanade.tachiyomi.util.lang.takeBytes
 import eu.kanade.tachiyomi.util.storage.DiskUtil
 import eu.kanade.tachiyomi.util.storage.cacheImageDir
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -209,9 +207,7 @@ class ReaderViewModel @JvmOverloads constructor(
         if (currentChapters != null) {
             currentChapters.unref()
             chapterToDownload?.let {
-                CoroutineScope(Dispatchers.IO).launch {
-                    downloadManager.addDownloadsToStartOfQueue(listOf(it))
-                }
+                downloadManager.addDownloadsToStartOfQueueAsync(listOf(it))
             }
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -42,6 +42,8 @@ import eu.kanade.tachiyomi.util.lang.takeBytes
 import eu.kanade.tachiyomi.util.storage.DiskUtil
 import eu.kanade.tachiyomi.util.storage.cacheImageDir
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -53,6 +55,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import logcat.LogPriority
 import tachiyomi.core.common.preference.toggle
 import tachiyomi.core.common.util.lang.launchIO
@@ -206,7 +209,9 @@ class ReaderViewModel @JvmOverloads constructor(
         if (currentChapters != null) {
             currentChapters.unref()
             chapterToDownload?.let {
-                downloadManager.addDownloadsToStartOfQueue(listOf(it))
+                CoroutineScope(Dispatchers.IO).launch {
+                    downloadManager.addDownloadsToStartOfQueue(listOf(it))
+                }
             }
         }
     }

--- a/app/src/test/java/eu/kanade/tachiyomi/data/download/core/DownloadQueueMutationsTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/data/download/core/DownloadQueueMutationsTest.kt
@@ -1,7 +1,7 @@
 package eu.kanade.tachiyomi.data.download.core
 
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.async
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.test.runTest
@@ -182,7 +182,6 @@ class DownloadQueueMutationsTest {
             isRunning = { true },
             pauseDownloader = {
                 pauseCount++
-                Thread.sleep(10) // Simulate pause delay
             },
             startDownloader = {
                 startCount++
@@ -191,10 +190,7 @@ class DownloadQueueMutationsTest {
 
         // Launch two concurrent removals
         val job1 = async { mutations.removeFromQueueSafely(listOf(entity1)) }
-        val job2 = async {
-            delay(5) // Slight delay to create contention
-            mutations.removeFromQueueSafely(listOf(entity2))
-        }
+        val job2 = async { mutations.removeFromQueueSafely(listOf(entity2)) }
 
         job1.await()
         job2.await()
@@ -307,16 +303,23 @@ class DownloadQueueMutationsTest {
         val download3 = FakeDownload(3, entity3)
         val queueState = MutableStateFlow(listOf(download1, download2, download3))
 
+        val removeApplied = CompletableDeferred<Unit>()
+
         val mutations = createMutations(
             queueState = queueState,
             updateQueue = { reordered -> queueState.value = reordered },
             isRunning = { true },
-            pauseDownloader = { Thread.sleep(10) },
+            removeFromQueue = { entities ->
+                queueState.value = queueState.value.filterNot { download ->
+                    entities.any { it.id == download.entity.id }
+                }
+                removeApplied.complete(Unit)
+            },
         )
 
         val removeJob = async { mutations.removeFromQueueSafely(listOf(entity2)) }
         val reorderJob = async {
-            delay(1)
+            removeApplied.await()
             mutations.reorderQueue(listOf(download3, download1, download2))
         }
 
@@ -340,6 +343,8 @@ class DownloadQueueMutationsTest {
         val download3 = FakeDownload(3, entity3)
         val queueState = MutableStateFlow(listOf(download1, download2, download3))
 
+        val removeApplied = CompletableDeferred<Unit>()
+
         val mutations = createMutations(
             queueState = queueState,
             addToStart = { downloads ->
@@ -348,12 +353,17 @@ class DownloadQueueMutationsTest {
                 queueState.value = newItems + queueState.value
             },
             isRunning = { true },
-            pauseDownloader = { Thread.sleep(10) },
+            removeFromQueue = { entities ->
+                queueState.value = queueState.value.filterNot { download ->
+                    entities.any { it.id == download.entity.id }
+                }
+                removeApplied.complete(Unit)
+            },
         )
 
         val removeJob = async { mutations.removeFromQueueSafely(listOf(entity2)) }
         val addToStartJob = async {
-            delay(1)
+            removeApplied.await()
             mutations.addDownloadsToStart(listOf(download3)) { }
         }
 

--- a/app/src/test/java/eu/kanade/tachiyomi/data/download/core/DownloadQueueMutationsTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/data/download/core/DownloadQueueMutationsTest.kt
@@ -108,7 +108,7 @@ class DownloadQueueMutationsTest {
     }
 
     @Test
-    fun `addDownloadsToStart skips empty list`() {
+    fun `addDownloadsToStart skips empty list`() = runTest {
         var started = false
         var added = false
         val mutations = createMutations(
@@ -257,9 +257,17 @@ class DownloadQueueMutationsTest {
     }
 
     @Test
-    fun `reorderQueue delegates to updateQueue`() {
+    fun `reorderQueue delegates to updateQueue`() = runTest {
         val reordered = mutableListOf<List<FakeDownload>>()
+        val queueState = MutableStateFlow(
+            listOf(
+                FakeDownload(1, FakeEntity(1, "Entity 1")),
+                FakeDownload(2, FakeEntity(2, "Entity 2")),
+                FakeDownload(3, FakeEntity(3, "Entity 3")),
+            ),
+        )
         val mutations = createMutations(
+            queueState = queueState,
             updateQueue = { reordered.add(it) },
         )
         val newOrder = listOf(
@@ -270,11 +278,11 @@ class DownloadQueueMutationsTest {
         mutations.reorderQueue(newOrder)
 
         assertEquals(1, reordered.size)
-        assertEquals(newOrder, reordered[0])
+        assertEquals(listOf(3L, 1L, 2L), reordered[0].map { it.id })
     }
 
     @Test
-    fun `addDownloadsToStart calls addToStart and startIfNeeded`() {
+    fun `addDownloadsToStart calls addToStart and startIfNeeded`() = runTest {
         val added = mutableListOf<List<FakeDownload>>()
         var started = false
         val mutations = createMutations(
@@ -287,6 +295,76 @@ class DownloadQueueMutationsTest {
         assertEquals(1, added.size)
         assertEquals(downloads, added[0])
         assertTrue(started, "startIfNeeded should be called")
+    }
+
+    @Test
+    fun `reorderQueue does not reintroduce removed item during concurrent removal`() = runTest {
+        val entity1 = FakeEntity(1, "Entity 1")
+        val entity2 = FakeEntity(2, "Entity 2")
+        val entity3 = FakeEntity(3, "Entity 3")
+        val download1 = FakeDownload(1, entity1)
+        val download2 = FakeDownload(2, entity2)
+        val download3 = FakeDownload(3, entity3)
+        val queueState = MutableStateFlow(listOf(download1, download2, download3))
+
+        val mutations = createMutations(
+            queueState = queueState,
+            updateQueue = { reordered -> queueState.value = reordered },
+            isRunning = { true },
+            pauseDownloader = { Thread.sleep(10) },
+        )
+
+        val removeJob = async { mutations.removeFromQueueSafely(listOf(entity2)) }
+        val reorderJob = async {
+            delay(1)
+            mutations.reorderQueue(listOf(download3, download1, download2))
+        }
+
+        removeJob.await()
+        reorderJob.await()
+
+        assertEquals(
+            listOf(1L, 3L),
+            queueState.value.map { it.entity.id }.sorted(),
+            "Removed item should not be reintroduced by concurrent reorder",
+        )
+    }
+
+    @Test
+    fun `addDownloadsToStart preserves remove outcome during concurrent removal`() = runTest {
+        val entity1 = FakeEntity(1, "Entity 1")
+        val entity2 = FakeEntity(2, "Entity 2")
+        val entity3 = FakeEntity(3, "Entity 3")
+        val download1 = FakeDownload(1, entity1)
+        val download2 = FakeDownload(2, entity2)
+        val download3 = FakeDownload(3, entity3)
+        val queueState = MutableStateFlow(listOf(download1, download2, download3))
+
+        val mutations = createMutations(
+            queueState = queueState,
+            addToStart = { downloads ->
+                val existingIds = queueState.value.map { it.id }.toSet()
+                val newItems = downloads.filterNot { it.id in existingIds }
+                queueState.value = newItems + queueState.value
+            },
+            isRunning = { true },
+            pauseDownloader = { Thread.sleep(10) },
+        )
+
+        val removeJob = async { mutations.removeFromQueueSafely(listOf(entity2)) }
+        val addToStartJob = async {
+            delay(1)
+            mutations.addDownloadsToStart(listOf(download3)) { }
+        }
+
+        removeJob.await()
+        addToStartJob.await()
+
+        assertEquals(
+            listOf(1L, 3L),
+            queueState.value.map { it.entity.id }.sorted(),
+            "Removed item should remain absent after concurrent add-to-start operation",
+        )
     }
 
     @Test

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/download/anime/AnimeDownloadQueueScreenModelTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/download/anime/AnimeDownloadQueueScreenModelTest.kt
@@ -5,6 +5,7 @@ import eu.kanade.tachiyomi.data.download.anime.AnimeDownloadManager
 import eu.kanade.tachiyomi.data.download.anime.model.AnimeDownload
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
@@ -14,6 +15,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
@@ -90,9 +92,10 @@ class AnimeDownloadQueueScreenModelTest {
         val model = AnimeDownloadQueueScreenModel(manager)
 
         model.moveToTop(model.state.value[0].downloads[1]) // d2 at index 1
+        advanceUntilIdle()
 
         val slot = slot<List<AnimeDownload>>()
-        verify { manager.reorderQueue(capture(slot)) }
+        coVerify { manager.reorderQueue(capture(slot)) }
         slot.captured.map { it.episode.id } shouldContainExactly listOf(2L, 1L, 3L)
     }
 
@@ -105,9 +108,10 @@ class AnimeDownloadQueueScreenModelTest {
         val model = AnimeDownloadQueueScreenModel(manager)
 
         model.moveToTop(model.state.value[0].downloads[0]) // d1 already first
+        advanceUntilIdle()
 
         val slot = slot<List<AnimeDownload>>()
-        verify { manager.reorderQueue(capture(slot)) }
+        coVerify { manager.reorderQueue(capture(slot)) }
         slot.captured.map { it.episode.id } shouldContainExactly listOf(1L, 2L)
     }
 
@@ -121,9 +125,10 @@ class AnimeDownloadQueueScreenModelTest {
         val model = AnimeDownloadQueueScreenModel(manager)
 
         model.moveToBottom(model.state.value[0].downloads[0]) // d1 at index 0
+        advanceUntilIdle()
 
         val slot = slot<List<AnimeDownload>>()
-        verify { manager.reorderQueue(capture(slot)) }
+        coVerify { manager.reorderQueue(capture(slot)) }
         slot.captured.map { it.episode.id } shouldContainExactly listOf(2L, 3L, 1L)
     }
 
@@ -139,9 +144,10 @@ class AnimeDownloadQueueScreenModelTest {
         val model = AnimeDownloadQueueScreenModel(manager)
 
         model.moveToTopSeries(2L) // anime2 downloads (d3, d4) to front
+        advanceUntilIdle()
 
         val slot = slot<List<AnimeDownload>>()
-        verify { manager.reorderQueue(capture(slot)) }
+        coVerify { manager.reorderQueue(capture(slot)) }
         slot.captured.map { it.episode.id } shouldContainExactly listOf(3L, 4L, 1L, 2L)
     }
 
@@ -157,9 +163,10 @@ class AnimeDownloadQueueScreenModelTest {
         val model = AnimeDownloadQueueScreenModel(manager)
 
         model.moveToBottomSeries(1L) // anime1 downloads (d1, d2) to back
+        advanceUntilIdle()
 
         val slot = slot<List<AnimeDownload>>()
-        verify { manager.reorderQueue(capture(slot)) }
+        coVerify { manager.reorderQueue(capture(slot)) }
         slot.captured.map { it.episode.id } shouldContainExactly listOf(3L, 4L, 1L, 2L)
     }
 
@@ -213,9 +220,10 @@ class AnimeDownloadQueueScreenModelTest {
         val model = AnimeDownloadQueueScreenModel(manager)
 
         model.reorderQueue(selector = { it.download.episode.id })
+        advanceUntilIdle()
 
         val slot = slot<List<AnimeDownload>>()
-        verify { manager.reorderQueue(capture(slot)) }
+        coVerify { manager.reorderQueue(capture(slot)) }
         slot.captured.map { it.episode.id } shouldContainExactly listOf(1L, 2L, 3L)
     }
 
@@ -229,9 +237,10 @@ class AnimeDownloadQueueScreenModelTest {
         val model = AnimeDownloadQueueScreenModel(manager)
 
         model.reorderQueue(selector = { it.download.episode.id }, reverse = true)
+        advanceUntilIdle()
 
         val slot = slot<List<AnimeDownload>>()
-        verify { manager.reorderQueue(capture(slot)) }
+        coVerify { manager.reorderQueue(capture(slot)) }
         slot.captured.map { it.episode.id } shouldContainExactly listOf(3L, 2L, 1L)
     }
 }

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/download/manga/MangaDownloadQueueScreenModelTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/download/manga/MangaDownloadQueueScreenModelTest.kt
@@ -5,6 +5,7 @@ import eu.kanade.tachiyomi.data.download.manga.model.MangaDownload
 import eu.kanade.tachiyomi.source.online.HttpSource
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
@@ -14,6 +15,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
@@ -90,9 +92,10 @@ class MangaDownloadQueueScreenModelTest {
         val model = MangaDownloadQueueScreenModel(manager)
 
         model.moveToTop(model.state.value[0].downloads[1]) // d2 at index 1
+        advanceUntilIdle()
 
         val slot = slot<List<MangaDownload>>()
-        verify { manager.reorderQueue(capture(slot)) }
+        coVerify { manager.reorderQueue(capture(slot)) }
         slot.captured.map { it.chapter.id } shouldContainExactly listOf(2L, 1L, 3L)
     }
 
@@ -105,9 +108,10 @@ class MangaDownloadQueueScreenModelTest {
         val model = MangaDownloadQueueScreenModel(manager)
 
         model.moveToTop(model.state.value[0].downloads[0]) // d1 already first
+        advanceUntilIdle()
 
         val slot = slot<List<MangaDownload>>()
-        verify { manager.reorderQueue(capture(slot)) }
+        coVerify { manager.reorderQueue(capture(slot)) }
         slot.captured.map { it.chapter.id } shouldContainExactly listOf(1L, 2L)
     }
 
@@ -121,9 +125,10 @@ class MangaDownloadQueueScreenModelTest {
         val model = MangaDownloadQueueScreenModel(manager)
 
         model.moveToBottom(model.state.value[0].downloads[0]) // d1 at index 0
+        advanceUntilIdle()
 
         val slot = slot<List<MangaDownload>>()
-        verify { manager.reorderQueue(capture(slot)) }
+        coVerify { manager.reorderQueue(capture(slot)) }
         slot.captured.map { it.chapter.id } shouldContainExactly listOf(2L, 3L, 1L)
     }
 
@@ -139,9 +144,10 @@ class MangaDownloadQueueScreenModelTest {
         val model = MangaDownloadQueueScreenModel(manager)
 
         model.moveToTopSeries(2L) // manga2 downloads (d3, d4) to front
+        advanceUntilIdle()
 
         val slot = slot<List<MangaDownload>>()
-        verify { manager.reorderQueue(capture(slot)) }
+        coVerify { manager.reorderQueue(capture(slot)) }
         slot.captured.map { it.chapter.id } shouldContainExactly listOf(3L, 4L, 1L, 2L)
     }
 
@@ -157,9 +163,10 @@ class MangaDownloadQueueScreenModelTest {
         val model = MangaDownloadQueueScreenModel(manager)
 
         model.moveToBottomSeries(1L) // manga1 downloads (d1, d2) to back
+        advanceUntilIdle()
 
         val slot = slot<List<MangaDownload>>()
-        verify { manager.reorderQueue(capture(slot)) }
+        coVerify { manager.reorderQueue(capture(slot)) }
         slot.captured.map { it.chapter.id } shouldContainExactly listOf(3L, 4L, 1L, 2L)
     }
 
@@ -213,9 +220,10 @@ class MangaDownloadQueueScreenModelTest {
         val model = MangaDownloadQueueScreenModel(manager)
 
         model.reorderQueue(selector = { it.download.chapter.id })
+        advanceUntilIdle()
 
         val slot = slot<List<MangaDownload>>()
-        verify { manager.reorderQueue(capture(slot)) }
+        coVerify { manager.reorderQueue(capture(slot)) }
         slot.captured.map { it.chapter.id } shouldContainExactly listOf(1L, 2L, 3L)
     }
 
@@ -229,9 +237,10 @@ class MangaDownloadQueueScreenModelTest {
         val model = MangaDownloadQueueScreenModel(manager)
 
         model.reorderQueue(selector = { it.download.chapter.id }, reverse = true)
+        advanceUntilIdle()
 
         val slot = slot<List<MangaDownload>>()
-        verify { manager.reorderQueue(capture(slot)) }
+        coVerify { manager.reorderQueue(capture(slot)) }
         slot.captured.map { it.chapter.id } shouldContainExactly listOf(3L, 2L, 1L)
     }
 }


### PR DESCRIPTION
## Ticket
- ID: R577
- Priority: P1
- Risk Tier: T2
- GitHub Issue: Closes #581

## Objective
- Prevent queue mutation races where canceled downloads can be restored by concurrent reorder/add-to-start operations.

## Scope
- Serialize reorder and add-to-start queue mutations with the existing queue mutex.
- Propagate suspend signatures through shared mutation and manager APIs.
- Update queue screen models and reader/player call paths to invoke updated suspend APIs.
- Add deterministic concurrency regression tests in shared queue mutation tests.
- Add one changelog bullet for this ticket.

## Non-goals
- No TLA+ spec additions in this ticket.
- No queue architecture redesign outside race fix scope.

## Files Changed
- Shared queue mutation core + manga/anime manager call-throughs
- Queue screen model call sites (anime/manga)
- Reader/player cleanup call sites
- Queue mutation + queue screen model tests
- `CHANGELOG.md`

## Verification
- Commands run:
  - `./gradlew :app:testStableDebugUnitTest --tests "*DownloadQueueMutationsTest*"`
  - `./gradlew :app:testStableDebugUnitTest --tests "*MangaDownloadQueueScreenModelTest*" --tests "*AnimeDownloadQueueScreenModelTest*"`
  - `./gradlew spotlessCheck`
  - `./gradlew :app:compileStableDebugKotlin`
- Results:
  - All commands passed.
- Not tested:
  - Manual runtime QA on device/emulator for queue UI interactions.

## Risk
- Medium: suspend signature propagation touches shared queue call paths.
- Mitigation: deterministic concurrency tests at mutation boundary and queue screen model tests for call behavior.

## SLO Impact
- None expected.

## Rollback
- Revert this PR commit to restore prior queue mutation behavior.

## Release Notes
- Download queue reorder/add-to-start operations are now synchronized with removals to prevent canceled items from being restored by concurrent queue mutations.

## Checklist
- [x] Naming conventions followed (use "Rayniyomi" in user-facing text, see [naming conventions](../docs/governance/naming-conventions.md))
- [x] Branch rebased on latest main and verification re-run (see [rebase policy](../docs/governance/agent-workflow.md#rebase-before-merge-policy-r45))
- [x] New coroutine scopes have documented owner and cancellation path
- [x] No new `runBlocking` on UI/main thread paths

## Definition of Done (DoD)
- [x] Acceptance criteria met and non-goals respected
- [x] Verification matrix completed (Risk Tier: T2)
- [x] Self-review completed
- [x] Rebased on latest `main` and revalidated (mandatory for merge)
- [x] Sprint board updated (branch, commit, checks, PR link)
- [x] Release notes drafted (if applicable)
