### PR TITLE
fix: ensure updater install path when notifications are denied (R678)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 ### Added
 
 ### Fixed
+- Updater now preserves an in-app install path when notification permission is denied on Android 13+, with validated downloaded-APK install actions surfaced in About and New Update details
 
 ### Changed
 - Added `rayniyomi://` deep-link alias support for add-repo and tracker auth callbacks while keeping `aniyomi://` and `tachiyomi://` compatibility routes intact

--- a/app/src/main/java/eu/kanade/presentation/more/NewUpdateScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/NewUpdateScreen.kt
@@ -53,6 +53,7 @@ fun NewUpdateScreen(
     versionName: String,
     changelogInfo: String,
     releaseDateEpochMillis: Long? = null,
+    isInstallAction: Boolean = false,
     onOpenInBrowser: () -> Unit,
     onRejectUpdate: () -> Unit,
     onAcceptUpdate: () -> Unit,
@@ -83,7 +84,15 @@ fun NewUpdateScreen(
                     modifier = Modifier.fillMaxWidth(),
                     onClick = onAcceptUpdate,
                 ) {
-                    Text(text = stringResource(MR.strings.update_check_confirm))
+                    Text(
+                        text = stringResource(
+                            if (isInstallAction) {
+                                MR.strings.action_install
+                            } else {
+                                MR.strings.update_check_confirm
+                            },
+                        ),
+                    )
                 }
                 Row(
                     modifier = Modifier.fillMaxWidth(),
@@ -216,6 +225,7 @@ private fun NewUpdateScreenPreview() {
                 - Hello
                 - World
             """.trimIndent(),
+            isInstallAction = false,
             onOpenInBrowser = {},
             onRejectUpdate = {},
             onAcceptUpdate = {},

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/about/AboutScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/about/AboutScreen.kt
@@ -33,6 +33,7 @@ import eu.kanade.presentation.more.settings.widget.TextPreferenceWidget
 import eu.kanade.presentation.util.LocalBackPress
 import eu.kanade.presentation.util.Screen
 import eu.kanade.tachiyomi.BuildConfig
+import eu.kanade.tachiyomi.data.updater.AppUpdateDownloadJob
 import eu.kanade.tachiyomi.data.updater.RELEASE_URL
 import eu.kanade.tachiyomi.ui.more.AppUpdatePromptDialogHost
 import eu.kanade.tachiyomi.ui.more.rememberAppUpdatePromptStateHolder
@@ -40,7 +41,9 @@ import eu.kanade.tachiyomi.util.CrashLogUtil
 import eu.kanade.tachiyomi.util.lang.toDateTimestampString
 import eu.kanade.tachiyomi.util.system.copyToClipboard
 import eu.kanade.tachiyomi.util.system.isPreviewBuildType
+import eu.kanade.tachiyomi.util.system.toast
 import eu.kanade.tachiyomi.util.system.updaterEnabled
+import eu.kanade.tachiyomi.util.system.workManager
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.components.LinkIcon
 import tachiyomi.presentation.core.components.ScrollbarLazyColumn
@@ -66,6 +69,12 @@ object AboutScreen : Screen() {
         val navigator = LocalNavigator.currentOrThrow
         val updateStateHolder = rememberAppUpdatePromptStateHolder()
         val updateState by updateStateHolder.state.collectAsStateWithLifecycle()
+        val updateWorkInfos by context.workManager
+            .getWorkInfosForUniqueWorkFlow(AppUpdateDownloadJob.TAG)
+            .collectAsStateWithLifecycle(initialValue = emptyList())
+        val hasInstallCandidate = remember(updateWorkInfos) {
+            AppUpdateDownloadJob.hasValidDownloadedUpdate(context)
+        }
         val updatePromptPreferences = remember { Injekt.get<UpdatePromptPreferences>() }
         val updateCheckInProgressA11y = stringResource(MR.strings.update_check_in_progress_a11y)
 
@@ -124,6 +133,20 @@ object AboutScreen : Screen() {
                                 }
                             },
                         )
+                    }
+
+                    if (hasInstallCandidate) {
+                        item {
+                            TextPreferenceWidget(
+                                title = stringResource(MR.strings.update_check_install_downloaded_update),
+                                onPreferenceClick = {
+                                    val installed = AppUpdateDownloadJob.installDownloadedUpdate(context)
+                                    if (!installed) {
+                                        context.toast(MR.strings.update_check_notification_download_error)
+                                    }
+                                },
+                            )
+                        }
                     }
 
                     item {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/notification/NotificationReceiver.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/notification/NotificationReceiver.kt
@@ -351,7 +351,14 @@ class NotificationReceiver : BroadcastReceiver() {
 
     private fun startDownloadAppUpdate(context: Context, intent: Intent) {
         val url = intent.getStringExtra(AppUpdateDownloadJob.EXTRA_DOWNLOAD_URL) ?: return
-        AppUpdateDownloadJob.start(context, url)
+        val title = intent.getStringExtra(AppUpdateDownloadJob.EXTRA_DOWNLOAD_TITLE)
+        val expectedVersion = intent.getStringExtra(AppUpdateDownloadJob.EXTRA_RELEASE_VERSION)
+        AppUpdateDownloadJob.start(
+            context = context,
+            url = url,
+            title = title,
+            expectedVersion = expectedVersion,
+        )
     }
 
     private fun cancelDownloadAppUpdate(context: Context) {
@@ -1019,6 +1026,7 @@ class NotificationReceiver : BroadcastReceiver() {
                 action = ACTION_START_APP_UPDATE
                 putExtra(AppUpdateDownloadJob.EXTRA_DOWNLOAD_URL, url)
                 title?.let { putExtra(AppUpdateDownloadJob.EXTRA_DOWNLOAD_TITLE, it) }
+                title?.let { putExtra(AppUpdateDownloadJob.EXTRA_RELEASE_VERSION, it) }
                 PendingIntent.getBroadcast(
                     context,
                     0,

--- a/app/src/main/java/eu/kanade/tachiyomi/data/updater/AppUpdateDownloadJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/updater/AppUpdateDownloadJob.kt
@@ -19,6 +19,7 @@ import eu.kanade.tachiyomi.network.await
 import eu.kanade.tachiyomi.network.newCachelessCallWithProgress
 import eu.kanade.tachiyomi.util.storage.getUriCompat
 import eu.kanade.tachiyomi.util.storage.saveTo
+import eu.kanade.tachiyomi.util.system.canPostNotifications
 import eu.kanade.tachiyomi.util.system.workManager
 import logcat.LogPriority
 import okhttp3.internal.http2.ErrorCode
@@ -36,10 +37,12 @@ class AppUpdateDownloadJob(private val context: Context, workerParams: WorkerPar
 
     private val notifier = AppUpdateNotifier(context)
     private val network: NetworkHelper by injectLazy()
+    private val installStateRepository = AppUpdateInstallStateRepository(context)
 
     override suspend fun doWork(): Result {
         val url = inputData.getString(EXTRA_DOWNLOAD_URL)
         val title = inputData.getString(EXTRA_DOWNLOAD_TITLE) ?: context.stringResource(MR.strings.app_name)
+        val expectedVersion = inputData.getString(EXTRA_RELEASE_VERSION)
 
         if (url.isNullOrEmpty()) {
             return Result.failure()
@@ -52,7 +55,7 @@ class AppUpdateDownloadJob(private val context: Context, workerParams: WorkerPar
         }
 
         withIOContext {
-            downloadApk(title, url)
+            downloadApk(title, url, expectedVersion)
         }
 
         return Result.success()
@@ -75,9 +78,10 @@ class AppUpdateDownloadJob(private val context: Context, workerParams: WorkerPar
      *
      * @param url url location of file
      */
-    private suspend fun downloadApk(title: String, url: String) {
+    private suspend fun downloadApk(title: String, url: String, expectedVersion: String?) {
         // Show notification download starting.
         notifier.onDownloadStarted(title)
+        installStateRepository.markDownloading(expectedVersion)
 
         val progressListener = object : ProgressListener {
             // Progress of the download
@@ -111,11 +115,15 @@ class AppUpdateDownloadJob(private val context: Context, workerParams: WorkerPar
                 response.close()
                 throw Exception("Unsuccessful response")
             }
+            installStateRepository.markDownloaded(apkFile, expectedVersion)
             notifier.cancel()
-            notifier.promptInstall(apkFile.getUriCompat(context))
+            if (context.canPostNotifications()) {
+                notifier.promptInstall(apkFile.getUriCompat(context))
+            }
         } catch (e: Exception) {
             val shouldCancel = e is CancellationException ||
                 (e is StreamResetException && e.errorCode == ErrorCode.CANCEL)
+            installStateRepository.markFailed()
             if (shouldCancel) {
                 notifier.cancel()
             } else {
@@ -125,12 +133,20 @@ class AppUpdateDownloadJob(private val context: Context, workerParams: WorkerPar
     }
 
     companion object {
-        private const val TAG = "AppUpdateDownload"
+        internal const val TAG = "AppUpdateDownload"
 
         const val EXTRA_DOWNLOAD_URL = "DOWNLOAD_URL"
         const val EXTRA_DOWNLOAD_TITLE = "DOWNLOAD_TITLE"
+        const val EXTRA_RELEASE_VERSION = "RELEASE_VERSION"
 
-        fun start(context: Context, url: String, title: String? = null) {
+        fun start(
+            context: Context,
+            url: String,
+            title: String? = null,
+            expectedVersion: String? = null,
+        ) {
+            val installStateRepository = AppUpdateInstallStateRepository(context)
+            installStateRepository.markDownloading(expectedVersion)
             val constraints = Constraints(
                 requiredNetworkType = NetworkType.CONNECTED,
             )
@@ -142,6 +158,7 @@ class AppUpdateDownloadJob(private val context: Context, workerParams: WorkerPar
                     workDataOf(
                         EXTRA_DOWNLOAD_URL to url,
                         EXTRA_DOWNLOAD_TITLE to title,
+                        EXTRA_RELEASE_VERSION to expectedVersion,
                     ),
                 )
                 .build()
@@ -150,7 +167,16 @@ class AppUpdateDownloadJob(private val context: Context, workerParams: WorkerPar
         }
 
         fun stop(context: Context) {
+            AppUpdateInstallStateRepository(context).markFailed()
             context.workManager.cancelUniqueWork(TAG)
+        }
+
+        fun hasValidDownloadedUpdate(context: Context, expectedVersion: String? = null): Boolean {
+            return AppUpdateInstallStateRepository(context).hasValidDownloadedArtifact(expectedVersion)
+        }
+
+        fun installDownloadedUpdate(context: Context, expectedVersion: String? = null): Boolean {
+            return AppUpdateInstallStateRepository(context).installDownloadedArtifact(expectedVersion)
         }
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/updater/AppUpdateInstallStateRepository.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/updater/AppUpdateInstallStateRepository.kt
@@ -1,0 +1,152 @@
+package eu.kanade.tachiyomi.data.updater
+
+import android.content.Context
+import eu.kanade.tachiyomi.BuildConfig
+import eu.kanade.tachiyomi.data.notification.NotificationHandler
+import eu.kanade.tachiyomi.util.storage.getUriCompat
+import java.io.File
+
+internal class AppUpdateInstallStateRepository(private val context: Context) {
+
+    enum class InstallState {
+        IDLE,
+        DOWNLOADING,
+        FAILED,
+        DOWNLOADED,
+    }
+
+    private val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    init {
+        clearIfAppVersionChanged()
+    }
+
+    fun markDownloading(expectedVersion: String?) {
+        deleteDownloadFile()
+        prefs.edit()
+            .putString(KEY_APP_VERSION, currentAppVersion())
+            .putString(KEY_STATE, InstallState.DOWNLOADING.name)
+            .putString(KEY_EXPECTED_VERSION, expectedVersion)
+            .remove(KEY_FILE_PATH)
+            .remove(KEY_COMPLETED_AT)
+            .putBoolean(KEY_COMPLETED, false)
+            .apply()
+    }
+
+    fun markFailed() {
+        deleteDownloadFile()
+        prefs.edit()
+            .putString(KEY_STATE, InstallState.FAILED.name)
+            .remove(KEY_FILE_PATH)
+            .remove(KEY_COMPLETED_AT)
+            .putBoolean(KEY_COMPLETED, false)
+            .apply()
+    }
+
+    fun markDownloaded(file: File, expectedVersion: String?) {
+        prefs.edit()
+            .putString(KEY_APP_VERSION, currentAppVersion())
+            .putString(KEY_STATE, InstallState.DOWNLOADED.name)
+            .putString(KEY_EXPECTED_VERSION, expectedVersion)
+            .putString(KEY_FILE_PATH, file.absolutePath)
+            .putLong(KEY_COMPLETED_AT, System.currentTimeMillis())
+            .putBoolean(KEY_COMPLETED, true)
+            .apply()
+    }
+
+    fun clearAll() {
+        deleteDownloadFile()
+        prefs.edit()
+            .putString(KEY_STATE, InstallState.IDLE.name)
+            .remove(KEY_EXPECTED_VERSION)
+            .remove(KEY_FILE_PATH)
+            .remove(KEY_COMPLETED_AT)
+            .putBoolean(KEY_COMPLETED, false)
+            .apply()
+    }
+
+    fun hasValidDownloadedArtifact(expectedVersion: String? = null): Boolean {
+        return getValidDownloadedArtifact(expectedVersion) != null
+    }
+
+    fun installDownloadedArtifact(expectedVersion: String? = null): Boolean {
+        val artifact = getValidDownloadedArtifact(expectedVersion) ?: return false
+        return runCatching {
+            NotificationHandler.installApkPendingActivity(
+                context,
+                artifact.file.getUriCompat(context),
+            ).send()
+            true
+        }.getOrElse {
+            clearAll()
+            false
+        }
+    }
+
+    private fun getValidDownloadedArtifact(expectedVersion: String?): DownloadedArtifact? {
+        clearIfAppVersionChanged()
+
+        val state = prefs.getString(KEY_STATE, InstallState.IDLE.name)
+            ?.let(InstallState::valueOf)
+            ?: InstallState.IDLE
+        if (state != InstallState.DOWNLOADED || !prefs.getBoolean(KEY_COMPLETED, false)) {
+            return null
+        }
+
+        val storedExpectedVersion = prefs.getString(KEY_EXPECTED_VERSION, null)
+        if (expectedVersion != null && storedExpectedVersion != expectedVersion) {
+            clearAll()
+            return null
+        }
+
+        val path = prefs.getString(KEY_FILE_PATH, null) ?: run {
+            clearAll()
+            return null
+        }
+        val file = File(path)
+        if (!AppUpdateInstallArtifactValidator.isValidDownloadedFile(file, MIN_APK_BYTES)) {
+            clearAll()
+            return null
+        }
+
+        return DownloadedArtifact(file = file, expectedVersion = storedExpectedVersion)
+    }
+
+    private fun clearIfAppVersionChanged() {
+        val storedVersion = prefs.getString(KEY_APP_VERSION, null) ?: return
+        if (storedVersion != currentAppVersion()) {
+            clearAll()
+        }
+    }
+
+    private fun currentAppVersion(): String {
+        return "${BuildConfig.VERSION_NAME}:${BuildConfig.COMMIT_SHA}"
+    }
+
+    private fun deleteDownloadFile() {
+        val path = prefs.getString(KEY_FILE_PATH, null) ?: return
+        runCatching { File(path).delete() }
+    }
+
+    private data class DownloadedArtifact(
+        val file: File,
+        val expectedVersion: String?,
+    )
+
+    companion object {
+        private const val PREFS_NAME = "app_update_install_state"
+        private const val KEY_STATE = "state"
+        private const val KEY_EXPECTED_VERSION = "expected_version"
+        private const val KEY_FILE_PATH = "file_path"
+        private const val KEY_COMPLETED = "completed"
+        private const val KEY_COMPLETED_AT = "completed_at"
+        private const val KEY_APP_VERSION = "app_version"
+        private const val MIN_APK_BYTES = 32 * 1024L
+    }
+}
+
+internal object AppUpdateInstallArtifactValidator {
+    fun isValidDownloadedFile(file: File, minBytes: Long): Boolean {
+        return file.exists() && file.length() >= minBytes
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/updater/AppUpdatePermissionPolicy.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/updater/AppUpdatePermissionPolicy.kt
@@ -1,0 +1,29 @@
+package eu.kanade.tachiyomi.data.updater
+
+internal object AppUpdatePermissionPolicy {
+
+    enum class StartMode {
+        START_WITH_NOTIFICATIONS,
+        REQUEST_NOTIFICATIONS_PERMISSION,
+        START_WITH_IN_APP_FALLBACK,
+    }
+
+    fun initialStartMode(
+        sdkInt: Int,
+        notificationPermissionGranted: Boolean,
+    ): StartMode {
+        return if (sdkInt < 33 || notificationPermissionGranted) {
+            StartMode.START_WITH_NOTIFICATIONS
+        } else {
+            StartMode.REQUEST_NOTIFICATIONS_PERMISSION
+        }
+    }
+
+    fun startModeAfterPermissionResult(granted: Boolean): StartMode {
+        return if (granted) {
+            StartMode.START_WITH_NOTIFICATIONS
+        } else {
+            StartMode.START_WITH_IN_APP_FALLBACK
+        }
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/more/AppUpdatePromptDialogHost.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/more/AppUpdatePromptDialogHost.kt
@@ -1,9 +1,21 @@
 package eu.kanade.tachiyomi.ui.more
 
+import android.Manifest
 import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.provider.Settings
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import cafe.adriel.voyager.navigator.LocalNavigator
@@ -12,6 +24,8 @@ import eu.kanade.domain.update.UpdatePromptGatekeeper
 import eu.kanade.presentation.more.AppUpdatePromptDialog
 import eu.kanade.tachiyomi.data.updater.AppUpdateChecker
 import eu.kanade.tachiyomi.data.updater.AppUpdateDownloadJob
+import eu.kanade.tachiyomi.data.updater.AppUpdatePermissionPolicy
+import eu.kanade.tachiyomi.util.system.canPostNotifications
 import eu.kanade.tachiyomi.util.system.toast
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -24,6 +38,7 @@ import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.release.interactor.GetApplicationRelease
 import tachiyomi.domain.release.model.Release
 import tachiyomi.i18n.MR
+import tachiyomi.presentation.core.i18n.stringResource
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 
@@ -32,28 +47,98 @@ fun AppUpdatePromptDialogHost(
     stateHolder: AppUpdatePromptStateHolder,
 ) {
     val state = stateHolder.state.collectAsStateWithLifecycle().value
-    val release = state.pendingRelease ?: return
 
+    val context = LocalContext.current
     val navigator = LocalNavigator.currentOrThrow
+    var pendingPermissionRelease by remember { mutableStateOf<Release?>(null) }
+    val permissionRequester = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission(),
+    ) { granted ->
+        val pendingRelease = pendingPermissionRelease ?: return@rememberLauncherForActivityResult
+        pendingPermissionRelease = null
 
-    AppUpdatePromptDialog(
-        versionName = release.version,
-        onUpdateNow = stateHolder::onUpdateNow,
-        onLater = stateHolder::onLater,
-        onSkipVersion = stateHolder::onSkipVersion,
-        onViewDetails = {
+        val mode = AppUpdatePermissionPolicy.startModeAfterPermissionResult(granted)
+        stateHolder.onUpdateNow(
+            showFallbackPermissionMessage = mode == AppUpdatePermissionPolicy.StartMode.START_WITH_IN_APP_FALLBACK,
+        )
+        if (mode == AppUpdatePermissionPolicy.StartMode.START_WITH_IN_APP_FALLBACK) {
             navigator.push(
                 NewUpdateScreen(
-                    versionName = release.version,
-                    changelogInfo = release.info,
-                    releaseLink = release.releaseLink,
-                    downloadLink = release.downloadLink,
-                    releaseDateEpochMillis = release.publishedAt,
+                    versionName = pendingRelease.version,
+                    changelogInfo = pendingRelease.info,
+                    releaseLink = pendingRelease.releaseLink,
+                    downloadLink = pendingRelease.downloadLink,
+                    releaseDateEpochMillis = pendingRelease.publishedAt,
                 ),
             )
-            stateHolder.onLater()
-        },
-    )
+        }
+    }
+
+    state.pendingRelease?.let { release ->
+        AppUpdatePromptDialog(
+            versionName = release.version,
+            onUpdateNow = {
+                when (
+                    AppUpdatePermissionPolicy.initialStartMode(
+                        Build.VERSION.SDK_INT,
+                        context.canPostNotifications(),
+                    )
+                ) {
+                    AppUpdatePermissionPolicy.StartMode.START_WITH_NOTIFICATIONS -> {
+                        stateHolder.onUpdateNow(showFallbackPermissionMessage = false)
+                    }
+                    AppUpdatePermissionPolicy.StartMode.REQUEST_NOTIFICATIONS_PERMISSION -> {
+                        pendingPermissionRelease = release
+                        permissionRequester.launch(Manifest.permission.POST_NOTIFICATIONS)
+                    }
+                    AppUpdatePermissionPolicy.StartMode.START_WITH_IN_APP_FALLBACK -> {
+                        stateHolder.onUpdateNow(showFallbackPermissionMessage = true)
+                    }
+                }
+            },
+            onLater = stateHolder::onLater,
+            onSkipVersion = stateHolder::onSkipVersion,
+            onViewDetails = {
+                navigator.push(
+                    NewUpdateScreen(
+                        versionName = release.version,
+                        changelogInfo = release.info,
+                        releaseLink = release.releaseLink,
+                        downloadLink = release.downloadLink,
+                        releaseDateEpochMillis = release.publishedAt,
+                    ),
+                )
+                stateHolder.onLater()
+            },
+        )
+    }
+
+    if (state.showNotificationPermissionDeniedMessage) {
+        AlertDialog(
+            onDismissRequest = stateHolder::dismissNotificationPermissionDeniedMessage,
+            title = { Text(text = stringResource(MR.strings.onboarding_permission_notifications)) },
+            text = { Text(text = stringResource(MR.strings.update_check_notifications_denied_message)) },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        context.startActivity(
+                            Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS).apply {
+                                putExtra(Settings.EXTRA_APP_PACKAGE, context.packageName)
+                            },
+                        )
+                        stateHolder.dismissNotificationPermissionDeniedMessage()
+                    },
+                ) {
+                    Text(text = stringResource(MR.strings.pref_manage_notifications))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = stateHolder::dismissNotificationPermissionDeniedMessage) {
+                    Text(text = stringResource(MR.strings.action_not_now))
+                }
+            },
+        )
+    }
 }
 
 @Composable
@@ -116,13 +201,17 @@ class AppUpdatePromptStateHolder(
         }
     }
 
-    fun onUpdateNow() {
+    fun onUpdateNow(showFallbackPermissionMessage: Boolean) {
         val release = state.value.pendingRelease ?: return
         AppUpdateDownloadJob.start(
             context = appContext,
             url = release.downloadLink,
             title = release.version,
+            expectedVersion = release.version,
         )
+        if (showFallbackPermissionMessage) {
+            mutableState.update { it.copy(showNotificationPermissionDeniedMessage = true) }
+        }
         onLater()
     }
 
@@ -137,8 +226,13 @@ class AppUpdatePromptStateHolder(
         mutableState.update { it.copy(pendingRelease = null) }
     }
 
+    fun dismissNotificationPermissionDeniedMessage() {
+        mutableState.update { it.copy(showNotificationPermissionDeniedMessage = false) }
+    }
+
     data class State(
         val pendingRelease: Release? = null,
         val isChecking: Boolean = false,
+        val showNotificationPermissionDeniedMessage: Boolean = false,
     )
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/more/NewUpdateScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/more/NewUpdateScreen.kt
@@ -1,9 +1,22 @@
 package eu.kanade.tachiyomi.ui.more
 
+import android.Manifest
+import android.content.Intent
+import android.os.Build
+import android.provider.Settings
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.VisibleForTesting
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.Navigator
 import cafe.adriel.voyager.navigator.currentOrThrow
@@ -11,7 +24,13 @@ import eu.kanade.domain.update.UpdatePromptGatekeeper
 import eu.kanade.presentation.more.NewUpdateScreen
 import eu.kanade.presentation.util.Screen
 import eu.kanade.tachiyomi.data.updater.AppUpdateDownloadJob
+import eu.kanade.tachiyomi.data.updater.AppUpdatePermissionPolicy
+import eu.kanade.tachiyomi.util.system.canPostNotifications
 import eu.kanade.tachiyomi.util.system.openInBrowser
+import eu.kanade.tachiyomi.util.system.toast
+import eu.kanade.tachiyomi.util.system.workManager
+import tachiyomi.i18n.MR
+import tachiyomi.presentation.core.i18n.stringResource
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 
@@ -45,6 +64,45 @@ class NewUpdateScreen(
     override fun Content() {
         val navigator = LocalNavigator.currentOrThrow
         val context = LocalContext.current
+        val workInfos by context.workManager
+            .getWorkInfosForUniqueWorkFlow(AppUpdateDownloadJob.TAG)
+            .collectAsStateWithLifecycle(initialValue = emptyList())
+        var installStateRefreshNonce by remember { mutableStateOf(0) }
+        val hasInstallCandidate = remember(workInfos, installStateRefreshNonce) {
+            AppUpdateDownloadJob.hasValidDownloadedUpdate(
+                context = context,
+                expectedVersion = versionName,
+            )
+        }
+        var showPermissionDeniedDialog by remember { mutableStateOf(false) }
+        var pendingPermissionRequest by remember { mutableStateOf(false) }
+        val permissionRequester = rememberLauncherForActivityResult(
+            contract = ActivityResultContracts.RequestPermission(),
+        ) { granted ->
+            val mode = AppUpdatePermissionPolicy.startModeAfterPermissionResult(granted)
+            when (mode) {
+                AppUpdatePermissionPolicy.StartMode.START_WITH_NOTIFICATIONS -> {
+                    AppUpdateDownloadJob.start(
+                        context = context,
+                        url = downloadLink,
+                        title = versionName,
+                        expectedVersion = versionName,
+                    )
+                    navigator.pop()
+                }
+                AppUpdatePermissionPolicy.StartMode.START_WITH_IN_APP_FALLBACK -> {
+                    AppUpdateDownloadJob.start(
+                        context = context,
+                        url = downloadLink,
+                        title = versionName,
+                        expectedVersion = versionName,
+                    )
+                    showPermissionDeniedDialog = true
+                }
+                AppUpdatePermissionPolicy.StartMode.REQUEST_NOTIFICATIONS_PERMISSION -> Unit
+            }
+            pendingPermissionRequest = false
+        }
         val changelogInfoNoChecksum = remember {
             changelogInfo.replace("""---(\R|.)*Checksums(\R|.)*""".toRegex(), "")
         }
@@ -53,17 +111,82 @@ class NewUpdateScreen(
             versionName = versionName,
             changelogInfo = changelogInfoNoChecksum,
             releaseDateEpochMillis = releaseDateEpochMillis,
+            isInstallAction = hasInstallCandidate,
             onOpenInBrowser = { context.openInBrowser(releaseLink) },
             onRejectUpdate = buildOnRejectUpdate(navigator),
             onAcceptUpdate = {
-                AppUpdateDownloadJob.start(
-                    context = context,
-                    url = downloadLink,
-                    title = versionName,
-                )
-                navigator.pop()
+                if (hasInstallCandidate) {
+                    val installed = AppUpdateDownloadJob.installDownloadedUpdate(
+                        context = context,
+                        expectedVersion = versionName,
+                    )
+                    if (installed) {
+                        navigator.pop()
+                    } else {
+                        installStateRefreshNonce++
+                        context.toast(MR.strings.update_check_notification_download_error)
+                    }
+                    return@NewUpdateScreen
+                }
+
+                when (
+                    AppUpdatePermissionPolicy.initialStartMode(
+                        Build.VERSION.SDK_INT,
+                        context.canPostNotifications(),
+                    )
+                ) {
+                    AppUpdatePermissionPolicy.StartMode.START_WITH_NOTIFICATIONS -> {
+                        AppUpdateDownloadJob.start(
+                            context = context,
+                            url = downloadLink,
+                            title = versionName,
+                            expectedVersion = versionName,
+                        )
+                        navigator.pop()
+                    }
+                    AppUpdatePermissionPolicy.StartMode.REQUEST_NOTIFICATIONS_PERMISSION -> {
+                        pendingPermissionRequest = true
+                        permissionRequester.launch(Manifest.permission.POST_NOTIFICATIONS)
+                    }
+                    AppUpdatePermissionPolicy.StartMode.START_WITH_IN_APP_FALLBACK -> {
+                        AppUpdateDownloadJob.start(
+                            context = context,
+                            url = downloadLink,
+                            title = versionName,
+                            expectedVersion = versionName,
+                        )
+                        showPermissionDeniedDialog = true
+                    }
+                }
             },
             onSkipVersion = buildOnSkipVersion(navigator),
         )
+
+        if (showPermissionDeniedDialog && !pendingPermissionRequest) {
+            AlertDialog(
+                onDismissRequest = { showPermissionDeniedDialog = false },
+                title = { Text(text = stringResource(MR.strings.onboarding_permission_notifications)) },
+                text = { Text(text = stringResource(MR.strings.update_check_notifications_denied_message)) },
+                confirmButton = {
+                    TextButton(
+                        onClick = {
+                            context.startActivity(
+                                Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS).apply {
+                                    putExtra(Settings.EXTRA_APP_PACKAGE, context.packageName)
+                                },
+                            )
+                            showPermissionDeniedDialog = false
+                        },
+                    ) {
+                        Text(text = stringResource(MR.strings.pref_manage_notifications))
+                    }
+                },
+                dismissButton = {
+                    TextButton(onClick = { showPermissionDeniedDialog = false }) {
+                        Text(text = stringResource(MR.strings.action_not_now))
+                    }
+                },
+            )
+        }
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/util/system/NotificationExtensions.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/system/NotificationExtensions.kt
@@ -27,12 +27,7 @@ fun Context.notify(
 }
 
 fun Context.notify(id: Int, notification: Notification) {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
-        PermissionChecker.checkSelfPermission(
-            this,
-            Manifest.permission.POST_NOTIFICATIONS,
-        ) != PermissionChecker.PERMISSION_GRANTED
-    ) {
+    if (!canPostNotifications()) {
         return
     }
 
@@ -40,16 +35,19 @@ fun Context.notify(id: Int, notification: Notification) {
 }
 
 fun Context.notify(notificationWithIdAndTags: List<NotificationWithIdAndTag>) {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
-        PermissionChecker.checkSelfPermission(
-            this,
-            Manifest.permission.POST_NOTIFICATIONS,
-        ) != PermissionChecker.PERMISSION_GRANTED
-    ) {
+    if (!canPostNotifications()) {
         return
     }
 
     NotificationManagerCompat.from(this).notify(notificationWithIdAndTags)
+}
+
+fun Context.canPostNotifications(): Boolean {
+    return Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ||
+        PermissionChecker.checkSelfPermission(
+            this,
+            Manifest.permission.POST_NOTIFICATIONS,
+        ) == PermissionChecker.PERMISSION_GRANTED
 }
 
 fun Context.cancelNotification(id: Int) {

--- a/app/src/test/java/eu/kanade/tachiyomi/data/updater/AppUpdateInstallArtifactValidatorTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/data/updater/AppUpdateInstallArtifactValidatorTest.kt
@@ -1,0 +1,34 @@
+package eu.kanade.tachiyomi.data.updater
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+import kotlin.io.path.createTempDirectory
+
+class AppUpdateInstallArtifactValidatorTest {
+
+    @Test
+    fun `isValidDownloadedFile returns true for non-trivial existing apk`() {
+        val tempDir = createTempDirectory(prefix = "app-update-validator").toFile()
+        val apkFile = File(tempDir, "update.apk").apply {
+            writeBytes(ByteArray(64 * 1024))
+        }
+
+        val valid = AppUpdateInstallArtifactValidator.isValidDownloadedFile(apkFile, minBytes = 32 * 1024L)
+
+        assertTrue(valid)
+    }
+
+    @Test
+    fun `isValidDownloadedFile returns false for missing or stale artifact`() {
+        val tempDir = createTempDirectory(prefix = "app-update-validator").toFile()
+        val missing = File(tempDir, "missing.apk")
+        val tiny = File(tempDir, "tiny.apk").apply {
+            writeBytes(ByteArray(8 * 1024))
+        }
+
+        assertFalse(AppUpdateInstallArtifactValidator.isValidDownloadedFile(missing, minBytes = 32 * 1024L))
+        assertFalse(AppUpdateInstallArtifactValidator.isValidDownloadedFile(tiny, minBytes = 32 * 1024L))
+    }
+}

--- a/app/src/test/java/eu/kanade/tachiyomi/data/updater/AppUpdatePermissionPolicyTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/data/updater/AppUpdatePermissionPolicyTest.kt
@@ -1,0 +1,34 @@
+package eu.kanade.tachiyomi.data.updater
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class AppUpdatePermissionPolicyTest {
+
+    @Test
+    fun `initialStartMode returns normal path below Android 13`() {
+        val mode = AppUpdatePermissionPolicy.initialStartMode(
+            sdkInt = 32,
+            notificationPermissionGranted = false,
+        )
+
+        assertEquals(AppUpdatePermissionPolicy.StartMode.START_WITH_NOTIFICATIONS, mode)
+    }
+
+    @Test
+    fun `initialStartMode requests permission on Android 13+ when denied`() {
+        val mode = AppUpdatePermissionPolicy.initialStartMode(
+            sdkInt = 33,
+            notificationPermissionGranted = false,
+        )
+
+        assertEquals(AppUpdatePermissionPolicy.StartMode.REQUEST_NOTIFICATIONS_PERMISSION, mode)
+    }
+
+    @Test
+    fun `startModeAfterPermissionResult returns fallback when denied`() {
+        val mode = AppUpdatePermissionPolicy.startModeAfterPermissionResult(granted = false)
+
+        assertEquals(AppUpdatePermissionPolicy.StartMode.START_WITH_IN_APP_FALLBACK, mode)
+    }
+}

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -1035,6 +1035,8 @@
     <string name="update_check_notification_download_in_progress">Downloading…</string>
     <string name="update_check_notification_download_complete">Tap to install update</string>
     <string name="update_check_notification_download_error">Download error</string>
+    <string name="update_check_notifications_denied_message">Notifications are off. Download will continue, and you can install from this screen when it completes.</string>
+    <string name="update_check_install_downloaded_update">Install downloaded update</string>
     <string name="update_check_notification_update_available">New version available!</string>
 
     <!-- Information Text -->


### PR DESCRIPTION
## Ticket
- ID: R678
- Priority: P1
- Risk Tier: T2
- GitHub Issue: Closes #678

## Objective
- Ensure updater install remains user-completable on Android 13+ when `POST_NOTIFICATIONS` is denied.

## Scope
- Add updater install-state repository with `idle/downloading/failed/downloaded` states and persisted artifact metadata validation.
- Keep permission request handling in UI entrypoints (`AppUpdatePromptDialogHost`, `NewUpdateScreen` wrapper).
- Add denied-permission fallback UX with notification-settings action.
- Surface validated in-app install CTA in About update area and New Update details.
- Revalidate artifact at install tap and clear stale/mismatch state.
- Add regression tests for permission policy and artifact validation helper.

## Non-goals
- No updater API/schema changes.
- No changes to install mechanism beyond existing APK install intent path.
- No instrumentation additions in this PR.

## Files Changed
- `app/src/main/java/eu/kanade/tachiyomi/data/updater/*`
- `app/src/main/java/eu/kanade/tachiyomi/ui/more/*`
- `app/src/main/java/eu/kanade/presentation/more/*`
- `app/src/main/java/eu/kanade/presentation/more/settings/screen/about/AboutScreen.kt`
- `app/src/main/java/eu/kanade/tachiyomi/data/notification/NotificationReceiver.kt`
- `app/src/main/java/eu/kanade/tachiyomi/util/system/NotificationExtensions.kt`
- `app/src/test/java/eu/kanade/tachiyomi/data/updater/*`
- `i18n/src/commonMain/moko-resources/base/strings.xml`
- `CHANGELOG.md`

## Verification
- Commands run:
  - `./gradlew :app:testDebugUnitTest --tests "*AppUpdate*"`
  - `./gradlew :app:testDebugUnitTest --tests "*AppUpdatePermissionPolicyTest*" --tests "*AppUpdateInstallArtifactValidatorTest*" --tests "*NewUpdateScreenTest*"`
  - `./gradlew spotlessCheck`
  - `./gradlew :app:compileStableDebugKotlin` (`:app:compileDebugKotlin` is flavor-ambiguous in this module)
- Results:
  - All commands above passed locally.
- Not tested:
  - Android instrumentation/emulator flow in this PR.

## Risk
- Main risk is invalid persisted artifact state exposing stale install CTA.
- Mitigation: repository validates state + file size/existence, revalidates on tap, clears mismatch/stale state.

## SLO Impact
- None expected (UI/update-path behavior change only).

## Rollback
- Revert this PR to return to notification-only install prompt behavior.

## Release Notes
- Updater now preserves an install path when notification permission is denied by exposing validated in-app install actions.

## Checklist
- [x] Naming conventions followed (use "Rayniyomi" in user-facing text, see [naming conventions](../docs/governance/naming-conventions.md))
- [x] Branch rebased on latest main and verification re-run (see [rebase policy](../docs/governance/agent-workflow.md#rebase-before-merge-policy-r45))
- [x] New coroutine scopes have documented owner and cancellation path
- [x] No new `runBlocking` on UI/main thread paths

## Definition of Done (DoD)
- [x] Acceptance criteria met and non-goals respected
- [x] Verification matrix completed (Risk Tier: T2)
- [x] Self-review completed
- [x] Rebased on latest `main` and revalidated (mandatory for merge)
- [ ] Sprint board updated (branch, commit, checks, PR link)
- [x] Release notes drafted (if applicable)

## Fork Compliance Checklist (for new forks only)
If you are creating a new fork of this project, ensure the following:
- [ ] **App Identity**: Changed app name from "Aniyomi" to your fork name
- [ ] **App Icon**: Replaced launcher icon assets with fork-specific icons
- [ ] **Application ID**: Changed `applicationId` in `app/build.gradle.kts` from `xyz.rayniyomi` to your unique ID
- [ ] **Update Checker**: Configured `AppUpdateChecker.kt` to point to your fork's repository
- [ ] **Analytics**: Either disabled Firebase Analytics or configured with your own `google-services.json`
- [ ] **Crash Reporting**: Either disabled ACRA crash reporting or configured with your own endpoint credentials
