### PR TITLE
ci: fix branding guardrail allowlist no-op check (R640)

### DIFF
--- a/.github/workflows/build_pull_request.yml
+++ b/.github/workflows/build_pull_request.yml
@@ -49,7 +49,7 @@ jobs:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           set -euxo pipefail
-          added_lines=$(git diff --unified=0 "$BASE_SHA...HEAD" -- scripts/branding_guardrail_allowlist.txt | grep -E '^\+[^+]' | wc -l | tr -d ' ')
+          added_lines=$(git diff --unified=0 "$BASE_SHA...HEAD" -- scripts/branding_guardrail_allowlist.txt | { grep -E '^\+[^+]' || true; } | wc -l | tr -d ' ')
           if [ "$added_lines" -gt 0 ]; then
             if ! printf '%s\n' "${PR_BODY:-}" | grep -Eq '^##[[:space:]]+Branding Guardrail Exceptions'; then
               echo "Allowlist grew, but PR body is missing '## Branding Guardrail Exceptions'" >&2


### PR DESCRIPTION
## Objective
Fix the `Branding guardrail (pull_request)` workflow so PRs that do not add allowlist entries do not fail the allowlist-exception step under `set -o pipefail`.

Closes #683

## Scope
- Keep `pipefail` enabled for the workflow step.
- Make the `grep` no-match case non-fatal when counting added allowlist lines.
- Preserve detection for actual added allowlist entries, so the required PR exception section is still enforced.

## Verification
- `set -euxo pipefail` shell reproduction for no-match and positive-match allowlist diffs
- `python3 scripts/check_branding_guardrail.py --base origin/main`
- `python3 -m pytest scripts/tests/test_branding_guardrail.py`
- `./gradlew spotlessCheck`
- `./gradlew :app:compileStableDebugKotlin`

## Risk
Risk Tier: T1. CI-only workflow fix with no app runtime impact.

## Rollback
Revert this PR to restore the previous workflow expression.

## Release Notes
None. CI-only change.
