### PR TITLE
fix: guard extension installer receiver registration atomically (R595)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 ### Added
 
 ### Fixed
+- Extension installer download-completion receivers now use atomic registration guards, preventing duplicate receiver registration during concurrent install starts
 - R588/#593: Backup restore progress and error tracking are now concurrency-safe so parallel restore branches cannot lose progress increments or drop captured restore errors
 - Download queue mutations now run through a single-writer actor/reducer path with ID-based command normalization to prevent stale concurrent queue operations from resurrecting removed entries
 - Manga battery optimization prompt check is now mutex-serialized so concurrent 10+ chapter queue actions cannot emit the prompt twice in one app session

--- a/app/src/main/java/eu/kanade/tachiyomi/extension/anime/util/AnimeExtensionInstaller.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/extension/anime/util/AnimeExtensionInstaller.kt
@@ -32,6 +32,7 @@ import tachiyomi.core.common.util.system.logcat
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import java.io.File
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.time.Duration.Companion.seconds
 
 /**
@@ -257,14 +258,13 @@ internal class AnimeExtensionInstaller(private val context: Context) {
         /**
          * Whether this receiver is currently registered.
          */
-        private var isRegistered = false
+        private val isRegistered = AtomicBoolean(false)
 
         /**
          * Registers this receiver if it's not already.
          */
         fun register() {
-            if (isRegistered) return
-            isRegistered = true
+            if (!isRegistered.compareAndSet(false, true)) return
 
             val filter = IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE)
             ContextCompat.registerReceiver(context, this, filter, ContextCompat.RECEIVER_EXPORTED)
@@ -274,8 +274,7 @@ internal class AnimeExtensionInstaller(private val context: Context) {
          * Unregisters this receiver if it's not already.
          */
         fun unregister() {
-            if (!isRegistered) return
-            isRegistered = false
+            if (!isRegistered.compareAndSet(true, false)) return
 
             context.unregisterReceiver(this)
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/extension/manga/util/MangaExtensionInstaller.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/extension/manga/util/MangaExtensionInstaller.kt
@@ -32,6 +32,7 @@ import tachiyomi.core.common.util.system.logcat
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import java.io.File
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.time.Duration.Companion.seconds
 
 /**
@@ -257,14 +258,13 @@ internal class MangaExtensionInstaller(private val context: Context) {
         /**
          * Whether this receiver is currently registered.
          */
-        private var isRegistered = false
+        private val isRegistered = AtomicBoolean(false)
 
         /**
          * Registers this receiver if it's not already.
          */
         fun register() {
-            if (isRegistered) return
-            isRegistered = true
+            if (!isRegistered.compareAndSet(false, true)) return
 
             val filter = IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE)
             ContextCompat.registerReceiver(context, this, filter, ContextCompat.RECEIVER_EXPORTED)
@@ -274,8 +274,7 @@ internal class MangaExtensionInstaller(private val context: Context) {
          * Unregisters this receiver if it's not already.
          */
         fun unregister() {
-            if (!isRegistered) return
-            isRegistered = false
+            if (!isRegistered.compareAndSet(true, false)) return
 
             context.unregisterReceiver(this)
         }


### PR DESCRIPTION
## Ticket
- ID: R595
- Priority: P1
- Risk Tier: T2
- GitHub Issue: Closes #595

## Objective
- Prevent duplicate BroadcastReceiver registration in extension installer download completion receivers during concurrent install starts.

## Scope
- Replace non-atomic `isRegistered` boolean guards with atomic CAS guards in:
  - `MangaExtensionInstaller.DownloadCompletionReceiver`
  - `AnimeExtensionInstaller.DownloadCompletionReceiver`
- Keep install/download flow behavior unchanged.
- Add exactly one changelog bullet for this ticket scope.

## Non-goals
- No installer architecture refactor.
- No shared abstraction extraction across anime/manga installers.
- No UI changes.

## Files Changed
- `app/src/main/java/eu/kanade/tachiyomi/extension/manga/util/MangaExtensionInstaller.kt`
- `app/src/main/java/eu/kanade/tachiyomi/extension/anime/util/AnimeExtensionInstaller.kt`
- `CHANGELOG.md`

## Verification
- Commands run:
  - `./gradlew spotlessCheck`
  - `./gradlew :app:compileStableDebugKotlin` (project compile target; `:app:compileDebugKotlin` is ambiguous in this flavor setup)
  - `./gradlew :app:testDebugUnitTest --tests "*MangaExtensionInstaller*" --tests "*AnimeExtensionInstaller*"` (attempted selector run)
- Results:
  - `spotlessCheck` passed.
  - `:app:compileStableDebugKotlin` passed.
  - No dedicated installer unit test class currently exists for the selectors above; compile + review evidence used for this small internal race fix.
- Not tested:
  - Full device/emulator install-flow E2E.

## Risk
- Low to moderate (T2): registration/unregistration guard path under concurrent extension install triggers.
- Mitigation: atomic one-way transition via `compareAndSet(false, true)` and `compareAndSet(true, false)` prevents duplicate register/unregister side effects.

## SLO Impact
- None expected.

## Rollback
- Revert this PR commit to restore previous registration guard logic.

## Release Notes
- Extension installer receivers now atomically guard register/unregister transitions, preventing duplicate download-completion receiver registration under concurrent starts.

## Checklist
- [x] Naming conventions followed (use "Rayniyomi" in user-facing text, see [naming conventions](../docs/governance/naming-conventions.md))
- [x] Branch rebased on latest main and verification re-run (see [rebase policy](../docs/governance/agent-workflow.md#rebase-before-merge-policy-r45))
- [x] New coroutine scopes have documented owner and cancellation path
- [x] No new `runBlocking` on UI/main thread paths

## Definition of Done (DoD)
- [x] Acceptance criteria met and non-goals respected
- [x] Verification matrix completed (Risk Tier: T2)
- [x] Self-review completed
- [x] Rebased on latest `main` and revalidated (mandatory for merge)
- [ ] Sprint board updated (branch, commit, checks, PR link)
- [x] Release notes drafted (if applicable)
