### PR TITLE
fix: harden add-to-start callback lock safety (R583)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 
 - Manga downloader now dismisses the stale crash-threshold notification when a subsequent successful start resets the crash counter
 - Download queue reorder and add-to-start operations are now mutex-serialized with removals to prevent canceled items from being restored by concurrent queue mutations
+- Download queue add-to-start now runs downloader start callbacks outside the queue mutex to prevent callback re-entrancy deadlocks while preserving queue mutation serialization
 ### Changed
 
 ### CI

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/core/DownloadQueueMutations.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/core/DownloadQueueMutations.kt
@@ -104,14 +104,20 @@ class DownloadQueueMutations<D : Any, I : Any>(
      */
     suspend fun addDownloadsToStart(downloads: List<D>, startIfNeeded: () -> Unit) {
         if (downloads.isEmpty()) return
-        queueMutex.withLock {
-            try {
+        try {
+            queueMutex.withLock {
                 addToStart(downloads)
-                startIfNeeded()
-            } catch (e: Exception) {
-                logcat(LogPriority.ERROR) { "Failed to add downloads to start: ${e.message}" }
-                throw e
             }
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR) { "Failed to add downloads to start: ${e.message}" }
+            throw e
+        }
+
+        try {
+            startIfNeeded()
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR) { "Failed to start downloader after add-to-start: ${e.message}" }
+            throw e
         }
     }
 

--- a/app/src/test/java/eu/kanade/tachiyomi/data/download/core/DownloadQueueMutationsTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/data/download/core/DownloadQueueMutationsTest.kt
@@ -3,10 +3,12 @@ package eu.kanade.tachiyomi.data.download.core
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeoutOrNull
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -337,6 +339,38 @@ class DownloadQueueMutationsTest {
         assertEquals(1, added.size)
         assertEquals(downloads, added[0])
         assertTrue(started, "startIfNeeded should be called")
+    }
+
+    @Test
+    fun `addDownloadsToStart callback can safely run nested queue mutation`() = runTest {
+        val queueState = MutableStateFlow(
+            listOf(
+                FakeDownload(1, FakeEntity(1, "Entity 1")),
+                FakeDownload(2, FakeEntity(2, "Entity 2")),
+            ),
+        )
+        val mutations = createMutations(
+            queueState = queueState,
+            addToStart = { downloads ->
+                queueState.value = downloads + queueState.value
+            },
+            updateQueue = { reordered ->
+                queueState.value = reordered
+            },
+        )
+
+        val added = FakeDownload(3, FakeEntity(3, "Entity 3"))
+        val completed = withTimeoutOrNull(500) {
+            mutations.addDownloadsToStart(listOf(added)) {
+                runBlocking {
+                    mutations.reorderQueue(queueState.value)
+                }
+            }
+            Unit
+        }
+
+        assertNotNull(completed, "Nested queue mutation in callback should not deadlock")
+        assertEquals(listOf(3L, 1L, 2L), queueState.value.map { it.id })
     }
 
     @Test


### PR DESCRIPTION
## Objective
Harden queue mutation race handling for `R583/#587` by removing callback re-entrancy risk in `addDownloadsToStart` while preserving existing serialized queue mutation behavior.

## Scope
- move `startIfNeeded` invocation in `DownloadQueueMutations.addDownloadsToStart()` to execute after the mutex-protected queue mutation
- add deterministic regression test proving nested queue mutation from callback does not deadlock
- add one changelog bullet for this PR scope
- no user-facing API/settings/UI changes

## Verification
- `./gradlew :app:testStableDebugUnitTest --tests "*DownloadQueueMutationsTest*"`
- `./gradlew :app:testStableDebugUnitTest --tests "*AnimeDownloadQueueScreenModelTest*"`
- `./gradlew :app:testStableDebugUnitTest --tests "*MangaDownloadQueueScreenModelTest*"`
- `./gradlew :app:compileStableDebugKotlin`
- `./gradlew spotlessCheck`
- pre-push hook passed (`spotlessCheck` + flavored debug compile)

## Risk
- Risk tier: T2
- Main risk is behavioral drift in downloader start triggering. Mitigation: callback still executes exactly once after successful add-to-start, and existing + new regression tests validate queue integrity and callback path safety.

## Deferred Follow-ups
- #658
- #659

Closes #587
