### PR TITLE
refactor: migrate queue mutations to command-based ID API (R626)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Download queue add-to-start now runs downloader start callbacks outside the queue mutex to prevent callback re-entrancy deadlocks while preserving queue mutation serialization
 - R586/#590: Anime `deleteAnime(removeQueued=true)` queue removal is now mutex-serialized so stale reorder snapshots cannot resurrect deleted anime entries
 - Extension installers now serialize per-package download slot ownership so concurrent install requests cannot spawn orphaned duplicate downloads
+- R626/#659: Queue reorder/prioritize callsites now dispatch ID-based commands (including reader/player priority hooks), removing production full-snapshot reorder payloads across anime and manga flows
 ### Changed
 
 ### CI

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloadManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloadManager.kt
@@ -192,8 +192,12 @@ class AnimeDownloadManager(
      *
      * @param downloads value to set the download queue to
      */
+    @Deprecated(
+        message = "Use reorderQueueByEpisodeIds to avoid stale object snapshot payloads",
+        replaceWith = ReplaceWith("reorderQueueByEpisodeIds(downloads.mapNotNull { it.episode.id })"),
+    )
     suspend fun reorderQueue(downloads: List<AnimeDownload>) {
-        queueMutations.reorderQueue(downloads)
+        reorderQueueByEpisodeIds(downloads.mapNotNull { it.episode.id })
     }
 
     suspend fun reorderQueueByEpisodeIds(episodeIds: List<Long>) {
@@ -229,9 +233,7 @@ class AnimeDownloadManager(
      * @param downloads the list of downloads to enqueue.
      */
     suspend fun addDownloadsToStartOfQueue(downloads: List<AnimeDownload>) {
-        queueMutations.addDownloadsToStart(downloads) {
-            if (!AnimeDownloadJob.isRunning(context)) startDownloads()
-        }
+        addDownloadsToStartByEpisodeIds(downloads.mapNotNull { it.episode.id })
     }
 
     suspend fun addDownloadsToStartByEpisodeIds(episodeIds: List<Long>) {
@@ -245,9 +247,21 @@ class AnimeDownloadManager(
      * Use this for call sites where no suspend scope is available (e.g., lifecycle teardown hooks).
      */
     fun addDownloadsToStartOfQueueAsync(downloads: List<AnimeDownload>) {
-        if (downloads.isEmpty()) return
+        val episodeIds = downloads.mapNotNull { it.episode.id }
+        if (episodeIds.isEmpty()) return
         scope.launch {
-            addDownloadsToStartOfQueue(downloads)
+            addDownloadsToStartByEpisodeIds(episodeIds)
+        }
+    }
+
+    /**
+     * Enqueues episode IDs to the front of the queue using manager-owned structured scope.
+     * Use this for call sites where no suspend scope is available.
+     */
+    fun addDownloadsToStartByEpisodeIdsAsync(episodeIds: List<Long>) {
+        if (episodeIds.isEmpty()) return
+        scope.launch {
+            addDownloadsToStartByEpisodeIds(episodeIds)
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/core/DownloadQueueMutations.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/core/DownloadQueueMutations.kt
@@ -63,6 +63,10 @@ class DownloadQueueMutations<D : Any, I : Any>(
      *
      * @param downloads The new queue order
      */
+    @Deprecated(
+        message = "Use reorderQueueByIds to avoid stale object snapshot payloads",
+        replaceWith = ReplaceWith("reorderQueueByIds(downloads.map(itemId))"),
+    )
     suspend fun reorderQueue(downloads: List<D>) {
         val ids = downloads.map(itemId)
         reorderQueueByIds(ids)
@@ -80,6 +84,10 @@ class DownloadQueueMutations<D : Any, I : Any>(
      * @param downloads The downloads to add
      * @param startIfNeeded Callback to start the downloader if needed (e.g., check if job is running)
      */
+    @Deprecated(
+        message = "Use addDownloadsToStartByIds to avoid stale object snapshot payloads",
+        replaceWith = ReplaceWith("addDownloadsToStartByIds(downloads.map(itemId), startIfNeeded)"),
+    )
     suspend fun addDownloadsToStart(downloads: List<D>, startIfNeeded: () -> Unit) {
         val ids = downloads.map(itemId)
         addDownloadsToStartByIds(ids, startIfNeeded)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/manga/MangaDownloadManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/manga/MangaDownloadManager.kt
@@ -206,8 +206,12 @@ class MangaDownloadManager(
      *
      * @param downloads value to set the download queue to
      */
+    @Deprecated(
+        message = "Use reorderQueueByChapterIds to avoid stale object snapshot payloads",
+        replaceWith = ReplaceWith("reorderQueueByChapterIds(downloads.mapNotNull { it.chapter.id })"),
+    )
     suspend fun reorderQueue(downloads: List<MangaDownload>) {
-        queueMutations.reorderQueue(downloads)
+        reorderQueueByChapterIds(downloads.mapNotNull { it.chapter.id })
     }
 
     suspend fun reorderQueueByChapterIds(chapterIds: List<Long>) {
@@ -244,9 +248,7 @@ class MangaDownloadManager(
      * @param downloads the list of downloads to enqueue.
      */
     suspend fun addDownloadsToStartOfQueue(downloads: List<MangaDownload>) {
-        queueMutations.addDownloadsToStart(downloads) {
-            if (!MangaDownloadJob.isRunning(context)) startDownloads()
-        }
+        addDownloadsToStartByChapterIds(downloads.mapNotNull { it.chapter.id })
     }
 
     suspend fun addDownloadsToStartByChapterIds(chapterIds: List<Long>) {
@@ -260,9 +262,21 @@ class MangaDownloadManager(
      * Use this for call sites where no suspend scope is available (e.g., lifecycle teardown hooks).
      */
     fun addDownloadsToStartOfQueueAsync(downloads: List<MangaDownload>) {
-        if (downloads.isEmpty()) return
+        val chapterIds = downloads.mapNotNull { it.chapter.id }
+        if (chapterIds.isEmpty()) return
         scope.launch {
-            addDownloadsToStartOfQueue(downloads)
+            addDownloadsToStartByChapterIds(chapterIds)
+        }
+    }
+
+    /**
+     * Enqueues chapter IDs to the front of the queue using manager-owned structured scope.
+     * Use this for call sites where no suspend scope is available.
+     */
+    fun addDownloadsToStartByChapterIdsAsync(chapterIds: List<Long>) {
+        if (chapterIds.isEmpty()) return
+        scope.launch {
+            addDownloadsToStartByChapterIds(chapterIds)
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/download/anime/AnimeDownloadQueueScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/download/anime/AnimeDownloadQueueScreen.kt
@@ -76,7 +76,7 @@ fun AnimeDownloadQueueScreen(
                     from.index,
                     to.index,
                 )
-                screenModel.reorder(reorderedDownloads)
+                screenModel.reorder(reorderedDownloads.mapNotNull { it.episode.id })
             }
         }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/download/anime/AnimeDownloadQueueScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/download/anime/AnimeDownloadQueueScreenModel.kt
@@ -71,7 +71,7 @@ class AnimeDownloadQueueScreenModel(
 
     fun moveToTop(item: AnimeDownloadUiItem) {
         val currentState = _state.value
-        val newDownloads = mutableListOf<AnimeDownload>()
+        val reorderedEpisodeIds = mutableListOf<Long>()
         currentState.forEach { header ->
             val mutable = header.downloads.toMutableList()
             val idx = mutable.indexOfFirst { it.download == item.download }
@@ -79,14 +79,14 @@ class AnimeDownloadQueueScreenModel(
                 mutable.removeAt(idx)
                 mutable.add(0, item)
             }
-            newDownloads.addAll(mutable.map { it.download })
+            reorderedEpisodeIds.addAll(mutable.mapNotNull { it.download.episode.id })
         }
-        reorder(newDownloads)
+        reorder(reorderedEpisodeIds)
     }
 
     fun moveToBottom(item: AnimeDownloadUiItem) {
         val currentState = _state.value
-        val newDownloads = mutableListOf<AnimeDownload>()
+        val reorderedEpisodeIds = mutableListOf<Long>()
         currentState.forEach { header ->
             val mutable = header.downloads.toMutableList()
             val idx = mutable.indexOfFirst { it.download == item.download }
@@ -94,21 +94,21 @@ class AnimeDownloadQueueScreenModel(
                 mutable.removeAt(idx)
                 mutable.add(mutable.size, item)
             }
-            newDownloads.addAll(mutable.map { it.download })
+            reorderedEpisodeIds.addAll(mutable.mapNotNull { it.download.episode.id })
         }
-        reorder(newDownloads)
+        reorder(reorderedEpisodeIds)
     }
 
     fun moveToTopSeries(animeId: Long) {
         val all = _state.value.flatMap { it.downloads }
         val (series, others) = all.partition { it.download.anime.id == animeId }
-        reorder((series + others).map { it.download })
+        reorder((series + others).mapNotNull { it.download.episode.id })
     }
 
     fun moveToBottomSeries(animeId: Long) {
         val all = _state.value.flatMap { it.downloads }
         val (series, others) = all.partition { it.download.anime.id == animeId }
-        reorder((others + series).map { it.download })
+        reorder((others + series).mapNotNull { it.download.episode.id })
     }
 
     fun cancelDownload(item: AnimeDownloadUiItem) {
@@ -144,9 +144,9 @@ class AnimeDownloadQueueScreenModel(
         downloadManager.clearQueue()
     }
 
-    fun reorder(downloads: List<AnimeDownload>) {
+    fun reorder(downloadEpisodeIds: List<Long>) {
         screenModelScope.launch {
-            downloadManager.reorderQueue(downloads)
+            downloadManager.reorderQueueByEpisodeIds(downloadEpisodeIds)
         }
     }
 
@@ -159,13 +159,13 @@ class AnimeDownloadQueueScreenModel(
         reverse: Boolean = false,
     ) {
         val currentState = _state.value
-        val newAnimeDownloads = mutableListOf<AnimeDownload>()
+        val newAnimeDownloadIds = mutableListOf<Long>()
         currentState.forEach { headerItem ->
             val sortedItems = headerItem.downloads.sortedBy(selector).let {
                 if (reverse) it.reversed() else it
             }
-            newAnimeDownloads.addAll(sortedItems.map { it.download })
+            newAnimeDownloadIds.addAll(sortedItems.mapNotNull { it.download.episode.id })
         }
-        reorder(newAnimeDownloads)
+        reorder(newAnimeDownloadIds)
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/download/manga/MangaDownloadQueueScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/download/manga/MangaDownloadQueueScreen.kt
@@ -76,7 +76,7 @@ fun DownloadQueueScreen(
                     from.index,
                     to.index,
                 )
-                screenModel.reorder(reorderedDownloads)
+                screenModel.reorder(reorderedDownloads.mapNotNull { it.chapter.id })
             }
         }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/download/manga/MangaDownloadQueueScreenModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/download/manga/MangaDownloadQueueScreenModel.kt
@@ -71,7 +71,7 @@ class MangaDownloadQueueScreenModel(
 
     fun moveToTop(item: MangaDownloadUiItem) {
         val currentState = _state.value
-        val newDownloads = mutableListOf<MangaDownload>()
+        val reorderedChapterIds = mutableListOf<Long>()
         currentState.forEach { header ->
             val mutable = header.downloads.toMutableList()
             val idx = mutable.indexOfFirst { it.download == item.download }
@@ -79,14 +79,14 @@ class MangaDownloadQueueScreenModel(
                 mutable.removeAt(idx)
                 mutable.add(0, item)
             }
-            newDownloads.addAll(mutable.map { it.download })
+            reorderedChapterIds.addAll(mutable.mapNotNull { it.download.chapter.id })
         }
-        reorder(newDownloads)
+        reorder(reorderedChapterIds)
     }
 
     fun moveToBottom(item: MangaDownloadUiItem) {
         val currentState = _state.value
-        val newDownloads = mutableListOf<MangaDownload>()
+        val reorderedChapterIds = mutableListOf<Long>()
         currentState.forEach { header ->
             val mutable = header.downloads.toMutableList()
             val idx = mutable.indexOfFirst { it.download == item.download }
@@ -94,21 +94,21 @@ class MangaDownloadQueueScreenModel(
                 mutable.removeAt(idx)
                 mutable.add(mutable.size, item)
             }
-            newDownloads.addAll(mutable.map { it.download })
+            reorderedChapterIds.addAll(mutable.mapNotNull { it.download.chapter.id })
         }
-        reorder(newDownloads)
+        reorder(reorderedChapterIds)
     }
 
     fun moveToTopSeries(mangaId: Long) {
         val all = _state.value.flatMap { it.downloads }
         val (series, others) = all.partition { it.download.manga.id == mangaId }
-        reorder((series + others).map { it.download })
+        reorder((series + others).mapNotNull { it.download.chapter.id })
     }
 
     fun moveToBottomSeries(mangaId: Long) {
         val all = _state.value.flatMap { it.downloads }
         val (series, others) = all.partition { it.download.manga.id == mangaId }
-        reorder((others + series).map { it.download })
+        reorder((others + series).mapNotNull { it.download.chapter.id })
     }
 
     fun cancelDownload(item: MangaDownloadUiItem) {
@@ -144,9 +144,9 @@ class MangaDownloadQueueScreenModel(
         downloadManager.clearQueue()
     }
 
-    fun reorder(downloads: List<MangaDownload>) {
+    fun reorder(downloadChapterIds: List<Long>) {
         screenModelScope.launch {
-            downloadManager.reorderQueue(downloads)
+            downloadManager.reorderQueueByChapterIds(downloadChapterIds)
         }
     }
 
@@ -159,13 +159,13 @@ class MangaDownloadQueueScreenModel(
         reverse: Boolean = false,
     ) {
         val currentState = _state.value
-        val newDownloads = mutableListOf<MangaDownload>()
+        val newDownloadIds = mutableListOf<Long>()
         currentState.forEach { headerItem ->
             val sortedItems = headerItem.downloads.sortedBy(selector).let {
                 if (reverse) it.reversed() else it
             }
-            newDownloads.addAll(sortedItems.map { it.download })
+            newDownloadIds.addAll(sortedItems.mapNotNull { it.download.chapter.id })
         }
-        reorder(newDownloads)
+        reorder(newDownloadIds)
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerViewModel.kt
@@ -1013,7 +1013,10 @@ class PlayerViewModel @JvmOverloads constructor(
         if (currentEpisode.value != null) {
             saveWatchingProgress(currentEpisode.value!!)
             episodeToDownload?.let {
-                downloadManager.addDownloadsToStartOfQueueAsync(listOf(it))
+                val episodeId = it.episode.id
+                if (episodeId != null) {
+                    downloadManager.addDownloadsToStartByEpisodeIdsAsync(listOf(episodeId))
+                }
             }
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -207,7 +207,10 @@ class ReaderViewModel @JvmOverloads constructor(
         if (currentChapters != null) {
             currentChapters.unref()
             chapterToDownload?.let {
-                downloadManager.addDownloadsToStartOfQueueAsync(listOf(it))
+                val chapterId = it.chapter.id
+                if (chapterId != null) {
+                    downloadManager.addDownloadsToStartByChapterIdsAsync(listOf(chapterId))
+                }
             }
         }
     }

--- a/app/src/test/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloadManagerTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloadManagerTest.kt
@@ -180,7 +180,7 @@ class AnimeDownloadManagerTest {
             removeEntered.await()
 
             val reorderJob = async {
-                localManager.reorderQueue(staleSnapshot)
+                localManager.reorderQueueByEpisodeIds(staleSnapshot.mapNotNull { it.episode.id })
             }
 
             val reorderFinishedEarly = withTimeoutOrNull(50) { reorderJob.await() }
@@ -271,7 +271,7 @@ class AnimeDownloadManagerTest {
             localManager.deleteAnime(anime, source, removeQueued = true)
             removeAttempted.await()
             val reorderCompleted = withTimeoutOrNull(500) {
-                localManager.reorderQueue(queueState.value)
+                localManager.reorderQueueByEpisodeIds(queueState.value.mapNotNull { it.episode.id })
                 Unit
             }
             assertEquals(Unit, reorderCompleted, "reorderQueue should not deadlock after delete failure")

--- a/app/src/test/java/eu/kanade/tachiyomi/data/download/manga/MangaDownloadManagerTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/data/download/manga/MangaDownloadManagerTest.kt
@@ -175,7 +175,7 @@ class MangaDownloadManagerTest {
             removeEntered.await()
 
             val reorderJob = async {
-                localManager.reorderQueue(staleSnapshot)
+                localManager.reorderQueueByChapterIds(staleSnapshot.mapNotNull { it.chapter.id })
             }
 
             val reorderFinishedEarly = withTimeoutOrNull(50) { reorderJob.await() }

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/download/anime/AnimeDownloadQueueScreenModelTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/download/anime/AnimeDownloadQueueScreenModelTest.kt
@@ -94,9 +94,9 @@ class AnimeDownloadQueueScreenModelTest {
         model.moveToTop(model.state.value[0].downloads[1]) // d2 at index 1
         advanceUntilIdle()
 
-        val slot = slot<List<AnimeDownload>>()
-        coVerify { manager.reorderQueue(capture(slot)) }
-        slot.captured.map { it.episode.id } shouldContainExactly listOf(2L, 1L, 3L)
+        val slot = slot<List<Long>>()
+        coVerify { manager.reorderQueueByEpisodeIds(capture(slot)) }
+        slot.captured shouldContainExactly listOf(2L, 1L, 3L)
     }
 
     @Test
@@ -110,9 +110,9 @@ class AnimeDownloadQueueScreenModelTest {
         model.moveToTop(model.state.value[0].downloads[0]) // d1 already first
         advanceUntilIdle()
 
-        val slot = slot<List<AnimeDownload>>()
-        coVerify { manager.reorderQueue(capture(slot)) }
-        slot.captured.map { it.episode.id } shouldContainExactly listOf(1L, 2L)
+        val slot = slot<List<Long>>()
+        coVerify { manager.reorderQueueByEpisodeIds(capture(slot)) }
+        slot.captured shouldContainExactly listOf(1L, 2L)
     }
 
     @Test
@@ -127,9 +127,9 @@ class AnimeDownloadQueueScreenModelTest {
         model.moveToBottom(model.state.value[0].downloads[0]) // d1 at index 0
         advanceUntilIdle()
 
-        val slot = slot<List<AnimeDownload>>()
-        coVerify { manager.reorderQueue(capture(slot)) }
-        slot.captured.map { it.episode.id } shouldContainExactly listOf(2L, 3L, 1L)
+        val slot = slot<List<Long>>()
+        coVerify { manager.reorderQueueByEpisodeIds(capture(slot)) }
+        slot.captured shouldContainExactly listOf(2L, 3L, 1L)
     }
 
     @Test
@@ -146,9 +146,9 @@ class AnimeDownloadQueueScreenModelTest {
         model.moveToTopSeries(2L) // anime2 downloads (d3, d4) to front
         advanceUntilIdle()
 
-        val slot = slot<List<AnimeDownload>>()
-        coVerify { manager.reorderQueue(capture(slot)) }
-        slot.captured.map { it.episode.id } shouldContainExactly listOf(3L, 4L, 1L, 2L)
+        val slot = slot<List<Long>>()
+        coVerify { manager.reorderQueueByEpisodeIds(capture(slot)) }
+        slot.captured shouldContainExactly listOf(3L, 4L, 1L, 2L)
     }
 
     @Test
@@ -165,9 +165,9 @@ class AnimeDownloadQueueScreenModelTest {
         model.moveToBottomSeries(1L) // anime1 downloads (d1, d2) to back
         advanceUntilIdle()
 
-        val slot = slot<List<AnimeDownload>>()
-        coVerify { manager.reorderQueue(capture(slot)) }
-        slot.captured.map { it.episode.id } shouldContainExactly listOf(3L, 4L, 1L, 2L)
+        val slot = slot<List<Long>>()
+        coVerify { manager.reorderQueueByEpisodeIds(capture(slot)) }
+        slot.captured shouldContainExactly listOf(3L, 4L, 1L, 2L)
     }
 
     @Test
@@ -222,9 +222,9 @@ class AnimeDownloadQueueScreenModelTest {
         model.reorderQueue(selector = { it.download.episode.id })
         advanceUntilIdle()
 
-        val slot = slot<List<AnimeDownload>>()
-        coVerify { manager.reorderQueue(capture(slot)) }
-        slot.captured.map { it.episode.id } shouldContainExactly listOf(1L, 2L, 3L)
+        val slot = slot<List<Long>>()
+        coVerify { manager.reorderQueueByEpisodeIds(capture(slot)) }
+        slot.captured shouldContainExactly listOf(1L, 2L, 3L)
     }
 
     @Test
@@ -239,8 +239,8 @@ class AnimeDownloadQueueScreenModelTest {
         model.reorderQueue(selector = { it.download.episode.id }, reverse = true)
         advanceUntilIdle()
 
-        val slot = slot<List<AnimeDownload>>()
-        coVerify { manager.reorderQueue(capture(slot)) }
-        slot.captured.map { it.episode.id } shouldContainExactly listOf(3L, 2L, 1L)
+        val slot = slot<List<Long>>()
+        coVerify { manager.reorderQueueByEpisodeIds(capture(slot)) }
+        slot.captured shouldContainExactly listOf(3L, 2L, 1L)
     }
 }

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/download/manga/MangaDownloadQueueScreenModelTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/download/manga/MangaDownloadQueueScreenModelTest.kt
@@ -94,9 +94,9 @@ class MangaDownloadQueueScreenModelTest {
         model.moveToTop(model.state.value[0].downloads[1]) // d2 at index 1
         advanceUntilIdle()
 
-        val slot = slot<List<MangaDownload>>()
-        coVerify { manager.reorderQueue(capture(slot)) }
-        slot.captured.map { it.chapter.id } shouldContainExactly listOf(2L, 1L, 3L)
+        val slot = slot<List<Long>>()
+        coVerify { manager.reorderQueueByChapterIds(capture(slot)) }
+        slot.captured shouldContainExactly listOf(2L, 1L, 3L)
     }
 
     @Test
@@ -110,9 +110,9 @@ class MangaDownloadQueueScreenModelTest {
         model.moveToTop(model.state.value[0].downloads[0]) // d1 already first
         advanceUntilIdle()
 
-        val slot = slot<List<MangaDownload>>()
-        coVerify { manager.reorderQueue(capture(slot)) }
-        slot.captured.map { it.chapter.id } shouldContainExactly listOf(1L, 2L)
+        val slot = slot<List<Long>>()
+        coVerify { manager.reorderQueueByChapterIds(capture(slot)) }
+        slot.captured shouldContainExactly listOf(1L, 2L)
     }
 
     @Test
@@ -127,9 +127,9 @@ class MangaDownloadQueueScreenModelTest {
         model.moveToBottom(model.state.value[0].downloads[0]) // d1 at index 0
         advanceUntilIdle()
 
-        val slot = slot<List<MangaDownload>>()
-        coVerify { manager.reorderQueue(capture(slot)) }
-        slot.captured.map { it.chapter.id } shouldContainExactly listOf(2L, 3L, 1L)
+        val slot = slot<List<Long>>()
+        coVerify { manager.reorderQueueByChapterIds(capture(slot)) }
+        slot.captured shouldContainExactly listOf(2L, 3L, 1L)
     }
 
     @Test
@@ -146,9 +146,9 @@ class MangaDownloadQueueScreenModelTest {
         model.moveToTopSeries(2L) // manga2 downloads (d3, d4) to front
         advanceUntilIdle()
 
-        val slot = slot<List<MangaDownload>>()
-        coVerify { manager.reorderQueue(capture(slot)) }
-        slot.captured.map { it.chapter.id } shouldContainExactly listOf(3L, 4L, 1L, 2L)
+        val slot = slot<List<Long>>()
+        coVerify { manager.reorderQueueByChapterIds(capture(slot)) }
+        slot.captured shouldContainExactly listOf(3L, 4L, 1L, 2L)
     }
 
     @Test
@@ -165,9 +165,9 @@ class MangaDownloadQueueScreenModelTest {
         model.moveToBottomSeries(1L) // manga1 downloads (d1, d2) to back
         advanceUntilIdle()
 
-        val slot = slot<List<MangaDownload>>()
-        coVerify { manager.reorderQueue(capture(slot)) }
-        slot.captured.map { it.chapter.id } shouldContainExactly listOf(3L, 4L, 1L, 2L)
+        val slot = slot<List<Long>>()
+        coVerify { manager.reorderQueueByChapterIds(capture(slot)) }
+        slot.captured shouldContainExactly listOf(3L, 4L, 1L, 2L)
     }
 
     @Test
@@ -222,9 +222,9 @@ class MangaDownloadQueueScreenModelTest {
         model.reorderQueue(selector = { it.download.chapter.id })
         advanceUntilIdle()
 
-        val slot = slot<List<MangaDownload>>()
-        coVerify { manager.reorderQueue(capture(slot)) }
-        slot.captured.map { it.chapter.id } shouldContainExactly listOf(1L, 2L, 3L)
+        val slot = slot<List<Long>>()
+        coVerify { manager.reorderQueueByChapterIds(capture(slot)) }
+        slot.captured shouldContainExactly listOf(1L, 2L, 3L)
     }
 
     @Test
@@ -239,8 +239,8 @@ class MangaDownloadQueueScreenModelTest {
         model.reorderQueue(selector = { it.download.chapter.id }, reverse = true)
         advanceUntilIdle()
 
-        val slot = slot<List<MangaDownload>>()
-        coVerify { manager.reorderQueue(capture(slot)) }
-        slot.captured.map { it.chapter.id } shouldContainExactly listOf(3L, 2L, 1L)
+        val slot = slot<List<Long>>()
+        coVerify { manager.reorderQueueByChapterIds(capture(slot)) }
+        slot.captured shouldContainExactly listOf(3L, 2L, 1L)
     }
 }


### PR DESCRIPTION
## Ticket
- ID: R626
- Priority: P1
- Risk Tier: T2
- GitHub Issue: Closes #659

## Objective
- Remove production full-list queue snapshot mutation paths and migrate reorder/prioritize flows to ID-based command APIs on top of the queue actor/reducer core.

## Scope
- Migrate manga/anime download queue screen-model and screen reorder flows to pass ordered IDs.
- Migrate reader/player priority hooks to ID-based async queue APIs.
- Make manager/object-list reorder/add-to-start entrypoints defer to ID-based methods and deprecate stale snapshot usage.
- Add/adjust regression tests to assert ID command dispatch parity.
- Add one changelog bullet.

## Non-goals
- No queue UX redesign.
- No downloader policy/tuning changes.
- No actor/reducer architecture rewrite beyond command API migration.

## Files Changed
- `app/src/main/java/eu/kanade/tachiyomi/data/download/core/DownloadQueueMutations.kt`
- `app/src/main/java/eu/kanade/tachiyomi/data/download/manga/MangaDownloadManager.kt`
- `app/src/main/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloadManager.kt`
- `app/src/main/java/eu/kanade/tachiyomi/ui/download/manga/MangaDownloadQueueScreenModel.kt`
- `app/src/main/java/eu/kanade/tachiyomi/ui/download/anime/AnimeDownloadQueueScreenModel.kt`
- `app/src/main/java/eu/kanade/tachiyomi/ui/download/manga/MangaDownloadQueueScreen.kt`
- `app/src/main/java/eu/kanade/tachiyomi/ui/download/anime/AnimeDownloadQueueScreen.kt`
- `app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt`
- `app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerViewModel.kt`
- `app/src/test/java/eu/kanade/tachiyomi/ui/download/manga/MangaDownloadQueueScreenModelTest.kt`
- `app/src/test/java/eu/kanade/tachiyomi/ui/download/anime/AnimeDownloadQueueScreenModelTest.kt`
- `app/src/test/java/eu/kanade/tachiyomi/data/download/manga/MangaDownloadManagerTest.kt`
- `app/src/test/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloadManagerTest.kt`
- `CHANGELOG.md`

## Verification
- Commands run:
  - `./gradlew :app:testDebugUnitTest --tests "*DownloadQueueMutationsTest*" --tests "*DownloadQueueReducerTest*" --tests "*MangaDownloadQueueScreenModelTest*" --tests "*AnimeDownloadQueueScreenModelTest*" --tests "*MangaDownloadManagerTest*" --tests "*AnimeDownloadManagerTest*"`
  - `./gradlew spotlessCheck`
  - `./gradlew :app:compileDebugKotlin || ./gradlew :app:compileStableDebugKotlin`
- Results:
  - All targeted queue/reorder/prioritize regression tests passed.
  - `spotlessCheck` passed.
  - `:app:compileDebugKotlin` is ambiguous for this module; fallback `:app:compileStableDebugKotlin` passed.
- Not tested:
  - Full unit/instrumentation suite.

## Risk
- Risk: regression in reorder sorting parity after ID payload migration.
- Mitigation: existing deterministic reducer/mutation tests retained + screen-model reorder tests updated to assert exact ordered ID payloads.

## SLO Impact
- None expected; this is correctness hardening for queue mutation API surfaces.

## Rollback
- Revert this PR commit to restore previous object-list entrypoint behavior.

## Release Notes
- Queue reorder/prioritize callsites now dispatch ID-based commands (including reader/player priority hooks), removing production full-snapshot reorder payloads across anime and manga flows.

## Checklist
- [x] Naming conventions followed (use "Rayniyomi" in user-facing text, see [naming conventions](../docs/governance/naming-conventions.md))
- [x] Branch rebased on latest main and verification re-run (see [rebase policy](../docs/governance/agent-workflow.md#rebase-before-merge-policy-r45))
- [x] New coroutine scopes have documented owner and cancellation path
- [x] No new `runBlocking` on UI/main thread paths

## Definition of Done (DoD)
- [x] Acceptance criteria met and non-goals respected
- [x] Verification matrix completed (Risk Tier: T2)
- [x] Self-review completed
- [x] Rebased on latest `main` and revalidated (mandatory for merge)
- [ ] Sprint board updated (branch, commit, checks, PR link)
- [x] Release notes drafted (if applicable)

## Fork Compliance Checklist (for new forks only)
If you are creating a new fork of this project, ensure the following:
- [ ] **App Identity**: Changed app name from "Aniyomi" to your fork name
- [ ] **App Icon**: Replaced launcher icon assets with fork-specific icons
- [ ] **Application ID**: Changed `applicationId` in `app/build.gradle.kts` from `xyz.rayniyomi` to your unique ID
- [ ] **Update Checker**: Configured `AppUpdateChecker.kt` to point to your fork's repository
- [ ] **Analytics**: Either disabled Firebase Analytics or configured with your own `google-services.json`
- [ ] **Crash Reporting**: Either disabled ACRA crash reporting or configured with your own endpoint credentials

See [CONTRIBUTING.md](../CONTRIBUTING.md) Forks section for details.
