### PR TITLE
fix: add rayniyomi deep-link compatibility aliases (R634)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 ### Fixed
 
 ### Changed
-- R634/#673: Added `rayniyomi://` deep-link alias support for add-repo and tracker auth callbacks while keeping `aniyomi://` and `tachiyomi://` compatibility routes intact
+- Added `rayniyomi://` deep-link alias support for add-repo and tracker auth callbacks while keeping `aniyomi://` and `tachiyomi://` compatibility routes intact
 
 ### CI
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 ### Fixed
 
 ### Changed
+- R634/#673: Added `rayniyomi://` deep-link alias support for add-repo and tracker auth callbacks while keeping `aniyomi://` and `tachiyomi://` compatibility routes intact
 
 ### CI
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -85,6 +85,17 @@
                 <data android:host="add-repo" />
             </intent-filter>
 
+            <!-- Deep link to add repos (fork-owned alias) -->
+            <intent-filter android:label="@string/action_add_repo">
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="rayniyomi" />
+                <data android:host="add-repo" />
+            </intent-filter>
+
             <!-- Open backup files -->
             <intent-filter android:label="@string/pref_restore_backup">
                 <action android:name="android.intent.action.VIEW" />
@@ -241,6 +252,7 @@
                 <category android:name="android.intent.category.BROWSABLE" />
 
                 <data android:scheme="aniyomi"/>
+                <data android:scheme="rayniyomi"/>
 
                 <data android:host="myanimelist-auth" />
                 <data android:host="anilist-auth" />

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
@@ -598,11 +598,25 @@ class MainActivity : BaseActivity() {
                         navigator.popUntilRoot()
                         navigator.push(AnimeExtensionReposScreen(repoUrl))
                     }
-                } // Deep link to add extension repo
+                }
+                // Deep link to add extension repo
                 else if (intent.scheme == "tachiyomi" && intent.data?.host == "add-repo") {
                     intent.data?.getQueryParameter("url")?.let { repoUrl ->
                         navigator.popUntilRoot()
                         navigator.push(MangaExtensionReposScreen(repoUrl))
+                    }
+                }
+                // Fork-owned alias for add-repo links.
+                // Uses explicit type query when provided; defaults to manga for safety.
+                else if (intent.scheme == "rayniyomi" && intent.data?.host == "add-repo") {
+                    intent.data?.getQueryParameter("url")?.let { repoUrl ->
+                        navigator.popUntilRoot()
+                        val type = intent.data?.getQueryParameter("type")
+                        if (type.equals("anime", ignoreCase = true)) {
+                            navigator.push(AnimeExtensionReposScreen(repoUrl))
+                        } else {
+                            navigator.push(MangaExtensionReposScreen(repoUrl))
+                        }
                     }
                 }
                 null


### PR DESCRIPTION
## Objective
Add fork-owned deep-link alias support so `rayniyomi://` works for add-repo and tracker auth callbacks without breaking existing `aniyomi://` and `tachiyomi://` compatibility routes.

## Scope
- Add `rayniyomi://add-repo` manifest intent-filter entry (keep legacy schemes intact)
- Add `rayniyomi://` tracker callback scheme in `TrackLoginActivity` intent-filter (keep `aniyomi://`)
- Update `MainActivity` ACTION_VIEW routing to handle `rayniyomi://add-repo` (optional `type=anime`, default manga)
- Add exactly one changelog bullet for ticket scope

## Verification
- `./gradlew spotlessCheck`
- `./gradlew :app:compileStableDebugKotlin`

## Risk
- Risk Tier: T2 (deep-link routing + callback aliasing)

Closes #673
