### PR TITLE
fix: serialize extension install ownership to prevent duplicate downloads (R592)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Download queue reorder and add-to-start operations are now mutex-serialized with removals to prevent canceled items from being restored by concurrent queue mutations
 - Download queue add-to-start now runs downloader start callbacks outside the queue mutex to prevent callback re-entrancy deadlocks while preserving queue mutation serialization
 - R586/#590: Anime `deleteAnime(removeQueued=true)` queue removal is now mutex-serialized so stale reorder snapshots cannot resurrect deleted anime entries
+- Extension installers now serialize per-package download slot ownership so concurrent install requests cannot spawn orphaned duplicate downloads
 ### Changed
 
 ### CI

--- a/app/src/main/java/eu/kanade/tachiyomi/extension/anime/util/AnimeExtensionInstaller.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/extension/anime/util/AnimeExtensionInstaller.kt
@@ -15,11 +15,11 @@ import eu.kanade.tachiyomi.extension.InstallStep
 import eu.kanade.tachiyomi.extension.anime.AnimeExtensionManager
 import eu.kanade.tachiyomi.extension.anime.installer.InstallerAnime
 import eu.kanade.tachiyomi.extension.anime.model.AnimeExtension
+import eu.kanade.tachiyomi.extension.util.ExtensionDownloadRegistry
 import eu.kanade.tachiyomi.util.storage.getUriCompat
 import eu.kanade.tachiyomi.util.system.isPackageInstalled
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.mapNotNull
@@ -55,9 +55,7 @@ internal class AnimeExtensionInstaller(private val context: Context) {
      * The currently requested downloads, with the package name (unique id) as key, and the id
      * returned by the download manager.
      */
-    private val activeDownloads = hashMapOf<String, Long>()
-
-    private val downloadsStateFlows = hashMapOf<Long, MutableStateFlow<InstallStep>>()
+    private val downloadRegistry = ExtensionDownloadRegistry()
 
     private val extensionInstaller = Injekt.get<BasePreferences>().extensionInstaller()
 
@@ -71,30 +69,24 @@ internal class AnimeExtensionInstaller(private val context: Context) {
     fun downloadAndInstall(url: String, extension: AnimeExtension): Flow<InstallStep> {
         val pkgName = extension.pkgName
 
-        val oldDownload = activeDownloads[pkgName]
-        if (oldDownload != null) {
-            deleteDownload(pkgName)
-        }
-
-        // Register the receiver after removing (and unregistering) the previous download
         downloadReceiver.register()
 
-        val downloadUri = url.toUri()
-        val request = DownloadManager.Request(downloadUri)
-            .setTitle(extension.name)
-            .setMimeType(APK_MIME)
-            .setDestinationInExternalFilesDir(
-                context,
-                Environment.DIRECTORY_DOWNLOADS,
-                downloadUri.lastPathSegment,
-            )
-            .setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
+        val activeDownload = downloadRegistry.getOrCreate(pkgName) {
+            val downloadUri = url.toUri()
+            val request = DownloadManager.Request(downloadUri)
+                .setTitle(extension.name)
+                .setMimeType(APK_MIME)
+                .setDestinationInExternalFilesDir(
+                    context,
+                    Environment.DIRECTORY_DOWNLOADS,
+                    downloadUri.lastPathSegment,
+                )
+                .setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
 
-        val id = downloadManager.enqueue(request)
-        activeDownloads[pkgName] = id
-
-        val downloadStateFlow = MutableStateFlow(InstallStep.Pending)
-        downloadsStateFlows[id] = downloadStateFlow
+            downloadManager.enqueue(request)
+        }
+        val id = activeDownload.downloadId
+        val downloadStateFlow = activeDownload.stateFlow
 
         // Poll download status
         val pollStatusFlow = downloadStatusFlow(id).mapNotNull { downloadStatus ->
@@ -114,7 +106,7 @@ internal class AnimeExtensionInstaller(private val context: Context) {
             // Always notify on main thread
             withUIContext {
                 // Always remove the download when unsubscribed
-                deleteDownload(pkgName)
+                deleteDownload(pkgName, expectedId = id)
             }
         }
     }
@@ -208,9 +200,13 @@ internal class AnimeExtensionInstaller(private val context: Context) {
      * Cancels extension install and remove from download manager and installer.
      */
     fun cancelInstall(pkgName: String) {
-        val downloadId = activeDownloads.remove(pkgName) ?: return
+        val activeDownload = downloadRegistry.removeCurrent(pkgName) ?: return
+        val downloadId = activeDownload.downloadId
         downloadManager.remove(downloadId)
         InstallerAnime.cancelInstallQueue(context, downloadId)
+        if (downloadRegistry.isEmpty()) {
+            downloadReceiver.unregister()
+        }
     }
 
     /**
@@ -237,7 +233,7 @@ internal class AnimeExtensionInstaller(private val context: Context) {
      * @param step New install step.
      */
     fun updateInstallStep(downloadId: Long, step: InstallStep) {
-        downloadsStateFlows[downloadId]?.let { it.value = step }
+        downloadRegistry.updateInstallStep(downloadId, step)
     }
 
     /**
@@ -245,13 +241,10 @@ internal class AnimeExtensionInstaller(private val context: Context) {
      *
      * @param pkgName The package name of the download to delete.
      */
-    private fun deleteDownload(pkgName: String) {
-        val downloadId = activeDownloads.remove(pkgName)
-        if (downloadId != null) {
-            downloadManager.remove(downloadId)
-            downloadsStateFlows.remove(downloadId)
-        }
-        if (activeDownloads.isEmpty()) {
+    private fun deleteDownload(pkgName: String, expectedId: Long? = null) {
+        val removed = downloadRegistry.removeIfMatch(pkgName, expectedId) ?: return
+        downloadManager.remove(removed.downloadId)
+        if (downloadRegistry.isEmpty()) {
             downloadReceiver.unregister()
         }
     }
@@ -295,7 +288,7 @@ internal class AnimeExtensionInstaller(private val context: Context) {
             val id = intent?.getLongExtra(DownloadManager.EXTRA_DOWNLOAD_ID, 0) ?: return
 
             // Avoid events for downloads we didn't request
-            if (id !in activeDownloads.values) return
+            if (!downloadRegistry.containsDownloadId(id)) return
 
             val uri = downloadManager.getUriForDownloadedFile(id)
 

--- a/app/src/main/java/eu/kanade/tachiyomi/extension/manga/util/MangaExtensionInstaller.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/extension/manga/util/MangaExtensionInstaller.kt
@@ -15,11 +15,11 @@ import eu.kanade.tachiyomi.extension.InstallStep
 import eu.kanade.tachiyomi.extension.manga.MangaExtensionManager
 import eu.kanade.tachiyomi.extension.manga.installer.InstallerManga
 import eu.kanade.tachiyomi.extension.manga.model.MangaExtension
+import eu.kanade.tachiyomi.extension.util.ExtensionDownloadRegistry
 import eu.kanade.tachiyomi.util.storage.getUriCompat
 import eu.kanade.tachiyomi.util.system.isPackageInstalled
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.mapNotNull
@@ -55,9 +55,7 @@ internal class MangaExtensionInstaller(private val context: Context) {
      * The currently requested downloads, with the package name (unique id) as key, and the id
      * returned by the download manager.
      */
-    private val activeDownloads = hashMapOf<String, Long>()
-
-    private val downloadsStateFlows = hashMapOf<Long, MutableStateFlow<InstallStep>>()
+    private val downloadRegistry = ExtensionDownloadRegistry()
 
     private val extensionInstaller = Injekt.get<BasePreferences>().extensionInstaller()
 
@@ -71,30 +69,24 @@ internal class MangaExtensionInstaller(private val context: Context) {
     fun downloadAndInstall(url: String, extension: MangaExtension): Flow<InstallStep> {
         val pkgName = extension.pkgName
 
-        val oldDownload = activeDownloads[pkgName]
-        if (oldDownload != null) {
-            deleteDownload(pkgName)
-        }
-
-        // Register the receiver after removing (and unregistering) the previous download
         downloadReceiver.register()
 
-        val downloadUri = url.toUri()
-        val request = DownloadManager.Request(downloadUri)
-            .setTitle(extension.name)
-            .setMimeType(APK_MIME)
-            .setDestinationInExternalFilesDir(
-                context,
-                Environment.DIRECTORY_DOWNLOADS,
-                downloadUri.lastPathSegment,
-            )
-            .setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
+        val activeDownload = downloadRegistry.getOrCreate(pkgName) {
+            val downloadUri = url.toUri()
+            val request = DownloadManager.Request(downloadUri)
+                .setTitle(extension.name)
+                .setMimeType(APK_MIME)
+                .setDestinationInExternalFilesDir(
+                    context,
+                    Environment.DIRECTORY_DOWNLOADS,
+                    downloadUri.lastPathSegment,
+                )
+                .setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
 
-        val id = downloadManager.enqueue(request)
-        activeDownloads[pkgName] = id
-
-        val downloadStateFlow = MutableStateFlow(InstallStep.Pending)
-        downloadsStateFlows[id] = downloadStateFlow
+            downloadManager.enqueue(request)
+        }
+        val id = activeDownload.downloadId
+        val downloadStateFlow = activeDownload.stateFlow
 
         // Poll download status
         val pollStatusFlow = downloadStatusFlow(id).mapNotNull { downloadStatus ->
@@ -114,7 +106,7 @@ internal class MangaExtensionInstaller(private val context: Context) {
             // Always notify on main thread
             withUIContext {
                 // Always remove the download when unsubscribed
-                deleteDownload(pkgName)
+                deleteDownload(pkgName, expectedId = id)
             }
         }
     }
@@ -208,9 +200,13 @@ internal class MangaExtensionInstaller(private val context: Context) {
      * Cancels extension install and remove from download manager and installer.
      */
     fun cancelInstall(pkgName: String) {
-        val downloadId = activeDownloads.remove(pkgName) ?: return
+        val activeDownload = downloadRegistry.removeCurrent(pkgName) ?: return
+        val downloadId = activeDownload.downloadId
         downloadManager.remove(downloadId)
         InstallerManga.cancelInstallQueue(context, downloadId)
+        if (downloadRegistry.isEmpty()) {
+            downloadReceiver.unregister()
+        }
     }
 
     /**
@@ -237,7 +233,7 @@ internal class MangaExtensionInstaller(private val context: Context) {
      * @param step New install step.
      */
     fun updateInstallStep(downloadId: Long, step: InstallStep) {
-        downloadsStateFlows[downloadId]?.let { it.value = step }
+        downloadRegistry.updateInstallStep(downloadId, step)
     }
 
     /**
@@ -245,13 +241,10 @@ internal class MangaExtensionInstaller(private val context: Context) {
      *
      * @param pkgName The package name of the download to delete.
      */
-    private fun deleteDownload(pkgName: String) {
-        val downloadId = activeDownloads.remove(pkgName)
-        if (downloadId != null) {
-            downloadManager.remove(downloadId)
-            downloadsStateFlows.remove(downloadId)
-        }
-        if (activeDownloads.isEmpty()) {
+    private fun deleteDownload(pkgName: String, expectedId: Long? = null) {
+        val removed = downloadRegistry.removeIfMatch(pkgName, expectedId) ?: return
+        downloadManager.remove(removed.downloadId)
+        if (downloadRegistry.isEmpty()) {
             downloadReceiver.unregister()
         }
     }
@@ -295,7 +288,7 @@ internal class MangaExtensionInstaller(private val context: Context) {
             val id = intent?.getLongExtra(DownloadManager.EXTRA_DOWNLOAD_ID, 0) ?: return
 
             // Avoid events for downloads we didn't request
-            if (id !in activeDownloads.values) return
+            if (!downloadRegistry.containsDownloadId(id)) return
 
             val uri = downloadManager.getUriForDownloadedFile(id)
 

--- a/app/src/main/java/eu/kanade/tachiyomi/extension/util/ExtensionDownloadRegistry.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/extension/util/ExtensionDownloadRegistry.kt
@@ -1,0 +1,61 @@
+package eu.kanade.tachiyomi.extension.util
+
+import eu.kanade.tachiyomi.extension.InstallStep
+import kotlinx.coroutines.flow.MutableStateFlow
+import java.util.concurrent.ConcurrentHashMap
+
+internal class ExtensionDownloadRegistry {
+
+    data class ActiveDownload(
+        val downloadId: Long,
+        val stateFlow: MutableStateFlow<InstallStep>,
+    )
+
+    private val packageDownloads = ConcurrentHashMap<String, ActiveDownload>()
+    private val downloadsStateFlows = ConcurrentHashMap<Long, MutableStateFlow<InstallStep>>()
+
+    fun getOrCreate(pkgName: String, createDownload: () -> Long): ActiveDownload {
+        return packageDownloads.compute(pkgName) { _, current ->
+            current ?: run {
+                val id = createDownload()
+                val stateFlow = MutableStateFlow(InstallStep.Pending)
+                val activeDownload = ActiveDownload(id, stateFlow)
+                downloadsStateFlows[id] = stateFlow
+                activeDownload
+            }
+        }!!
+    }
+
+    fun updateInstallStep(downloadId: Long, step: InstallStep) {
+        downloadsStateFlows[downloadId]?.value = step
+    }
+
+    fun containsDownloadId(downloadId: Long): Boolean {
+        return downloadsStateFlows.containsKey(downloadId)
+    }
+
+    fun removeCurrent(pkgName: String): ActiveDownload? {
+        return removeIfMatch(pkgName, expectedId = null)
+    }
+
+    fun removeIfMatch(pkgName: String, expectedId: Long?): ActiveDownload? {
+        var removed: ActiveDownload? = null
+        packageDownloads.compute(pkgName) { _, current ->
+            if (current == null) {
+                null
+            } else if (expectedId != null && current.downloadId != expectedId) {
+                current
+            } else {
+                removed = current
+                null
+            }
+        }
+
+        removed?.let { downloadsStateFlows.remove(it.downloadId) }
+        return removed
+    }
+
+    fun isEmpty(): Boolean {
+        return packageDownloads.isEmpty()
+    }
+}

--- a/app/src/test/java/eu/kanade/tachiyomi/extension/util/ExtensionDownloadRegistryTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/extension/util/ExtensionDownloadRegistryTest.kt
@@ -1,0 +1,74 @@
+package eu.kanade.tachiyomi.extension.util
+
+import eu.kanade.tachiyomi.extension.InstallStep
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
+
+class ExtensionDownloadRegistryTest {
+
+    @Test
+    fun `getOrCreate starts download once for concurrent same package calls`() = runTest {
+        val registry = ExtensionDownloadRegistry()
+        val starts = AtomicInteger(0)
+        val ids = AtomicLong(100)
+
+        val jobs = List(20) {
+            async {
+                registry.getOrCreate("pkg.test") {
+                    starts.incrementAndGet()
+                    ids.incrementAndGet()
+                }
+            }
+        }
+
+        val results = jobs.awaitAll()
+        val firstId = results.first().downloadId
+
+        assertEquals(1, starts.get(), "Only one download should be created for a package")
+        assertTrue(results.all { it.downloadId == firstId }, "All callers should share same active download")
+        assertTrue(registry.containsDownloadId(firstId))
+    }
+
+    @Test
+    fun `removeIfMatch does not remove when expected id mismatches`() {
+        val registry = ExtensionDownloadRegistry()
+        val active = registry.getOrCreate("pkg.test") { 101L }
+
+        val removed = registry.removeIfMatch("pkg.test", expectedId = 999L)
+
+        assertEquals(null, removed)
+        assertTrue(registry.containsDownloadId(active.downloadId))
+        assertFalse(registry.isEmpty())
+    }
+
+    @Test
+    fun `removeIfMatch removes when expected id matches`() {
+        val registry = ExtensionDownloadRegistry()
+        val active = registry.getOrCreate("pkg.test") { 101L }
+
+        val removed = registry.removeIfMatch("pkg.test", expectedId = active.downloadId)
+
+        assertNotNull(removed)
+        assertEquals(active.downloadId, removed?.downloadId)
+        assertFalse(registry.containsDownloadId(active.downloadId))
+        assertTrue(registry.isEmpty())
+    }
+
+    @Test
+    fun `updateInstallStep updates flow value for active id`() {
+        val registry = ExtensionDownloadRegistry()
+        val active = registry.getOrCreate("pkg.test") { 101L }
+
+        registry.updateInstallStep(active.downloadId, InstallStep.Downloading)
+
+        assertEquals(InstallStep.Downloading, active.stateFlow.value)
+    }
+}

--- a/specs/tlaplus/ExtensionDuplicateInstall.cfg
+++ b/specs/tlaplus/ExtensionDuplicateInstall.cfg
@@ -1,0 +1,8 @@
+SPECIFICATION SpecFixed
+
+INVARIANT AtMostOneActiveDownloadPerPackage
+
+CHECK_DEADLOCK FALSE
+
+CONSTANTS
+  PACKAGE = "pkg.test"

--- a/specs/tlaplus/ExtensionDuplicateInstall.tla
+++ b/specs/tlaplus/ExtensionDuplicateInstall.tla
@@ -1,0 +1,80 @@
+---- MODULE ExtensionDuplicateInstall ----
+EXTENDS Naturals, TLC
+
+CONSTANT PACKAGE
+
+VARIABLES mapEntry, dl1Running, dl2Running, c1State, c2State
+
+Init ==
+  /\ mapEntry = "none"
+  /\ dl1Running = FALSE
+  /\ dl2Running = FALSE
+  /\ c1State = "idle"
+  /\ c2State = "idle"
+
+\* Old racy behavior model:
+\* both callers can observe empty map and both enqueue.
+C1_Read ==
+  /\ c1State = "idle"
+  /\ c1State' = "read"
+  /\ UNCHANGED << mapEntry, dl1Running, dl2Running, c2State >>
+
+C2_Read ==
+  /\ c2State = "idle"
+  /\ c2State' = "read"
+  /\ UNCHANGED << mapEntry, dl1Running, dl2Running, c1State >>
+
+C1_Enqueue ==
+  /\ c1State = "read"
+  /\ dl1Running' = TRUE
+  /\ mapEntry' = "dl1"
+  /\ c1State' = "done"
+  /\ UNCHANGED << dl2Running, c2State >>
+
+C2_Enqueue_OldRace ==
+  /\ c2State = "read"
+  /\ dl2Running' = TRUE
+  /\ mapEntry' = "dl2"
+  /\ c2State' = "done"
+  /\ UNCHANGED << dl1Running, c1State >>
+
+\* Fixed behavior model: second caller reuses existing active download
+\* and does not enqueue a duplicate.
+C2_Reuse_Existing ==
+  /\ c2State = "read"
+  /\ mapEntry # "none"
+  /\ c2State' = "done"
+  /\ UNCHANGED << mapEntry, dl1Running, dl2Running, c1State >>
+
+\* Environment step: canceled/replaced download no longer running.
+StopDl1 ==
+  /\ dl1Running
+  /\ dl1Running' = FALSE
+  /\ UNCHANGED << mapEntry, dl2Running, c1State, c2State >>
+
+NextOld ==
+  \/ C1_Read
+  \/ C2_Read
+  \/ C1_Enqueue
+  \/ C2_Enqueue_OldRace
+  \/ StopDl1
+
+NextFixed ==
+  \/ C1_Read
+  \/ C2_Read
+  \/ C1_Enqueue
+  \/ C2_Reuse_Existing
+  \/ StopDl1
+
+AtMostOneActiveDownloadPerPackage ==
+  ~(dl1Running /\ dl2Running)
+
+SpecOld ==
+  Init /\ [][NextOld]_<< mapEntry, dl1Running, dl2Running, c1State, c2State >>
+
+SpecFixed ==
+  Init /\ [][NextFixed]_<< mapEntry, dl1Running, dl2Running, c1State, c2State >>
+
+THEOREM SpecFixed => []AtMostOneActiveDownloadPerPackage
+
+=============================================================================


### PR DESCRIPTION
## Ticket
- ID: R592
- Priority: P1
- Risk Tier: T2
- GitHub Issue: Closes #592

## Objective
- Prevent duplicate/orphaned extension downloads when concurrent install requests target the same package.

## Scope
- Add a shared concurrent extension download registry.
- Route manga/anime installers through the registry for per-package ownership and guarded cleanup.
- Add deterministic unit tests for registry concurrency behavior.
- Add TLA+ spec/config modeling duplicate-install race prevention.
- Add one changelog bullet.

## Non-goals
- No functional changes to extension installation UX beyond race prevention.
- No unrelated download manager refactors.

## Files Changed
- `app/src/main/java/eu/kanade/tachiyomi/extension/util/ExtensionDownloadRegistry.kt`
- `app/src/main/java/eu/kanade/tachiyomi/extension/manga/util/MangaExtensionInstaller.kt`
- `app/src/main/java/eu/kanade/tachiyomi/extension/anime/util/AnimeExtensionInstaller.kt`
- `app/src/test/java/eu/kanade/tachiyomi/extension/util/ExtensionDownloadRegistryTest.kt`
- `specs/tlaplus/ExtensionDuplicateInstall.tla`
- `specs/tlaplus/ExtensionDuplicateInstall.cfg`
- `CHANGELOG.md`

## Verification
- Commands run:
  - `./gradlew :app:testDebugUnitTest --tests "*ExtensionDownloadRegistryTest*"`
  - `./gradlew spotlessCheck`
  - `./gradlew :app:compileDebugKotlin || ./gradlew :app:compileStableDebugKotlin`
  - `java -jar ~/tla2tools.jar -config ExtensionDuplicateInstall.cfg ExtensionDuplicateInstall.tla`
- Results:
  - Unit tests passed.
  - `spotlessCheck` passed.
  - `compileDebugKotlin` was ambiguous for this module setup; fallback `:app:compileStableDebugKotlin` passed.
  - TLC model check passed.
- Not tested:
  - Full app test suite.

## Risk
- Risk: mismatched cleanup could remove a newer in-flight download.
- Mitigation: guarded `removeIfMatch` semantics + deterministic tests for mismatch/exact-match behavior.

## SLO Impact
- None expected; this is correctness synchronization around extension install bookkeeping.

## Rollback
- Revert this PR commit to restore previous installer map-based behavior.

## Release Notes
- Extension installers now serialize per-package download slot ownership so concurrent install requests cannot spawn orphaned duplicate downloads.

## Checklist
- [x] Naming conventions followed (use "Rayniyomi" in user-facing text, see [naming conventions](../docs/governance/naming-conventions.md))
- [x] Branch rebased on latest main and verification re-run (see [rebase policy](../docs/governance/agent-workflow.md#rebase-before-merge-policy-r45))
- [x] New coroutine scopes have documented owner and cancellation path
- [x] No new `runBlocking` on UI/main thread paths

## Definition of Done (DoD)
- [x] Acceptance criteria met and non-goals respected
- [x] Verification matrix completed (Risk Tier: T2)
- [x] Self-review completed
- [x] Rebased on latest `main` and revalidated (mandatory for merge)
- [ ] Sprint board updated (branch, commit, checks, PR link)
- [x] Release notes drafted (if applicable)

## Fork Compliance Checklist (for new forks only)
If you are creating a new fork of this project, ensure the following:
- [ ] **App Identity**: Changed app name from "Aniyomi" to your fork name
- [ ] **App Icon**: Replaced launcher icon assets with fork-specific icons
- [ ] **Application ID**: Changed `applicationId` in `app/build.gradle.kts` from `xyz.rayniyomi` to your unique ID
- [ ] **Update Checker**: Configured `AppUpdateChecker.kt` to point to your fork's repository
- [ ] **Analytics**: Either disabled Firebase Analytics or configured with your own `google-services.json`
- [ ] **Crash Reporting**: Either disabled ACRA crash reporting or configured with your own endpoint credentials

See [CONTRIBUTING.md](../CONTRIBUTING.md) Forks section for details.
