### PR TITLE
test: add anime battery prompt crash-count regression coverage (R586)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Download queue `start now` is now mutex-serialized with safe removal so cancelled entries cannot be reinserted during concurrent queue mutations
 - Manga delete queue removal now executes under the shared download queue mutex so stale reorder snapshots cannot resurrect deleted manga entries
 - Added regression coverage proving anime downloader crash counter reset behavior in `downloaderStart()` so retries cannot be silenced after prior crash counts
+- Added regression coverage proving anime battery optimization prompt emission remains active for 10+ queued episodes even when crash count is non-zero
 
 - Manga downloader now dismisses the stale crash-threshold notification when a subsequent successful start resets the crash counter
 - Download queue reorder and add-to-start operations are now mutex-serialized with removals to prevent canceled items from being restored by concurrent queue mutations

--- a/app/src/test/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloadManagerBatteryPromptTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloadManagerBatteryPromptTest.kt
@@ -66,6 +66,9 @@ class AnimeDownloadManagerBatteryPromptTest {
         val fillermarkPreference = createStatefulBooleanPreference(false)
         every { downloadPreferences.downloadFillermarkedItems() } returns fillermarkPreference
 
+        val crashCountPreference = createStatefulIntPreference(0)
+        every { downloadPreferences.animeDownloadJobCrashCount() } returns crashCountPreference
+
         // Create a fully mocked AnimeDownloader without calling the real constructor
         downloader = mockk(relaxed = true) {
             every { queueState } returns MutableStateFlow(emptyList())
@@ -298,11 +301,60 @@ class AnimeDownloadManagerBatteryPromptTest {
         emittedRequests.size shouldBe 1
     }
 
+    @Test
+    fun `flow emits even when anime crash count is non-zero`() = runTest {
+        // Arrange
+        every { batteryOptimizationChecker.isOptimizationEnabled() } returns true
+
+        val crashCountPreference = createStatefulIntPreference(4)
+        every { downloadPreferences.animeDownloadJobCrashCount() } returns crashCountPreference
+
+        val anime = mockk<Anime>()
+        val episodes = createEpisodes(count = 10)
+        val emittedRequests = mutableListOf<BatteryOptimizationPromptRequest>()
+
+        manager = AnimeDownloadManager(
+            context = context,
+            storageManager = storageManager,
+            provider = provider,
+            cache = cache,
+            getCategories = getCategories,
+            sourceManager = sourceManager,
+            downloadPreferences = downloadPreferences,
+            batteryOptimizationChecker = batteryOptimizationChecker,
+            downloaderForTesting = downloader,
+            scopeForTesting = CoroutineScope(coroutineContext),
+        )
+
+        batteryPromptFlow = manager.batteryOptimizationPromptFlow
+
+        val collectorJob = async {
+            batteryPromptFlow.collect { request ->
+                emittedRequests.add(request)
+            }
+        }
+
+        manager.downloadEpisodes(anime, episodes)
+
+        advanceUntilIdle()
+        collectorJob.cancel()
+
+        emittedRequests.size shouldBe 1
+    }
+
     /**
      * Helper to create a stateful Boolean preference mock.
      * Uses the pattern from project MEMORY.md to handle InMemoryPreferenceStore limitation.
      */
     private fun createStatefulBooleanPreference(initialValue: Boolean): Preference<Boolean> {
+        var currentValue = initialValue
+        return mockk {
+            every { get() } answers { currentValue }
+            every { set(any()) } answers { currentValue = firstArg() }
+        }
+    }
+
+    private fun createStatefulIntPreference(initialValue: Int): Preference<Int> {
         var currentValue = initialValue
         return mockk {
             every { get() } answers { currentValue }


### PR DESCRIPTION
## Ticket
- ID: R586
- Priority: P2
- Risk Tier: T1
- GitHub Issue: Closes #586

## Objective
- Add regression coverage proving anime battery optimization prompt behavior is unaffected by a non-zero crash count.

## Scope
- Add a focused test in `AnimeDownloadManagerBatteryPromptTest` that sets non-zero `animeDownloadJobCrashCount`, queues 10 episodes with optimization enabled and prompt-not-shown, and asserts a single emission.
- Add one changelog bullet for this PR scope.

## Non-goals
- No production behavior refactor.
- No API changes.

## Files Changed
- `app/src/test/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloadManagerBatteryPromptTest.kt`
- `CHANGELOG.md`

## Verification
- Commands run:
  - `./gradlew :app:testDebugUnitTest --tests "*AnimeDownloadManagerBatteryPromptTest*"`
  - `./gradlew :app:testDebugUnitTest --tests "*AnimeDownloadManagerTest*"`
  - `./gradlew spotlessCheck`
  - `./gradlew :app:compileDebugKotlin` (ambiguous in this module setup)
  - `./gradlew :app:compileStableDebugKotlin` (fallback)
- Results:
  - All commands passed.
- Not tested:
  - Full app/instrumentation flows (out of scope for test-only ticket).

## Risk
- Low risk; test-only change plus changelog line.
- Mitigation: targeted regression assertion and existing anime manager tests remain green.

## SLO Impact
- None expected (no runtime production-path change).

## Rollback
- Revert this commit to remove the added regression test/changelog line.

## Release Notes
- Added regression coverage to ensure anime battery optimization prompt still emits once with 10+ queued episodes even when crash count is non-zero.

## Checklist
- [x] Naming conventions followed (use "Rayniyomi" in user-facing text, see [naming conventions](../docs/governance/naming-conventions.md))
- [x] Branch rebased on latest main and verification re-run (see [rebase policy](../docs/governance/agent-workflow.md#rebase-before-merge-policy-r45))
- [x] New coroutine scopes have documented owner and cancellation path
- [x] No new `runBlocking` on UI/main thread paths

## Definition of Done (DoD)
- [x] Acceptance criteria met and non-goals respected
- [x] Verification matrix completed (Risk Tier: T1)
- [x] Self-review completed
- [x] Rebased on latest `main` and revalidated (mandatory for merge)
- [ ] Sprint board updated (branch, commit, checks, PR link)
- [x] Release notes drafted (if applicable)

## Fork Compliance Checklist (for new forks only)
If you are creating a new fork of this project, ensure the following:
- [ ] **App Identity**: Changed app name from "Aniyomi" to your fork name
- [ ] **App Icon**: Replaced launcher icon assets with fork-specific icons
- [ ] **Application ID**: Changed `applicationId` in `app/build.gradle.kts` from `xyz.rayniyomi` to your unique ID
- [ ] **Update Checker**: Configured `AppUpdateChecker.kt` to point to your fork's repository
- [ ] **Analytics**: Either disabled Firebase Analytics or configured with your own `google-services.json`
- [ ] **Crash Reporting**: Either disabled ACRA crash reporting or configured with your own endpoint credentials
