### PR TITLE
fix: serialize anime delete queue removal under mutex (R586)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Manga downloader now dismisses the stale crash-threshold notification when a subsequent successful start resets the crash counter
 - Download queue reorder and add-to-start operations are now mutex-serialized with removals to prevent canceled items from being restored by concurrent queue mutations
 - Download queue add-to-start now runs downloader start callbacks outside the queue mutex to prevent callback re-entrancy deadlocks while preserving queue mutation serialization
+- R586/#590: Anime `deleteAnime(removeQueued=true)` queue removal is now mutex-serialized so stale reorder snapshots cannot resurrect deleted anime entries
 ### Changed
 
 ### CI

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloadManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloadManager.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import logcat.LogPriority
 import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.core.common.util.system.logcat
@@ -380,7 +381,9 @@ class AnimeDownloadManager(
      */
     fun deleteAnime(anime: Anime, source: AnimeSource, removeQueued: Boolean = true) {
         scope.launch {
-            if (removeQueued) downloader.removeFromQueue(anime)
+            if (removeQueued) {
+                removeQueuedAnimeFromQueue(anime)
+            }
             provider.findAnimeDir(anime.title, source)?.delete()
             cache.removeAnime(anime)
             // Delete source directory if empty
@@ -389,6 +392,12 @@ class AnimeDownloadManager(
                 sourceDir.delete()
                 cache.removeSource(source)
             }
+        }
+    }
+
+    private suspend fun removeQueuedAnimeFromQueue(anime: Anime) {
+        queueMutex.withLock {
+            downloader.removeFromQueue(anime)
         }
     }
 

--- a/app/src/test/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloadManagerTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloadManagerTest.kt
@@ -1,15 +1,26 @@
 package eu.kanade.tachiyomi.data.download.anime
 
 import android.content.Context
+import eu.kanade.tachiyomi.animesource.online.AnimeHttpSource
+import eu.kanade.tachiyomi.data.download.anime.model.AnimeDownload
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeoutOrNull
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import tachiyomi.core.common.preference.Preference
 import tachiyomi.domain.download.service.DownloadPreferences
+import tachiyomi.domain.entries.anime.model.Anime
+import tachiyomi.domain.items.episode.model.Episode
 
 class AnimeDownloadManagerTest {
 
@@ -115,5 +126,159 @@ class AnimeDownloadManagerTest {
 
         assertEquals(0, crashCountPref.get())
         verify(exactly = 1) { mockDownloader.start() }
+    }
+
+    @Test
+    fun `deleteAnime removeQueued serializes with reorder and prevents stale resurrection`() = runTest {
+        val targetAnime = Anime.create().copy(id = 1L, source = 100L, title = "Target")
+        val otherAnime = Anime.create().copy(id = 2L, source = 100L, title = "Other")
+        val source = mockk<AnimeHttpSource>(relaxed = true)
+
+        val targetDownload = AnimeDownload(
+            source = source,
+            anime = targetAnime,
+            episode = Episode.create().copy(id = 11L, animeId = targetAnime.id, name = "T"),
+        )
+        val otherDownload = AnimeDownload(
+            source = source,
+            anime = otherAnime,
+            episode = Episode.create().copy(id = 22L, animeId = otherAnime.id, name = "O"),
+        )
+
+        val queueState = MutableStateFlow(listOf(targetDownload, otherDownload))
+        val removeEntered = CompletableDeferred<Unit>()
+        val allowRemove = CompletableDeferred<Unit>()
+
+        every { mockDownloader.queueState } returns queueState
+        every { mockDownloader.updateQueue(any()) } answers {
+            queueState.value = firstArg()
+        }
+        every { mockDownloader.removeFromQueue(any<Anime>()) } answers {
+            val anime = firstArg<Anime>()
+            if (anime.id == targetAnime.id) {
+                removeEntered.complete(Unit)
+                runBlocking { allowRemove.await() }
+            }
+            queueState.value = queueState.value.filterNot { it.anime.id == anime.id }
+        }
+
+        val localManager = AnimeDownloadManager(
+            context = context,
+            storageManager = mockk(relaxed = true),
+            provider = mockk(relaxed = true) {
+                every { findAnimeDir(any(), any()) } returns null
+                every { findSourceDir(any()) } returns null
+            },
+            cache = mockk(relaxed = true),
+            getCategories = mockk(relaxed = true),
+            sourceManager = mockk(relaxed = true),
+            downloadPreferences = mockk(relaxed = true),
+            downloaderForTesting = mockDownloader,
+        )
+
+        try {
+            val staleSnapshot = listOf(targetDownload, otherDownload)
+            localManager.deleteAnime(targetAnime, source, removeQueued = true)
+            removeEntered.await()
+
+            val reorderJob = async {
+                localManager.reorderQueue(staleSnapshot)
+            }
+
+            val reorderFinishedEarly = withTimeoutOrNull(50) { reorderJob.await() }
+            assertNull(reorderFinishedEarly, "reorderQueue should block while delete holds queueMutex")
+
+            allowRemove.complete(Unit)
+            reorderJob.await()
+
+            val queuedAnimeIds = queueState.value.map { it.anime.id }.toSet()
+            assertEquals(setOf(otherAnime.id), queuedAnimeIds)
+        } finally {
+            localManager.close()
+        }
+    }
+
+    @Test
+    fun `deleteAnime with removeQueued false does not touch queue`() = runTest {
+        val anime = Anime.create().copy(id = 1L, source = 100L, title = "Target")
+        val source = mockk<AnimeHttpSource>(relaxed = true)
+        val deleteEntered = CompletableDeferred<Unit>()
+        every { mockDownloader.removeFromQueue(any<Anime>()) } answers {}
+
+        val localManager = AnimeDownloadManager(
+            context = context,
+            storageManager = mockk(relaxed = true),
+            provider = mockk(relaxed = true) {
+                every { findAnimeDir(any(), any()) } answers {
+                    deleteEntered.complete(Unit)
+                    null
+                }
+                every { findSourceDir(any()) } returns null
+            },
+            cache = mockk(relaxed = true),
+            getCategories = mockk(relaxed = true),
+            sourceManager = mockk(relaxed = true),
+            downloadPreferences = mockk(relaxed = true),
+            downloaderForTesting = mockDownloader,
+        )
+
+        try {
+            localManager.deleteAnime(anime, source, removeQueued = false)
+            deleteEntered.await()
+            verify(exactly = 0) { mockDownloader.removeFromQueue(any<Anime>()) }
+        } finally {
+            localManager.close()
+        }
+    }
+
+    @Test
+    fun `deleteAnime queue removal failure does not deadlock subsequent reorder`() = runTest {
+        val anime = Anime.create().copy(id = 1L, source = 100L, title = "Target")
+        val source = mockk<AnimeHttpSource>(relaxed = true)
+        val removeAttempted = CompletableDeferred<Unit>()
+        val queueState = MutableStateFlow(
+            listOf(
+                AnimeDownload(
+                    source = source,
+                    anime = anime,
+                    episode = Episode.create().copy(id = 11L, animeId = anime.id, name = "T"),
+                ),
+            ),
+        )
+
+        every { mockDownloader.queueState } returns queueState
+        every { mockDownloader.updateQueue(any()) } answers {
+            queueState.value = firstArg()
+        }
+        every { mockDownloader.removeFromQueue(any<Anime>()) } answers {
+            removeAttempted.complete(Unit)
+            throw RuntimeException("remove failed")
+        }
+
+        val localManager = AnimeDownloadManager(
+            context = context,
+            storageManager = mockk(relaxed = true),
+            provider = mockk(relaxed = true) {
+                every { findAnimeDir(any(), any()) } returns null
+                every { findSourceDir(any()) } returns null
+            },
+            cache = mockk(relaxed = true),
+            getCategories = mockk(relaxed = true),
+            sourceManager = mockk(relaxed = true),
+            downloadPreferences = mockk(relaxed = true),
+            downloaderForTesting = mockDownloader,
+        )
+
+        try {
+            localManager.deleteAnime(anime, source, removeQueued = true)
+            removeAttempted.await()
+            val reorderCompleted = withTimeoutOrNull(500) {
+                localManager.reorderQueue(queueState.value)
+                Unit
+            }
+            assertEquals(Unit, reorderCompleted, "reorderQueue should not deadlock after delete failure")
+        } finally {
+            localManager.close()
+        }
     }
 }


### PR DESCRIPTION
## Objective
Fix `R586/#590` by serializing anime `deleteAnime(removeQueued=true)` queue removal under the existing queue mutex so stale reorder snapshots cannot restore deleted anime entries.

## Scope
- route `deleteAnime(removeQueued=true)` through a private suspend helper that executes `downloader.removeFromQueue(anime)` inside `queueMutex.withLock`
- keep lock boundary limited to queue removal only; file/cache/source cleanup remains outside lock
- add deterministic regression tests for delete+reorder stale-resurrection race, `removeQueued=false` bypass, and queue-removal failure non-deadlock behavior
- add one changelog bullet tagged with `R586/#590`

## Verification
- `./gradlew :app:testStableDebugUnitTest --tests "*AnimeDownloadManagerTest*"`
- `./gradlew :app:testStableDebugUnitTest --tests "*MangaDownloadManagerTest*"`
- `./gradlew spotlessCheck`
- `./gradlew :app:compileStableDebugKotlin`
- pre-push hook passed (`spotlessCheck` + flavored compile)

## Risk
- Risk tier: T2
- Main risk is accidental behavior drift in delete flow ordering. Mitigation: lock scope is minimal and tests assert no stale resurrection, no extra queue removal for `removeQueued=false`, and no post-failure deadlock.

Closes #590
