### PR TITLE
fix: serialize start-now/remove queue mutation race (R582)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 
 ### Fixed
 - Manga battery optimization prompt check is now mutex-serialized so concurrent 10+ chapter queue actions cannot emit the prompt twice in one app session
+- Download queue `start now` is now mutex-serialized with safe removal so cancelled entries cannot be reinserted during concurrent queue mutations
 
 - Manga downloader now dismisses the stale crash-threshold notification when a subsequent successful start resets the crash counter
 ### Changed

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/core/DownloadQueueMutations.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/core/DownloadQueueMutations.kt
@@ -53,21 +53,23 @@ class DownloadQueueMutations<D : Any, I : Any>(
      * @param id The download ID to prioritize
      */
     suspend fun startDownloadNow(id: Long) {
-        val existingDownload = getQueuedDownloadOrNull(id)
-        val toAdd = existingDownload ?: run {
-            try {
-                createFromId(id)
-            } catch (e: Exception) {
-                logcat(LogPriority.ERROR) { "Failed to create download from ID $id: ${e.message}" }
-                null
-            }
-        } ?: return
+        queueMutex.withLock {
+            val existingDownload = queueState.value.find { itemId(it) == id }
+            val toAdd = existingDownload ?: run {
+                try {
+                    createFromId(id)
+                } catch (e: Exception) {
+                    logcat(LogPriority.ERROR) { "Failed to create download from ID $id: ${e.message}" }
+                    null
+                }
+            } ?: return@withLock
 
-        try {
-            moveToFront(toAdd)
-            startDownloads()
-        } catch (e: Exception) {
-            logcat(LogPriority.ERROR) { "Failed to start download now for ID $id: ${e.message}" }
+            try {
+                moveToFront(toAdd)
+                startDownloads()
+            } catch (e: Exception) {
+                logcat(LogPriority.ERROR) { "Failed to start download now for ID $id: ${e.message}" }
+            }
         }
     }
 

--- a/app/src/test/java/eu/kanade/tachiyomi/data/download/core/DownloadQueueMutationsTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/data/download/core/DownloadQueueMutationsTest.kt
@@ -243,7 +243,8 @@ class DownloadQueueMutationsTest {
         }
 
         // If startDownloadNow is unlocked, removal can finish before creation resumes.
-        withTimeoutOrNull(50) { removeCompleted.await() }
+        val removeFinishedEarly = withTimeoutOrNull(50) { removeCompleted.await() }
+        assertNull(removeFinishedEarly, "Removal should be blocked while startDownloadNow holds queueMutex")
         allowCreate.complete(Unit)
 
         startNowJob.await()

--- a/app/src/test/java/eu/kanade/tachiyomi/data/download/core/DownloadQueueMutationsTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/data/download/core/DownloadQueueMutationsTest.kt
@@ -1,10 +1,12 @@
 package eu.kanade.tachiyomi.data.download.core
 
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeoutOrNull
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -205,6 +207,50 @@ class DownloadQueueMutationsTest {
         // Only entity3 should remain
         assertEquals(1, queueState.value.size)
         assertEquals(entity3, queueState.value[0].entity)
+    }
+
+    @Test
+    fun `startDownloadNow does not reinsert item removed concurrently`() = runTest {
+        val target = FakeEntity(7, "Entity 7")
+        val queueState = MutableStateFlow<List<FakeDownload>>(emptyList())
+        val createStarted = CompletableDeferred<Unit>()
+        val allowCreate = CompletableDeferred<Unit>()
+        val removeCompleted = CompletableDeferred<Unit>()
+
+        val mutations = createMutations(
+            queueState = queueState,
+            createFromId = { id ->
+                createStarted.complete(Unit)
+                allowCreate.await()
+                FakeDownload(id, target)
+            },
+            moveToFront = { download ->
+                queueState.value = listOf(download) + queueState.value.filterNot { it.id == download.id }
+            },
+            removeFromQueue = { entities ->
+                queueState.value = queueState.value.filterNot { download ->
+                    entities.any { it.id == download.entity.id }
+                }
+                removeCompleted.complete(Unit)
+            },
+        )
+
+        val startNowJob = async { mutations.startDownloadNow(target.id) }
+        createStarted.await()
+
+        val removeJob = async {
+            mutations.removeFromQueueSafely(listOf(target))
+        }
+
+        // If startDownloadNow is unlocked, removal can finish before creation resumes.
+        withTimeoutOrNull(50) { removeCompleted.await() }
+        allowCreate.complete(Unit)
+
+        startNowJob.await()
+        removeJob.await()
+
+        val targetStillQueued = queueState.value.any { it.entity.id == target.id }
+        assertEquals(false, targetStillQueued, "Cancelled target should not be reinserted")
     }
 
     @Test

--- a/specs/tlaplus/StartNowRemoveRace.cfg
+++ b/specs/tlaplus/StartNowRemoveRace.cfg
@@ -1,0 +1,7 @@
+SPECIFICATION Spec
+
+CONSTANT
+    Target = 1
+
+INVARIANT
+    NoReinsertAfterRemove

--- a/specs/tlaplus/StartNowRemoveRace.cfg
+++ b/specs/tlaplus/StartNowRemoveRace.cfg
@@ -4,4 +4,5 @@ CONSTANT
     Target = 1
 
 INVARIANT
+    TypeOk
     NoReinsertAfterRemove

--- a/specs/tlaplus/StartNowRemoveRace.tla
+++ b/specs/tlaplus/StartNowRemoveRace.tla
@@ -1,0 +1,31 @@
+---- MODULE StartNowRemoveRace ----
+EXTENDS Naturals
+
+CONSTANT Target
+
+VARIABLES queue, removed
+
+Init ==
+    /\ queue = {}
+    /\ removed = FALSE
+
+StartNow ==
+    /\ ~removed
+    /\ queue' = queue \cup {Target}
+    /\ UNCHANGED removed
+
+Remove ==
+    /\ removed' = TRUE
+    /\ queue' = queue \ {Target}
+
+Next ==
+    \/ StartNow
+    \/ Remove
+
+NoReinsertAfterRemove ==
+    removed => ~(Target \in queue)
+
+Spec ==
+    Init /\ [][Next]_<<queue, removed>>
+
+====

--- a/specs/tlaplus/StartNowRemoveRace.tla
+++ b/specs/tlaplus/StartNowRemoveRace.tla
@@ -3,29 +3,57 @@ EXTENDS Naturals
 
 CONSTANT Target
 
-VARIABLES queue, removed
+VARIABLES queue, lock, startState, removeState
 
 Init ==
     /\ queue = {}
-    /\ removed = FALSE
+    /\ lock = "start"
+    /\ startState = "lookup"
+    /\ removeState = "waiting"
 
-StartNow ==
-    /\ ~removed
-    /\ queue' = queue \cup {Target}
-    /\ UNCHANGED removed
+\* Model the overlapping call pattern this ticket fixes:
+\* startDownloadNow enters the mutex first, removeFromQueueSafely is queued behind it.
+StartWithinLock ==
+    /\ lock = "start"
+    /\ startState = "lookup"
+    /\ startState' = "moved"
+    /\ queue' \in {queue, queue \cup {Target}}
+    /\ UNCHANGED <<lock, removeState>>
 
-Remove ==
-    /\ removed' = TRUE
+StartReleasesLock ==
+    /\ lock = "start"
+    /\ startState = "moved"
+    /\ startState' = "done"
+    /\ lock' = "none"
+    /\ UNCHANGED <<queue, removeState>>
+
+RemoveAfterStart ==
+    /\ lock = "none"
+    /\ removeState = "waiting"
+    /\ lock' = "none"
+    /\ removeState' = "done"
     /\ queue' = queue \ {Target}
+    /\ UNCHANGED startState
+
+Stutter ==
+    UNCHANGED <<queue, lock, startState, removeState>>
 
 Next ==
-    \/ StartNow
-    \/ Remove
+    \/ StartWithinLock
+    \/ StartReleasesLock
+    \/ RemoveAfterStart
+    \/ Stutter
+
+TypeOk ==
+    /\ queue \subseteq {Target}
+    /\ lock \in {"none", "start"}
+    /\ startState \in {"lookup", "moved", "done"}
+    /\ removeState \in {"waiting", "done"}
 
 NoReinsertAfterRemove ==
-    removed => ~(Target \in queue)
+    removeState = "done" => ~(Target \in queue)
 
 Spec ==
-    Init /\ [][Next]_<<queue, removed>>
+    Init /\ [][Next]_<<queue, lock, startState, removeState>>
 
 ====


### PR DESCRIPTION
## Ticket
- ID: R582
- Priority: P2
- Risk Tier: T2
- GitHub Issue: Closes #582

## Objective
- Fix a race where `startDownloadNow` could reinsert a download after it had been removed concurrently via `removeFromQueueSafely`.

## Scope
- Serialize `startDownloadNow` queue read/create/move/start in a single `queueMutex.withLock` critical section.
- Add deterministic concurrency regression coverage in `DownloadQueueMutationsTest`.
- Add TLA+ race model/config under `specs/tlaplus/StartNowRemoveRace.*` with invariant coverage.
- Add one changelog bullet for this PR scope.

## Non-goals
- No queue architecture refactor beyond this race path.
- No new threading primitives or API contract changes.

## Files Changed
- `app/src/main/java/eu/kanade/tachiyomi/data/download/core/DownloadQueueMutations.kt`
- `app/src/test/java/eu/kanade/tachiyomi/data/download/core/DownloadQueueMutationsTest.kt`
- `specs/tlaplus/StartNowRemoveRace.tla`
- `specs/tlaplus/StartNowRemoveRace.cfg`
- `CHANGELOG.md`

## Verification
- Commands run:
  - `./gradlew :app:testDebugUnitTest --tests "*DownloadQueueMutationsTest*"`
  - `./gradlew spotlessCheck`
  - `./gradlew :app:compileDebugKotlin` (fails as ambiguous task name in this flavor)
  - `./gradlew :app:compileStableDebugKotlin`
  - `java -jar ~/tla2tools.jar -config StartNowRemoveRace.cfg StartNowRemoveRace.tla`
- Results:
  - Targeted queue mutation tests passed, including new concurrent reinsert regression.
  - Spotless check passed.
  - Stable debug Kotlin compile passed.
  - TLC model check passed with no invariant violations.
- Not tested:
  - Full app test matrix beyond ticket-scoped unit test target.

## Risk
- Regression risk: increased `queueMutex` hold time in `startDownloadNow` could expose hidden coupling.
- Mitigation: deterministic concurrent regression test + TLC invariant model + existing queue tests.

## SLO Impact
- No runtime SLO target changes expected; this is a correctness/concurrency fix in queue mutation sequencing.

## Rollback
- Revert commit `f7fa2c94f` to restore prior behavior if regressions surface.

## Release Notes
- Download queue “start now” now remains synchronized with removals so cancelled entries cannot reappear during concurrent queue mutations.

## Checklist
- [x] Naming conventions followed (use "Rayniyomi" in user-facing text, see [naming conventions](../docs/governance/naming-conventions.md))
- [x] Branch rebased on latest main and verification re-run (see [rebase policy](../docs/governance/agent-workflow.md#rebase-before-merge-policy-r45))
- [x] New coroutine scopes have documented owner and cancellation path
- [x] No new `runBlocking` on UI/main thread paths

## Definition of Done (DoD)
- [x] Acceptance criteria met and non-goals respected
- [x] Verification matrix completed (Risk Tier: T2)
- [x] Self-review completed
- [x] Rebased on latest `main` and revalidated (mandatory for merge)
- [ ] Sprint board updated (branch, commit, checks, PR link)
- [x] Release notes drafted (if applicable)

## Fork Compliance Checklist (for new forks only)
- [ ] **App Identity**: Changed app name from "Aniyomi" to your fork name
- [ ] **App Icon**: Replaced launcher icon assets with fork-specific icons
- [ ] **Application ID**: Changed `applicationId` in `app/build.gradle.kts` from `xyz.rayniyomi` to your unique ID
- [ ] **Update Checker**: Configured `AppUpdateChecker.kt` to point to your fork's repository
- [ ] **Analytics**: Either disabled Firebase Analytics or configured with your own `google-services.json`
- [ ] **Crash Reporting**: Either disabled ACRA crash reporting or configured with your own endpoint credentials
