### PR TITLE
fix: add anime downloader crash-reset regression coverage (R581)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Manga battery optimization prompt check is now mutex-serialized so concurrent 10+ chapter queue actions cannot emit the prompt twice in one app session
 - Download queue `start now` is now mutex-serialized with safe removal so cancelled entries cannot be reinserted during concurrent queue mutations
 - Manga delete queue removal now executes under the shared download queue mutex so stale reorder snapshots cannot resurrect deleted manga entries
+- Added regression coverage proving anime downloader crash counter reset behavior in `downloaderStart()` so retries cannot be silenced after prior crash counts
 
 - Manga downloader now dismisses the stale crash-threshold notification when a subsequent successful start resets the crash counter
 - Download queue reorder and add-to-start operations are now mutex-serialized with removals to prevent canceled items from being restored by concurrent queue mutations

--- a/app/src/test/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloadManagerTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloadManagerTest.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import tachiyomi.core.common.preference.Preference
@@ -13,17 +15,23 @@ class AnimeDownloadManagerTest {
 
     private lateinit var context: Context
     private lateinit var mockNotifier: AnimeDownloadNotifier
+    private lateinit var mockDownloader: AnimeDownloader
     private lateinit var manager: AnimeDownloadManager
+    private lateinit var crashCountPref: Preference<Int>
+    private var crashCount = 0
 
     @BeforeEach
     fun setUp() {
         context = mockk(relaxed = true)
         mockNotifier = mockk(relaxed = true)
+        mockDownloader = mockk(relaxed = true) {
+            every { start() } returns true
+        }
 
         // InMemoryPreferenceStore creates a new Preference object each call, so set() doesn't
         // persist. Use a shared mock preference that actually tracks state.
-        var crashCount = 0
-        val crashCountPref: Preference<Int> = mockk {
+        crashCount = 0
+        crashCountPref = mockk {
             every { get() } answers { crashCount }
             every { set(any()) } answers { crashCount = firstArg() }
         }
@@ -39,6 +47,7 @@ class AnimeDownloadManagerTest {
             getCategories = mockk(relaxed = true),
             sourceManager = mockk(relaxed = true),
             downloadPreferences = downloadPreferences,
+            downloaderForTesting = mockDownloader,
         )
         manager.notifier = mockNotifier
     }
@@ -71,5 +80,40 @@ class AnimeDownloadManagerTest {
         manager.incrementJobCrashCount()
 
         verify(atLeast = 2) { mockNotifier.onCrashThresholdExceeded() }
+    }
+
+    @Test
+    fun `downloaderStart resets non-zero crash count before start attempt`() {
+        crashCount = 3
+
+        val started = manager.downloaderStart()
+
+        assertEquals(true, started)
+        assertEquals(0, crashCountPref.get())
+        verify(exactly = 1) { mockDownloader.start() }
+    }
+
+    @Test
+    fun `downloaderStart leaves zero crash count unchanged`() {
+        crashCount = 0
+
+        val started = manager.downloaderStart()
+
+        assertEquals(true, started)
+        assertEquals(0, crashCountPref.get())
+        verify(exactly = 1) { mockDownloader.start() }
+    }
+
+    @Test
+    fun `downloaderStart keeps reset state when start attempt throws`() {
+        crashCount = 2
+        every { mockDownloader.start() } throws RuntimeException("start failed")
+
+        assertThrows(RuntimeException::class.java) {
+            manager.downloaderStart()
+        }
+
+        assertEquals(0, crashCountPref.get())
+        verify(exactly = 1) { mockDownloader.start() }
     }
 }


### PR DESCRIPTION
## Objective
Add explicit regression coverage for `AnimeDownloadManager.downloaderStart()` crash-counter reset semantics so ticket #585 can be closed with evidence.

## Scope
- Added focused unit tests in `AnimeDownloadManagerTest` for:
  - reset non-zero crash count to zero on `downloaderStart()`
  - start delegation invoked exactly once
  - zero crash count remains unchanged
  - reset persists even when delegated start throws
- Added exactly one `CHANGELOG.md` bullet for this PR scope.
- No production behavior changes.

## Verification
- `./gradlew :app:testStableDebugUnitTest --tests "*AnimeDownloadManagerTest*"`
- `./gradlew spotlessCheck`
- `./gradlew :app:compileStableDebugKotlin`

## Risk
T1/T2 low risk: test-only plus changelog update.

Closes #585
