### PR TITLE
refactor: remove remaining queue migration wrappers (R659)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 
 ### Fixed
 - R588/#593: Backup restore progress and error tracking are now concurrency-safe so parallel restore branches cannot lose progress increments or drop captured restore errors
-- R625/#658: Download queue mutations now run through a single-writer actor/reducer path with ID-based command normalization to prevent stale concurrent queue operations from resurrecting removed entries
+- Download queue mutations now run through a single-writer actor/reducer path with ID-based command normalization to prevent stale concurrent queue operations from resurrecting removed entries
 - Manga battery optimization prompt check is now mutex-serialized so concurrent 10+ chapter queue actions cannot emit the prompt twice in one app session
 - Download queue `start now` is now mutex-serialized with safe removal so cancelled entries cannot be reinserted during concurrent queue mutations
 - Manga delete queue removal now executes under the shared download queue mutex so stale reorder snapshots cannot resurrect deleted manga entries

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloadManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloadManager.kt
@@ -187,19 +187,6 @@ class AnimeDownloadManager(
         queueMutations.startDownloadNow(episodeId)
     }
 
-    /**
-     * Reorders the download queue.
-     *
-     * @param downloads value to set the download queue to
-     */
-    @Deprecated(
-        message = "Use reorderQueueByEpisodeIds to avoid stale object snapshot payloads",
-        replaceWith = ReplaceWith("reorderQueueByEpisodeIds(downloads.mapNotNull { it.episode.id })"),
-    )
-    suspend fun reorderQueue(downloads: List<AnimeDownload>) {
-        reorderQueueByEpisodeIds(downloads.mapNotNull { it.episode.id })
-    }
-
     suspend fun reorderQueueByEpisodeIds(episodeIds: List<Long>) {
         queueMutations.reorderQueueByIds(episodeIds)
     }
@@ -227,30 +214,9 @@ class AnimeDownloadManager(
         downloader.queueEpisodes(anime, filteredEpisodes, autoStart, alt, video)
     }
 
-    /**
-     * Tells the downloader to enqueue the given list of downloads at the start of the queue.
-     *
-     * @param downloads the list of downloads to enqueue.
-     */
-    suspend fun addDownloadsToStartOfQueue(downloads: List<AnimeDownload>) {
-        addDownloadsToStartByEpisodeIds(downloads.mapNotNull { it.episode.id })
-    }
-
     suspend fun addDownloadsToStartByEpisodeIds(episodeIds: List<Long>) {
         queueMutations.addDownloadsToStartByIds(episodeIds) {
             if (!AnimeDownloadJob.isRunning(context)) startDownloads()
-        }
-    }
-
-    /**
-     * Enqueues downloads to the front of the queue using manager-owned structured scope.
-     * Use this for call sites where no suspend scope is available (e.g., lifecycle teardown hooks).
-     */
-    fun addDownloadsToStartOfQueueAsync(downloads: List<AnimeDownload>) {
-        val episodeIds = downloads.mapNotNull { it.episode.id }
-        if (episodeIds.isEmpty()) return
-        scope.launch {
-            addDownloadsToStartByEpisodeIds(episodeIds)
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/core/DownloadQueueMutations.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/core/DownloadQueueMutations.kt
@@ -58,39 +58,10 @@ class DownloadQueueMutations<D : Any, I : Any>(
         }
     }
 
-    /**
-     * Reorders the download queue to match the provided list.
-     *
-     * @param downloads The new queue order
-     */
-    @Deprecated(
-        message = "Use reorderQueueByIds to avoid stale object snapshot payloads",
-        replaceWith = ReplaceWith("reorderQueueByIds(downloads.map(itemId))"),
-    )
-    suspend fun reorderQueue(downloads: List<D>) {
-        val ids = downloads.map(itemId)
-        reorderQueueByIds(ids)
-    }
-
     suspend fun reorderQueueByIds(downloadIds: List<Long>) {
         queueActor.submit(DownloadQueueCommand.Reorder(downloadIds)) {
             runReducerCommand(DownloadQueueCommand.Reorder(downloadIds))
         }
-    }
-
-    /**
-     * Adds downloads to the start of the queue and optionally starts the downloader.
-     *
-     * @param downloads The downloads to add
-     * @param startIfNeeded Callback to start the downloader if needed (e.g., check if job is running)
-     */
-    @Deprecated(
-        message = "Use addDownloadsToStartByIds to avoid stale object snapshot payloads",
-        replaceWith = ReplaceWith("addDownloadsToStartByIds(downloads.map(itemId), startIfNeeded)"),
-    )
-    suspend fun addDownloadsToStart(downloads: List<D>, startIfNeeded: () -> Unit) {
-        val ids = downloads.map(itemId)
-        addDownloadsToStartByIds(ids, startIfNeeded)
     }
 
     suspend fun addDownloadsToStartByIds(downloadIds: List<Long>, startIfNeeded: () -> Unit) {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/manga/MangaDownloadManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/manga/MangaDownloadManager.kt
@@ -201,19 +201,6 @@ class MangaDownloadManager(
         queueMutations.startDownloadNow(chapterId)
     }
 
-    /**
-     * Reorders the download queue.
-     *
-     * @param downloads value to set the download queue to
-     */
-    @Deprecated(
-        message = "Use reorderQueueByChapterIds to avoid stale object snapshot payloads",
-        replaceWith = ReplaceWith("reorderQueueByChapterIds(downloads.mapNotNull { it.chapter.id })"),
-    )
-    suspend fun reorderQueue(downloads: List<MangaDownload>) {
-        reorderQueueByChapterIds(downloads.mapNotNull { it.chapter.id })
-    }
-
     suspend fun reorderQueueByChapterIds(chapterIds: List<Long>) {
         queueMutations.reorderQueueByIds(chapterIds)
     }
@@ -242,30 +229,9 @@ class MangaDownloadManager(
         }
     }
 
-    /**
-     * Tells the downloader to enqueue the given list of downloads at the start of the queue.
-     *
-     * @param downloads the list of downloads to enqueue.
-     */
-    suspend fun addDownloadsToStartOfQueue(downloads: List<MangaDownload>) {
-        addDownloadsToStartByChapterIds(downloads.mapNotNull { it.chapter.id })
-    }
-
     suspend fun addDownloadsToStartByChapterIds(chapterIds: List<Long>) {
         queueMutations.addDownloadsToStartByIds(chapterIds) {
             if (!MangaDownloadJob.isRunning(context)) startDownloads()
-        }
-    }
-
-    /**
-     * Enqueues downloads to the front of the queue using manager-owned structured scope.
-     * Use this for call sites where no suspend scope is available (e.g., lifecycle teardown hooks).
-     */
-    fun addDownloadsToStartOfQueueAsync(downloads: List<MangaDownload>) {
-        val chapterIds = downloads.mapNotNull { it.chapter.id }
-        if (chapterIds.isEmpty()) return
-        scope.launch {
-            addDownloadsToStartByChapterIds(chapterIds)
         }
     }
 


### PR DESCRIPTION
## Ticket
- ID: R659
- Priority: P1
- Risk Tier: T1
- GitHub Issue: Closes #659

## Objective
- Finish queue mutation migration cleanup by removing remaining object-list wrappers now that all call sites use ID-based APIs.

## Scope
- Remove deprecated object-list queue mutation wrappers from shared mutation layer.
- Remove corresponding manager wrappers in manga and anime download managers.
- Keep only ID-based methods (`*ByIds` / `*ByChapterIds` / `*ByEpisodeIds`).
- Update changelog wording to drop `R625` alias reference as requested.

## Non-goals
- No behavior changes to queue execution semantics.
- No UI flow changes.
- No new queue reducers/locks/primitives.

## Files Changed
- `app/src/main/java/eu/kanade/tachiyomi/data/download/core/DownloadQueueMutations.kt`
- `app/src/main/java/eu/kanade/tachiyomi/data/download/manga/MangaDownloadManager.kt`
- `app/src/main/java/eu/kanade/tachiyomi/data/download/anime/AnimeDownloadManager.kt`
- `CHANGELOG.md`

## Verification
- Commands run:
  - `./gradlew :app:testDebugUnitTest --tests "*DownloadQueueMutationsTest*" --tests "*DownloadQueueReducerTest*" --tests "*MangaDownloadQueueScreenModelTest*" --tests "*AnimeDownloadQueueScreenModelTest*" --tests "*MangaDownloadManagerTest*" --tests "*AnimeDownloadManagerTest*"`
  - `./gradlew spotlessCheck`
  - `./gradlew :app:compileDebugKotlin` (ambiguous task in this flavor setup)
  - `./gradlew :app:compileStableDebugKotlin` (fallback compile target)
- Results:
  - All listed tests passed.
  - `spotlessCheck` passed.
  - `:app:compileStableDebugKotlin` passed.
- Not tested:
  - Full end-to-end device download flows (out of scope for this API cleanup).

## Risk
- Low risk. Change removes wrapper APIs only; execution path remains via existing ID-based methods already in use.
- Mitigation: focused queue reducer/mutation and manager/screen-model tests pass.

## SLO Impact
- None expected.

## Rollback
- Revert this PR commit to restore wrapper methods.

## Release Notes
- Internal cleanup only; no user-visible behavior change.

## Checklist
- [x] Naming conventions followed (use "Rayniyomi" in user-facing text, see [naming conventions](../docs/governance/naming-conventions.md))
- [x] Branch rebased on latest main and verification re-run (see [rebase policy](../docs/governance/agent-workflow.md#rebase-before-merge-policy-r45))
- [x] New coroutine scopes have documented owner and cancellation path
- [x] No new `runBlocking` on UI/main thread paths

## Definition of Done (DoD)
- [x] Acceptance criteria met and non-goals respected
- [x] Verification matrix completed (Risk Tier: T1)
- [x] Self-review completed
- [x] Rebased on latest `main` and revalidated (mandatory for merge)
- [ ] Sprint board updated (branch, commit, checks, PR link)
- [x] Release notes drafted (if applicable)
