### PR TITLE
fix: normalize localized format placeholders (R686)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 ### Fixed
 - Updater now preserves an in-app install path when notification permission is denied on Android 13+, with validated downloaded-APK install actions surfaced in About and New Update details
 - Extension repo restore now skips database insertions for exact duplicate repo records already present in local storage, preventing restore failures from primary-key/unique-key collisions when restoring the same backup more than once
+- Localized string format placeholders were normalized to Android-compatible positional syntax and malformed locale placeholders were corrected, unblocking stable release resource merge/build failures
 
 ### Changed
 - Added `rayniyomi://` deep-link alias support for add-repo and tracker auth callbacks while keeping `aniyomi://` and `tachiyomi://` compatibility routes intact

--- a/i18n-aniyomi/src/commonMain/moko-resources/ar/strings.xml
+++ b/i18n-aniyomi/src/commonMain/moko-resources/ar/strings.xml
@@ -144,7 +144,7 @@
     <string name="enable_auto_play">التشغيل التلقائي مفعل</string>
     <string name="disable_auto_play">التشغيل التلقائي متوقف</string>
     <string name="player_aniskip_dontskip">لا تتخطى</string>
-    <string name="player_aniskip_dontskip_toast">تخطي %s خلال %d ثانية</string>
+    <string name="player_aniskip_dontskip_toast">تخطي %1$s خلال %2$d ثانية</string>
     <string name="player_aniskip_skip">تم تخطي %s</string>
     <string name="no_next_episode">الحلقة التالية غير موجودة!</string>
     <string name="no_prev_episode">الحلقة السابقة غير موجودة!</string>
@@ -192,7 +192,7 @@
     <string name="player_sheets_filters_hue">الصبغة</string>
     <string name="player_sheets_filters_warning">قد لا تعمل بعض الفلاتر على برنامج تشغيل الفيديو الحالي لديك</string>
     <string name="player_sheets_add_ext_audio">إضافة صوت خارجي</string>
-    <string name="player_sheets_decoder_formatted">%s (%s)</string>
+    <string name="player_sheets_decoder_formatted">%1$s (%2$s)</string>
     <string name="player_sheets_more_title">المزيد</string>
     <string name="player_hwdec_mode">تعيين وضع فك تشفير الأجهزة الافتراضي</string>
     <string name="pref_audio_channels">قنوات الصوت</string>

--- a/i18n-aniyomi/src/commonMain/moko-resources/as/strings.xml
+++ b/i18n-aniyomi/src/commonMain/moko-resources/as/strings.xml
@@ -146,7 +146,7 @@
     <string name="enable_auto_play">স্বয়ংক্ৰিয় চলন সক্ৰিয়</string>
     <string name="disable_auto_play">স্বয়ংক্ৰিয় চলন অক্ষম</string>
     <string name="player_aniskip_dontskip">এৰি নিদিব</string>
-    <string name="player_aniskip_dontskip_toast">%s ৰ %d ছেকেণ্ডত এৰি দিয়া হ’ব</string>
+    <string name="player_aniskip_dontskip_toast">%1$s ৰ %2$d ছেকেণ্ডত এৰি দিয়া হ’ব</string>
     <string name="player_aniskip_skip">%s এৰি দিয়া হৈছে</string>
     <string name="no_next_episode">পৰৱৰ্তী পৰ্ব পোৱা নগ’ল!</string>
     <string name="no_prev_episode">আগৰ পৰ্ব পোৱা নগ’ল!</string>
@@ -194,7 +194,7 @@
     <string name="player_sheets_filters_hue">ৰঙৰ ছাঁ</string>
     <string name="player_sheets_filters_warning">কিছুমান ফিল্টাৰ আপোনাৰ বৰ্তমানৰ ভিডিঅ’ ড্ৰাইভাৰত কাম নকৰিব পাৰে</string>
     <string name="player_sheets_add_ext_audio">বাহ্যিক শব্দৰ ট্ৰেক যোগ কৰক</string>
-    <string name="player_sheets_decoder_formatted">%s (%s)</string>
+    <string name="player_sheets_decoder_formatted">%1$s (%2$s)</string>
     <string name="player_sheets_more_title">অধিক</string>
     <string name="player_hwdec_mode">হাৰ্ডৱেৰ ডিক’ডিং মোড</string>
     <string name="pref_audio_channels">শব্দৰ চেনেল</string>

--- a/i18n-aniyomi/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n-aniyomi/src/commonMain/moko-resources/base/strings.xml
@@ -265,7 +265,7 @@
     <string name="enable_auto_play">Auto-play is on</string>
     <string name="disable_auto_play">Auto-play is off</string>
     <string name="player_aniskip_dontskip">Don\'t skip</string>
-    <string name="player_aniskip_dontskip_toast">Skipping %s in %d seconds</string>
+    <string name="player_aniskip_dontskip_toast">Skipping %1$s in %2$d seconds</string>
     <string name="player_aniskip_skip">%s skipped</string>
     <!-- Errors -->
     <string name="no_next_episode">Next Episode not found!</string>
@@ -276,9 +276,9 @@
     <string name="select_hoster_from_empty_list">Hoster selected from empty list</string>
     <!-- Sheets -->
     <string name="player_sheets_delay_set_as_default">Set as default</string>
-    <string name="player_sheets_track_title_w_lang" translatable="false">#%d: %s (%s)</string>
-    <string name="player_sheets_track_title_wo_lang" translatable="false">#%d: %s</string>
-    <string name="player_sheets_track_lang_wo_title" translatable="false">#%d: %s</string>
+    <string name="player_sheets_track_title_w_lang" translatable="false">#%1$d: %2$s (%3$s)</string>
+    <string name="player_sheets_track_title_wo_lang" translatable="false">#%1$d: %2$s</string>
+    <string name="player_sheets_track_lang_wo_title" translatable="false">#%1$d: %2$s</string>
     <string name="player_sheets_track_delay">Delay</string>
     <string name="player_sheets_track_palette">Palette</string>
     <!-- Sheets - Audio delay -->
@@ -338,7 +338,7 @@
     <string name="player_hoster_failed">Failed to load videos</string>
     <string name="player_sheets_qualities_title">Qualities</string>
     <!-- Sheets - Decoders -->
-    <string name="player_sheets_decoder_formatted">%s (%s)</string>
+    <string name="player_sheets_decoder_formatted">%1$s (%2$s)</string>
     <!-- Sheets - More Sheet -->
     <string name="player_sheets_more_title">More</string>
     <string name="player_hwdec_mode">Hardware decoding mode</string>
@@ -348,7 +348,7 @@
     <string name="player_sheets_stats_page_chip">Page %d</string>
     <string name="player_sheets_custom_buttons_title">Custom buttons</string>
     <string name="player_seek_n_seconds">%d seconds</string>
-    <string name="player_gesture_seek_indicator" translatable="false">%c%s\n[%s]</string>
+    <string name="player_gesture_seek_indicator" translatable="false">%1$c%2$s\n[%3$s]</string>
     <string name="timer_title">Sleep Timer</string>
     <string name="timer_remaining">%s remaining</string>
     <string name="timer_picker_enter_timer">Enter duration</string>

--- a/i18n-aniyomi/src/commonMain/moko-resources/ca/strings.xml
+++ b/i18n-aniyomi/src/commonMain/moko-resources/ca/strings.xml
@@ -58,7 +58,7 @@
     <string name="enable_auto_play">Reproducció automàtica activada</string>
     <string name="disable_auto_play">Reproducció automàtica desactivada</string>
     <string name="player_aniskip_dontskip">No saltar</string>
-    <string name="player_aniskip_dontskip_toast">Salta %s en %d segons</string>
+    <string name="player_aniskip_dontskip_toast">Salta %1$s en %2$d segons</string>
     <string name="player_aniskip_skip">%s saltats</string>
     <string name="no_next_episode">No s\'ha trobat el següent episodi!</string>
     <string name="player_hwdec_mode">Establir per defecte el mode decodificació per hardware</string>

--- a/i18n-aniyomi/src/commonMain/moko-resources/cs/strings.xml
+++ b/i18n-aniyomi/src/commonMain/moko-resources/cs/strings.xml
@@ -85,7 +85,7 @@
     <string name="enable_auto_play">Automatické přerávání je zapnuté</string>
     <string name="disable_auto_play">Automatické přerávání je vypnuté</string>
     <string name="player_aniskip_dontskip">Nepřeskakovat</string>
-    <string name="player_aniskip_dontskip_toast">Přeskočí %s za %d sekund</string>
+    <string name="player_aniskip_dontskip_toast">Přeskočí %1$s za %2$d sekund</string>
     <string name="player_aniskip_skip">Přeskočeno %s</string>
     <string name="no_next_episode">Další epizoda nenalezena!</string>
     <string name="player_hwdec_mode">Nastavit výchozí hardwarový dekódovací režim</string>
@@ -413,7 +413,7 @@
     <string name="player_hoster_tap_to_load">Stisknutím načtete videa</string>
     <string name="player_hoster_failed">Nepodařilo se načíst videa</string>
     <string name="player_sheets_qualities_title">Kvality</string>
-    <string name="player_sheets_decoder_formatted">%s (%s)</string>
+    <string name="player_sheets_decoder_formatted">%1$s (%2$s)</string>
     <string name="player_sheets_more_title">Více</string>
     <string name="pref_audio_channels">Audio kanály</string>
     <string name="player_sheets_stats_page_title">Stránka výchozích statistik</string>

--- a/i18n-aniyomi/src/commonMain/moko-resources/de/strings.xml
+++ b/i18n-aniyomi/src/commonMain/moko-resources/de/strings.xml
@@ -110,7 +110,7 @@
     <string name="enable_auto_play">Automatische Wiedergabe ist an</string>
     <string name="disable_auto_play">Automatische Wiedergabe ist aus</string>
     <string name="player_aniskip_dontskip">Nicht überspringen</string>
-    <string name="player_aniskip_dontskip_toast">%s wird in %d Sekunden übersprungen</string>
+    <string name="player_aniskip_dontskip_toast">%1$s wird in %2$d Sekunden übersprungen</string>
     <string name="player_aniskip_skip">%s übersprungen</string>
     <string name="no_next_episode">Nächste Folge nicht gefunden!</string>
     <string name="player_hwdec_mode">Standard Hardware-Dekodierung wählen</string>

--- a/i18n-aniyomi/src/commonMain/moko-resources/es/strings.xml
+++ b/i18n-aniyomi/src/commonMain/moko-resources/es/strings.xml
@@ -145,7 +145,7 @@
     <string name="enable_auto_play">Reproducción automática activada</string>
     <string name="disable_auto_play">Reproducción automática desactivada</string>
     <string name="player_aniskip_dontskip">No te lo saltes</string>
-    <string name="player_aniskip_dontskip_toast">Omitiendo %s en %d segundos</string>
+    <string name="player_aniskip_dontskip_toast">Omitiendo %1$s en %2$d segundos</string>
     <string name="player_aniskip_skip">%s omitidos</string>
     <string name="no_next_episode">¡Próximo episodio no encontrado!</string>
     <string name="no_prev_episode">Episodio anterior no encontrado!</string>
@@ -471,7 +471,7 @@
     <string name="player_hoster_tap_to_load">Toca para cargar vídeos</string>
     <string name="player_hoster_failed">Error al cargar videos</string>
     <string name="player_sheets_qualities_title">Calidades</string>
-    <string name="player_sheets_decoder_formatted">%s (%s)</string>
+    <string name="player_sheets_decoder_formatted">%1$s (%2$s)</string>
     <string name="player_sheets_more_title">Más</string>
     <string name="pref_audio_channels">Canales de audio</string>
     <string name="player_sheets_stats_page_title">Pagina de estadísticas predeterminada</string>

--- a/i18n-aniyomi/src/commonMain/moko-resources/fa/strings.xml
+++ b/i18n-aniyomi/src/commonMain/moko-resources/fa/strings.xml
@@ -46,7 +46,7 @@
     <string name="enable_auto_play">پخش خودکار فعال است</string>
     <string name="disable_auto_play">پخش خودکار فعال نیست</string>
     <string name="player_aniskip_dontskip">گذر نکن</string>
-    <string name="player_aniskip_dontskip_toast">گذر از %s در %d ثانیه</string>
+    <string name="player_aniskip_dontskip_toast">گذر از %1$s در %2$d ثانیه</string>
     <string name="player_aniskip_skip">%s گذشت شد</string>
     <string name="no_next_episode">قسمت‌ بعدی پیدا نشد!</string>
     <string name="player_hwdec_mode">تنظیم حالت پیشفرض رمزگشایی سخت افزاری</string>

--- a/i18n-aniyomi/src/commonMain/moko-resources/fi/strings.xml
+++ b/i18n-aniyomi/src/commonMain/moko-resources/fi/strings.xml
@@ -43,7 +43,7 @@
     <string name="enable_auto_play">Automaattinen toisto on käytössä</string>
     <string name="disable_auto_play">Automaattinen toisto on poissa käytöstä</string>
     <string name="player_aniskip_dontskip">Älä ohita</string>
-    <string name="player_aniskip_dontskip_toast">%s ohitetaan %d sekunnin kuluttua</string>
+    <string name="player_aniskip_dontskip_toast">%1$s ohitetaan %2$d sekunnin kuluttua</string>
     <string name="player_aniskip_skip">%s ohitettu</string>
     <string name="no_next_episode">Seuraavaa jaksoa ei löytynyt!</string>
     <string name="screenshot_show_subs">Näytä tekstitys näyttökuvassa</string>

--- a/i18n-aniyomi/src/commonMain/moko-resources/fil/strings.xml
+++ b/i18n-aniyomi/src/commonMain/moko-resources/fil/strings.xml
@@ -130,7 +130,7 @@
     <string name="enable_auto_play">Naka-on ang auto-play</string>
     <string name="disable_auto_play">Naka-off ang auto-play</string>
     <string name="player_aniskip_dontskip">Huwag laktawan</string>
-    <string name="player_aniskip_dontskip_toast">Laktawan ang %s sa loob ng %d segundo</string>
+    <string name="player_aniskip_dontskip_toast">Laktawan ang %1$s sa loob ng %2$d segundo</string>
     <string name="player_aniskip_skip">Nilaktawan ng %s</string>
     <string name="no_next_episode">Hindi nahanap ang Susunod na Episode!</string>
     <string name="no_prev_episode">Hindi nahanap ang Nakaraang Episode!</string>
@@ -177,7 +177,7 @@
     <string name="player_sheets_filters_hue">Hue</string>
     <string name="player_sheets_filters_warning">Maaaring hindi gumana ang ilang filter sa iyong kasalukuyang video driver</string>
     <string name="player_sheets_add_ext_audio">Magdagdag ng mga external na audio track</string>
-    <string name="player_sheets_decoder_formatted">%s (%s)</string>
+    <string name="player_sheets_decoder_formatted">%1$s (%2$s)</string>
     <string name="player_sheets_more_title">Higit pa</string>
     <string name="player_hwdec_mode">Itakda ang default na hardware decoding mode</string>
     <string name="pref_audio_channels">Mga channel ng audio</string>

--- a/i18n-aniyomi/src/commonMain/moko-resources/fr/strings.xml
+++ b/i18n-aniyomi/src/commonMain/moko-resources/fr/strings.xml
@@ -87,7 +87,7 @@
     <string name="enable_auto_play">La lecture automatique est activée</string>
     <string name="disable_auto_play">La lecture automatique est désactivée</string>
     <string name="player_aniskip_dontskip">Ne pas passer</string>
-    <string name="player_aniskip_dontskip_toast">Passage de %s dans %d secondes</string>
+    <string name="player_aniskip_dontskip_toast">Passage de %1$s dans %2$d secondes</string>
     <string name="player_aniskip_skip">%s passer</string>
     <string name="no_next_episode">L\'épisode suivant n\'a pas été trouvé !</string>
     <string name="player_hwdec_mode">Définir le mode de décodage matériel par défaut</string>
@@ -463,7 +463,7 @@
     <string name="player_hoster_tap_to_load">Appuyer pour charger les vidéos</string>
     <string name="player_hoster_failed">Impossible de charger les vidéos</string>
     <string name="player_sheets_qualities_title">Qualités</string>
-    <string name="player_sheets_decoder_formatted">%s (%s)</string>
+    <string name="player_sheets_decoder_formatted">%1$s (%2$s)</string>
     <string name="player_sheets_more_title">Plus</string>
     <string name="pref_audio_channels">Canaux audio</string>
     <string name="player_sheets_stats_page_title">Page des statistiques par défaut</string>

--- a/i18n-aniyomi/src/commonMain/moko-resources/he/strings.xml
+++ b/i18n-aniyomi/src/commonMain/moko-resources/he/strings.xml
@@ -49,7 +49,7 @@
     <string name="enable_auto_play">נגינה אוטומטית מופעלת</string>
     <string name="disable_auto_play">נגינה אוטומטית כבויה</string>
     <string name="player_aniskip_dontskip">אל תדלג</string>
-    <string name="player_aniskip_dontskip_toast">דלג %s בעוד %d שניות</string>
+    <string name="player_aniskip_dontskip_toast">דלג %1$s בעוד %2$d שניות</string>
     <string name="player_aniskip_skip">%s דולג</string>
     <string name="no_next_episode">הפרק הבא לא נמצא!</string>
     <string name="player_hwdec_mode">הגדר מצב פענוח חומרה ברירת מחדל</string>

--- a/i18n-aniyomi/src/commonMain/moko-resources/hr/strings.xml
+++ b/i18n-aniyomi/src/commonMain/moko-resources/hr/strings.xml
@@ -146,7 +146,7 @@
     <string name="enable_auto_play">Automatska reprodukcija je aktivirana</string>
     <string name="disable_auto_play">Automatska reprodukcija je deaktivirana</string>
     <string name="player_aniskip_dontskip">Nemoj preskočiti</string>
-    <string name="player_aniskip_dontskip_toast">%s se preskače za %d sekunde</string>
+    <string name="player_aniskip_dontskip_toast">%1$s se preskače za %2$d sekunde</string>
     <string name="player_aniskip_skip">%s preskočeno</string>
     <string name="no_next_episode">Sljedeća epizoda nije pronađena!</string>
     <string name="no_prev_episode">Prethodna epizoda nije pronađena!</string>
@@ -194,7 +194,7 @@
     <string name="player_sheets_filters_hue">Nijansa</string>
     <string name="player_sheets_filters_warning">Neki filtri možda neće raditi s tvojim trenutačnim upravljačkim programom za videa</string>
     <string name="player_sheets_add_ext_audio">Dodaj vanjske audio snimke</string>
-    <string name="player_sheets_decoder_formatted">%s (%s)</string>
+    <string name="player_sheets_decoder_formatted">%1$s (%2$s)</string>
     <string name="player_sheets_more_title">Više</string>
     <string name="player_hwdec_mode">Modus hardverskog dekodiranja</string>
     <string name="pref_audio_channels">Audio kanali</string>
@@ -302,7 +302,7 @@
     <string name="pref_anime_library_update_categories_details">Anime u isključenim kategorijama se neće aktualizirati čak i ako se također nalaze u uključenim kategorijama.</string>
     <string name="unofficial_extension_message_aniyomi">Ovo proširenje nije sa službenog popisa Aniyomi proširenja.</string>
     <string name="unofficial_anime_extension_message">Ovo proširenje nije službeno Aniyomi proširenje.</string>
-    <string name="episode_download_progress">%1$d% %</string>
+    <string name="episode_download_progress">%1$d%%</string>
     <string name="pref_remove_exclude_categories_manga">Isključene manga kategorije</string>
     <string name="pref_remove_exclude_categories_anime">Isključene anime kategorije</string>
     <string name="pref_category_external_downloader">Eksterni upravljač preuzimanja</string>
@@ -334,7 +334,7 @@
     <string name="snack_add_to_manga_library">Dodati manga u biblioteku?</string>
     <string name="snack_add_to_anime_library">Dodati anime u biblioteku?</string>
     <string name="display_mode_episode">Epizoda %1$s</string>
-    <string name="episode_downloading_progress">Preuzimanje (%d% %)</string>
+    <string name="episode_downloading_progress">Preuzimanje (%d%%)</string>
     <string name="download_error">Greška</string>
     <string name="download_paused">Zaustavljeno</string>
     <string name="show_episode_number">Broj epizode</string>

--- a/i18n-aniyomi/src/commonMain/moko-resources/in/strings.xml
+++ b/i18n-aniyomi/src/commonMain/moko-resources/in/strings.xml
@@ -146,7 +146,7 @@
     <string name="enable_auto_play">Otomatis memutar menyala</string>
     <string name="disable_auto_play">Otomatis memutar mati</string>
     <string name="player_aniskip_dontskip">Jangan di skip</string>
-    <string name="player_aniskip_dontskip_toast">Melewatkan %s dalam %d detik</string>
+    <string name="player_aniskip_dontskip_toast">Melewatkan %1$s dalam %2$d detik</string>
     <string name="player_aniskip_skip">%s lewati</string>
     <string name="no_next_episode">episode selanjutnya tidak ditemukan!</string>
     <string name="no_prev_episode">Episode sebelumnya tidak ditemukan!</string>
@@ -194,7 +194,7 @@
     <string name="player_sheets_filters_hue">Hue</string>
     <string name="player_sheets_filters_warning">Beberapa filter kemungkinan tidak bekerja pada driver video saat ini</string>
     <string name="player_sheets_add_ext_audio">Tambahkan trek audio eksternal</string>
-    <string name="player_sheets_decoder_formatted">%s (%s)</string>
+    <string name="player_sheets_decoder_formatted">%1$s (%2$s)</string>
     <string name="player_sheets_more_title">Lebih lanjut</string>
     <string name="player_hwdec_mode">Pengaturan standar mode decoding hardware</string>
     <string name="pref_audio_channels">Saluran audio</string>

--- a/i18n-aniyomi/src/commonMain/moko-resources/it/strings.xml
+++ b/i18n-aniyomi/src/commonMain/moko-resources/it/strings.xml
@@ -149,7 +149,7 @@
     <string name="enable_auto_play">Auto-play è attivo</string>
     <string name="disable_auto_play">Auto-play è disattivato</string>
     <string name="player_aniskip_dontskip">Non saltare</string>
-    <string name="player_aniskip_dontskip_toast">Salto di %s in %d secondi</string>
+    <string name="player_aniskip_dontskip_toast">Salto di %1$s in %2$d secondi</string>
     <string name="player_aniskip_skip">%s saltati</string>
     <string name="no_next_episode">Episodio successivo non trovato!</string>
     <string name="no_prev_episode">Episodio precedente non trovato!</string>
@@ -203,7 +203,7 @@
     <string name="player_sheets_add_ext_audio">Aggiungi tracce audio esterne</string>
     <string name="player_hoster_tap_to_load">Tocca per caricare i video</string>
     <string name="player_hoster_failed">Caricamento video fallito</string>
-    <string name="player_sheets_decoder_formatted">%s (%s)</string>
+    <string name="player_sheets_decoder_formatted">%1$s (%2$s)</string>
     <string name="player_sheets_more_title">Altro</string>
     <string name="player_hwdec_mode">Imposta la modalità di decodifica hardware predefinita</string>
     <string name="pref_audio_channels">Canali audio</string>

--- a/i18n-aniyomi/src/commonMain/moko-resources/ko/strings.xml
+++ b/i18n-aniyomi/src/commonMain/moko-resources/ko/strings.xml
@@ -64,7 +64,7 @@
     <string name="enable_auto_play">자동 재생 사용 중</string>
     <string name="disable_auto_play">자동 재생이 사용 중지됨</string>
     <string name="player_aniskip_dontskip">건너뛰지 않기</string>
-    <string name="player_aniskip_dontskip_toast">%s을 %d초 후에 건너뛰기</string>
+    <string name="player_aniskip_dontskip_toast">%1$s을 %2$d초 후에 건너뛰기</string>
     <string name="player_aniskip_skip">%s 건너뜀</string>
     <string name="no_next_episode">다음 에피소드를 찾을 수 없습니다!</string>
     <string name="player_hwdec_mode">기본 하드웨어 디코딩 모드 설정</string>

--- a/i18n-aniyomi/src/commonMain/moko-resources/pl/strings.xml
+++ b/i18n-aniyomi/src/commonMain/moko-resources/pl/strings.xml
@@ -54,7 +54,7 @@
     <string name="enable_auto_play">Auto-play jest włączone</string>
     <string name="disable_auto_play">Auto-play jest wyłączone</string>
     <string name="player_aniskip_dontskip">Nie pomiń</string>
-    <string name="player_aniskip_dontskip_toast">Pomijanie %s za %d sekund</string>
+    <string name="player_aniskip_dontskip_toast">Pomijanie %1$s za %2$d sekund</string>
     <string name="player_aniskip_skip">Pominięto %s</string>
     <string name="no_next_episode">Następny odcinek nie został znaleziony!</string>
     <string name="player_hwdec_mode">Ustaw domyślny tryb dekodowania sprzętowego</string>

--- a/i18n-aniyomi/src/commonMain/moko-resources/pt-rBR/strings.xml
+++ b/i18n-aniyomi/src/commonMain/moko-resources/pt-rBR/strings.xml
@@ -146,7 +146,7 @@
     <string name="enable_auto_play">A reprodução automática está ativada</string>
     <string name="disable_auto_play">A reprodução automática está desativada</string>
     <string name="player_aniskip_dontskip">Não pular</string>
-    <string name="player_aniskip_dontskip_toast">Pular %s em %d segundos</string>
+    <string name="player_aniskip_dontskip_toast">Pular %1$s em %2$d segundos</string>
     <string name="player_aniskip_skip">%s pulou</string>
     <string name="no_next_episode">Próximo episódio não encontrado!</string>
     <string name="no_prev_episode">Episódio anterior não foi encontrado!</string>
@@ -194,7 +194,7 @@
     <string name="player_sheets_filters_hue">Matiz</string>
     <string name="player_sheets_filters_warning">Alguns filtros podem não funcionar no seu driver de vídeo</string>
     <string name="player_sheets_add_ext_audio">Adicione faixas de áudio externas</string>
-    <string name="player_sheets_decoder_formatted">%s (%s)</string>
+    <string name="player_sheets_decoder_formatted">%1$s (%2$s)</string>
     <string name="player_sheets_more_title">Mais</string>
     <string name="player_hwdec_mode">Definir o modo de decodificação de hardware padrão</string>
     <string name="pref_audio_channels">Canais de áudio</string>

--- a/i18n-aniyomi/src/commonMain/moko-resources/pt/strings.xml
+++ b/i18n-aniyomi/src/commonMain/moko-resources/pt/strings.xml
@@ -62,7 +62,7 @@
     <string name="enable_auto_play">A reprodução automática está ativada</string>
     <string name="disable_auto_play">A reprodução automática está desativada</string>
     <string name="player_aniskip_dontskip">Não saltar</string>
-    <string name="player_aniskip_dontskip_toast">Saltar %s em %d segundos</string>
+    <string name="player_aniskip_dontskip_toast">Saltar %1$s em %2$d segundos</string>
     <string name="player_aniskip_skip">%s saltado</string>
     <string name="no_next_episode">Episódio seguinte não encontrado!</string>
     <string name="player_hwdec_mode">Modo de descodificação por hardware</string>
@@ -398,7 +398,7 @@
     <string name="player_sheets_filters_Saturation">Saturação</string>
     <string name="player_sheets_filters_hue">Tonalidade</string>
     <string name="player_sheets_qualities_title">Qualidades</string>
-    <string name="player_sheets_decoder_formatted">%s (%s)</string>
+    <string name="player_sheets_decoder_formatted">%1$s (%2$s)</string>
     <string name="player_sheets_more_title">Mais</string>
     <string name="pref_audio_channels">Canais de áudio</string>
     <string name="player_sheets_stats_page_chip">Página %d</string>

--- a/i18n-aniyomi/src/commonMain/moko-resources/ru/strings.xml
+++ b/i18n-aniyomi/src/commonMain/moko-resources/ru/strings.xml
@@ -146,7 +146,7 @@
     <string name="enable_auto_play">Автовоспроизведение включено</string>
     <string name="disable_auto_play">Автовоспроизведение отключено</string>
     <string name="player_aniskip_dontskip">Не пропускать</string>
-    <string name="player_aniskip_dontskip_toast">%s: будет пропущено через %d сек</string>
+    <string name="player_aniskip_dontskip_toast">%1$s: будет пропущено через %2$d сек</string>
     <string name="player_aniskip_skip">%s: пропущено</string>
     <string name="no_next_episode">Следующий эпизод не найден!</string>
     <string name="no_prev_episode">Предыдущий эпизод не найден!</string>
@@ -194,7 +194,7 @@
     <string name="player_sheets_filters_hue">Оттенок</string>
     <string name="player_sheets_filters_warning">Некоторые фильтры могут не работать на вашем текущем видеодрайвере</string>
     <string name="player_sheets_add_ext_audio">Добавить внешние звуковые дорожки</string>
-    <string name="player_sheets_decoder_formatted">%s (%s)</string>
+    <string name="player_sheets_decoder_formatted">%1$s (%2$s)</string>
     <string name="player_sheets_more_title">Ещё</string>
     <string name="player_hwdec_mode">Режим аппаратного декодирования</string>
     <string name="pref_audio_channels">Звуковые каналы</string>

--- a/i18n-aniyomi/src/commonMain/moko-resources/sr/strings.xml
+++ b/i18n-aniyomi/src/commonMain/moko-resources/sr/strings.xml
@@ -130,7 +130,7 @@
     <string name="enable_auto_play">Аутоматска репродукција је укључена</string>
     <string name="disable_auto_play">Аутоматска репродукција је искључена</string>
     <string name="player_aniskip_dontskip">Не прескачи</string>
-    <string name="player_aniskip_dontskip_toast">Прескочи %s у %d секунди</string>
+    <string name="player_aniskip_dontskip_toast">Прескочи %1$s у %2$d секунди</string>
     <string name="player_aniskip_skip">%s прескочено</string>
     <string name="no_next_episode">Следећа епизода није пронађена!</string>
     <string name="no_prev_episode">Претходна епизода није пронађена!</string>
@@ -178,7 +178,7 @@
     <string name="player_sheets_filters_hue">Нијанса</string>
     <string name="player_sheets_filters_warning">Неки филтери можда неће радити на вашим тренутним видео драјверима</string>
     <string name="player_sheets_add_ext_audio">Додајте спољне аудио траке</string>
-    <string name="player_sheets_decoder_formatted">%s (%s)</string>
+    <string name="player_sheets_decoder_formatted">%1$s (%2$s)</string>
     <string name="player_sheets_more_title">Више</string>
     <string name="player_hwdec_mode">Режим хардверског декодирања</string>
     <string name="pref_audio_channels">Аудио канали</string>

--- a/i18n-aniyomi/src/commonMain/moko-resources/ta/strings.xml
+++ b/i18n-aniyomi/src/commonMain/moko-resources/ta/strings.xml
@@ -111,7 +111,7 @@
     <string name="enable_auto_play">ஆட்டோ-பிளே இயக்கத்தில் உள்ளது</string>
     <string name="disable_auto_play">ஆட்டோ-பிளே முடக்கப்பட்டுள்ளது</string>
     <string name="player_aniskip_dontskip">தவிர்க்க வேண்டாம்</string>
-    <string name="player_aniskip_dontskip_toast">%s ஐ %d வினாடிகளில் தவிர்க்கவும்</string>
+    <string name="player_aniskip_dontskip_toast">%1$s ஐ %2$d வினாடிகளில் தவிர்க்கவும்</string>
     <string name="player_aniskip_skip">%s தவிர்க்கப்பட்டன</string>
     <string name="no_next_episode">அடுத்த அத்தியாயம் கிடைக்கவில்லை!</string>
     <string name="player_hwdec_mode">வன்பொருள் டிகோடிங் பயன்முறை</string>
@@ -255,7 +255,7 @@
     <string name="share_screenshot_info">%1$s: %2$s, %3$s</string>
     <string name="episode_progress">முன்னேற்றம்: %1$s/ %2$s</string>
     <string name="episode_progress_no_total">முன்னேற்றம்: %1$s</string>
-    <string name="recent_anime_time">ஈ.பி. %1 $ C - %$ 2 s</string>
+    <string name="recent_anime_time">ஈ.பி. %1$s - %2$s</string>
     <string name="video_list_empty_error">வீடியோ எதுவும் கிடைக்கவில்லை</string>
     <string name="notification_new_episodes">புதிய அத்தியாயங்கள் காணப்பட்டன</string>
     <string name="information_no_recent_anime">அண்மைக் காலத்தில் எதுவும் பார்க்கவில்லை</string>

--- a/i18n-aniyomi/src/commonMain/moko-resources/tr/strings.xml
+++ b/i18n-aniyomi/src/commonMain/moko-resources/tr/strings.xml
@@ -148,7 +148,7 @@
     <string name="enable_auto_play">Otomatik oynatma açık</string>
     <string name="disable_auto_play">Otomatik oynatma kapalı</string>
     <string name="player_aniskip_dontskip">Atlama</string>
-    <string name="player_aniskip_dontskip_toast">%s, %d saniye içinde atlanacak</string>
+    <string name="player_aniskip_dontskip_toast">%1$s, %2$d saniye içinde atlanacak</string>
     <string name="player_aniskip_skip">%s atlandı</string>
     <string name="no_next_episode">Sonraki bölüm bulunamadı!</string>
     <string name="no_prev_episode">Önceki Bölüm bulunamadı!</string>
@@ -202,7 +202,7 @@
     <string name="player_sheets_add_ext_audio">Harici ses kaynakları ekle</string>
     <string name="player_hoster_tap_to_load">Videoları yüklemek için dokunun</string>
     <string name="player_hoster_failed">Videolar yüklenemedi</string>
-    <string name="player_sheets_decoder_formatted">%s (%s)</string>
+    <string name="player_sheets_decoder_formatted">%1$s (%2$s)</string>
     <string name="player_sheets_more_title">Daha fazla</string>
     <string name="player_hwdec_mode">Donanım kod çözme modu</string>
     <string name="pref_audio_channels">Ses kanalları</string>

--- a/i18n-aniyomi/src/commonMain/moko-resources/uk/strings.xml
+++ b/i18n-aniyomi/src/commonMain/moko-resources/uk/strings.xml
@@ -149,7 +149,7 @@
     <string name="enable_auto_play">Ввімкнено автовідтворення</string>
     <string name="disable_auto_play">Автовідтворення вимкнено</string>
     <string name="player_aniskip_dontskip">Не пропускати</string>
-    <string name="player_aniskip_dontskip_toast">Пропуск %s через %d секунд</string>
+    <string name="player_aniskip_dontskip_toast">Пропуск %1$s через %2$d секунд</string>
     <string name="player_aniskip_skip">%s пропущено</string>
     <string name="no_next_episode">Наступний епізод не знайдено!</string>
     <string name="no_prev_episode">Попередній епізод не знайдено!</string>
@@ -203,7 +203,7 @@
     <string name="player_sheets_add_ext_audio">Додати зовнішні звукові доріжки</string>
     <string name="player_hoster_tap_to_load">Торкніться, щоб завантажити відео</string>
     <string name="player_hoster_failed">Не вдалося завантажити відео</string>
-    <string name="player_sheets_decoder_formatted">%s (%s)</string>
+    <string name="player_sheets_decoder_formatted">%1$s (%2$s)</string>
     <string name="player_sheets_more_title">більше</string>
     <string name="player_hwdec_mode">Встановити режим апаратного декодування за замовчуванням</string>
     <string name="pref_audio_channels">Аудіо канали</string>

--- a/i18n-aniyomi/src/commonMain/moko-resources/vi/strings.xml
+++ b/i18n-aniyomi/src/commonMain/moko-resources/vi/strings.xml
@@ -67,7 +67,7 @@
     <string name="enable_auto_play">Tự động phát đang bật</string>
     <string name="disable_auto_play">Tự động phát đang tắt</string>
     <string name="player_aniskip_dontskip">Không skip</string>
-    <string name="player_aniskip_dontskip_toast">Skip %s sau %d giây</string>
+    <string name="player_aniskip_dontskip_toast">Skip %1$s sau %2$d giây</string>
     <string name="player_aniskip_skip">bỏ qua %s giây</string>
     <string name="no_next_episode">Không tìm thấy tập tiếp theo!</string>
     <string name="player_hwdec_mode">Chế độ giải mã phần cứng</string>

--- a/i18n-aniyomi/src/commonMain/moko-resources/zh-rCN/strings.xml
+++ b/i18n-aniyomi/src/commonMain/moko-resources/zh-rCN/strings.xml
@@ -146,7 +146,7 @@
     <string name="enable_auto_play">自动连播已开启</string>
     <string name="disable_auto_play">自动连播已关闭</string>
     <string name="player_aniskip_dontskip">不跳过</string>
-    <string name="player_aniskip_dontskip_toast">%s 将在 %d 秒内跳过</string>
+    <string name="player_aniskip_dontskip_toast">%1$s 将在 %2$d 秒内跳过</string>
     <string name="player_aniskip_skip">已跳过 %s</string>
     <string name="no_next_episode">没有下一集！</string>
     <string name="no_prev_episode">未找到上一集！</string>
@@ -194,7 +194,7 @@
     <string name="player_sheets_filters_hue">色调</string>
     <string name="player_sheets_filters_warning">某些过滤器可能无法在您当前的视频驱动程序上运行</string>
     <string name="player_sheets_add_ext_audio">添加外部音轨</string>
-    <string name="player_sheets_decoder_formatted">%s (%s)</string>
+    <string name="player_sheets_decoder_formatted">%1$s (%2$s)</string>
     <string name="player_sheets_more_title">更多</string>
     <string name="player_hwdec_mode">解码模式</string>
     <string name="pref_audio_channels">音频通道</string>

--- a/i18n-aniyomi/src/commonMain/moko-resources/zh-rTW/strings.xml
+++ b/i18n-aniyomi/src/commonMain/moko-resources/zh-rTW/strings.xml
@@ -67,7 +67,7 @@
     <string name="enable_auto_play">自動播放已開啟</string>
     <string name="disable_auto_play">自動播放已關閉</string>
     <string name="player_aniskip_dontskip">不要跳過</string>
-    <string name="player_aniskip_dontskip_toast">跳過 %s 在 %d 秒後</string>
+    <string name="player_aniskip_dontskip_toast">跳過 %1$s 在 %2$d 秒後</string>
     <string name="player_aniskip_skip">%s 已跳過</string>
     <string name="no_next_episode">未找到下一集！</string>
     <string name="player_hwdec_mode">硬體解碼模式</string>

--- a/i18n/src/commonMain/moko-resources/am/strings.xml
+++ b/i18n/src/commonMain/moko-resources/am/strings.xml
@@ -270,7 +270,7 @@
     <string name="creating_backup">ምትኬን መፍጠር</string>
     <string name="backup_choice">ምትኬ ለማስቀመጥ ምን ይፈልጋሉ?</string>
     <string name="backup_in_progress">ምትኬ ቀድሞውኑ በሂደት ላይ ነው</string>
-    <string name="restore_duration">%02d ደቂቃ ፣ %02d ሰከንድ</string>
+    <string name="restore_duration">%1$02d ደቂቃ ፣ %2$02d ሰከንድ</string>
     <string name="restore_completed">እነበረበት መልስ ተጠናቅቋል</string>
     <string name="backup_restore_missing_trackers">መከታተያዎች አልገቡም:</string>
     <string name="backup_restore_missing_sources">የጠፋ ምንጮች:</string>

--- a/i18n/src/commonMain/moko-resources/ar/strings.xml
+++ b/i18n/src/commonMain/moko-resources/ar/strings.xml
@@ -330,7 +330,7 @@
     <string name="restore_in_progress">الاستعادة قيد التقدم بالفعل</string>
     <string name="creating_backup_error">فشل النسخ الاحتياطي</string>
     <string name="backup_in_progress">يُنسخ احتياطيًّا بالفعل</string>
-    <string name="restore_duration">%02d دقيقة و %02d ثانية</string>
+    <string name="restore_duration">%1$02d دقيقة و %2$02d ثانية</string>
     <string name="action_unpin">إلغاء التثبيت</string>
     <string name="action_pin">تثبيت</string>
     <string name="action_select_inverse">عكس التحديد</string>

--- a/i18n/src/commonMain/moko-resources/bg/strings.xml
+++ b/i18n/src/commonMain/moko-resources/bg/strings.xml
@@ -329,7 +329,7 @@
     <string name="restore_in_progress">Възстановяването е в процес</string>
     <string name="creating_backup_error">Съхраняването неуспешно</string>
     <string name="backup_in_progress">Архивирането вече е в ход</string>
-    <string name="restore_duration">%02d мин, %02d сек</string>
+    <string name="restore_duration">%1$02d мин, %2$02d сек</string>
     <string name="pref_webtoon_side_padding">Странично разстояние</string>
     <string name="pref_category_reading">Четене</string>
     <string name="pref_always_show_chapter_transition">Винаги показвай прехода между главите</string>

--- a/i18n/src/commonMain/moko-resources/bn/strings.xml
+++ b/i18n/src/commonMain/moko-resources/bn/strings.xml
@@ -346,7 +346,7 @@
     <string name="restore_in_progress">বর্তমানে পুনরুদ্ধার চলছে</string>
     <string name="creating_backup_error">ব্যাকআপ ব্যর্থ হয়েছে</string>
     <string name="backup_in_progress">ব্যাকআপ ইতিমধ্যেই চলছে</string>
-    <string name="restore_duration">%02d মিনিট, %02d সেকেন্ড</string>
+    <string name="restore_duration">%1$02d মিনিট, %2$02d সেকেন্ড</string>
     <string name="backup_restore_missing_sources">উৎস অনুপলব্ধ:</string>
     <string name="invalid_backup_file_missing_manga">ব্যাকআপে কোনো মাংগা নেই।</string>
     <string name="invalid_backup_file">ব্যাকআপ ফাইল গ্রহণযোগ্য নয়</string>

--- a/i18n/src/commonMain/moko-resources/ceb/strings.xml
+++ b/i18n/src/commonMain/moko-resources/ceb/strings.xml
@@ -357,7 +357,7 @@
     <string name="pref_dns_over_https">DNS sa HTTPS (DoH)</string>
     <string name="requires_app_restart">Nagkinahanglan nga i-restart ang app aron ma-epekto</string>
     <string name="backup_in_progress">Ang pag-backup nagpadayon na</string>
-    <string name="restore_duration">%02d minuto , %02d ikaduha</string>
+    <string name="restore_duration">%1$02d minuto , %2$02d ikaduha</string>
     <string name="backup_choice">Unsa ang gusto nimo i-backup?</string>
     <string name="backup_restore_content_full">Ang datos gikan sa backup file mapasig-uli.
 \n

--- a/i18n/src/commonMain/moko-resources/cv/strings.xml
+++ b/i18n/src/commonMain/moko-resources/cv/strings.xml
@@ -5,7 +5,7 @@
     <string name="cookies_cleared">Куккисем катертнӗ</string>
     <string name="pref_clear_cookies">Кукки тасат</string>
     <string name="label_network">Тетел</string>
-    <string name="restore_duration">%02d минут та %02d ҫеккунт</string>
+    <string name="restore_duration">%1$02d минут та %2$02d ҫеккунт</string>
     <string name="services">Сервиссем</string>
     <string name="pref_download_new">Ҫӗнӗ сыпӑксене тийесе илмелле</string>
     <string name="last_read_chapter">Юлашки вуланӑ сыпăк</string>

--- a/i18n/src/commonMain/moko-resources/da/strings.xml
+++ b/i18n/src/commonMain/moko-resources/da/strings.xml
@@ -301,7 +301,7 @@
     <string name="split_tall_images">Opdel høje billeder</string>
     <string name="disabled">Deaktiveret</string>
     <string name="last_read_chapter">Senest læste kapitel</string>
-    <string name="restore_duration">%02d min, %02d sek</string>
+    <string name="restore_duration">%1$02d min, %2$02d sek</string>
     <string name="pref_high">Høj</string>
     <string name="pref_restore_backup_summ">Gendan biblioteket fra sikkerhedskopi</string>
     <string name="spen_previous_page">Forrige side</string>

--- a/i18n/src/commonMain/moko-resources/eu/strings.xml
+++ b/i18n/src/commonMain/moko-resources/eu/strings.xml
@@ -35,7 +35,7 @@
     <string name="no_more_results">Ez dago emaitza gehiagorik</string>
     <string name="download_queue_size_warning">Abisua: deskarga handiek iturriak motelagoak izatea eta/edo Mihon blokeatzea ekar dezakete</string>
     <string name="creating_backup">Babeskopia sortzen</string>
-    <string name="restore_duration">%02d min, %02d seg</string>
+    <string name="restore_duration">%1$02d min, %2$02d seg</string>
     <string name="add_tracking">Gehitu jarraipena</string>
     <string name="cache_delete_error">Errore bat gertatu da cachea garbitzean</string>
     <string name="backup_created">Babeskopia sortu da</string>

--- a/i18n/src/commonMain/moko-resources/fa/strings.xml
+++ b/i18n/src/commonMain/moko-resources/fa/strings.xml
@@ -344,7 +344,7 @@
     <string name="creating_backup">درحال ایجاد نسخه پشتیبان</string>
     <string name="backup_choice">چه چیزی را می خواهید پشتیبان گیری کنید ؟</string>
     <string name="backup_in_progress">پشتیبان گیری هنوز در حال انجام است</string>
-    <string name="restore_duration">%02d دقیقه, %02d ثانیه</string>
+    <string name="restore_duration">%1$02d دقیقه, %2$02d ثانیه</string>
     <string name="restore_completed">بازیابی کامل شد</string>
     <string name="backup_restore_missing_sources">منابع ناموجود:</string>
     <string name="invalid_backup_file_missing_manga">فایل پشتیبان حاوی هیچ ورودی کتابخانه نیست.</string>

--- a/i18n/src/commonMain/moko-resources/fi/strings.xml
+++ b/i18n/src/commonMain/moko-resources/fi/strings.xml
@@ -358,7 +358,7 @@
     <string name="check_for_updates">Tarkista päivitykset</string>
     <string name="last_used_source">Viimeksi käytetty</string>
     <string name="local_source_help_guide">Paikallinen lähdeopas</string>
-    <string name="restore_duration">%02d min, %02d sek</string>
+    <string name="restore_duration">%1$02d min, %2$02d sek</string>
     <string name="downloaded_only_summary">Suodattaa kaikki sarjat kirjastossasi</string>
     <string name="gray_background">Harmaa</string>
     <string name="pref_category_for_this_series">Tälle sarjalle</string>

--- a/i18n/src/commonMain/moko-resources/he/strings.xml
+++ b/i18n/src/commonMain/moko-resources/he/strings.xml
@@ -476,7 +476,7 @@
     <string name="reading">קריאה</string>
     <string name="login">התחברות</string>
     <string name="pinned_sources">נעוץ</string>
-    <string name="restore_duration">%02d דקות, %02d שניות</string>
+    <string name="restore_duration">%1$02d דקות, %2$02d שניות</string>
     <string name="restoring_backup_canceled">השחזור בוטל</string>
     <string name="backup_info">רצוי לשמור עותקים נוספים של גיבויים במקומות אחרים בנוסף.</string>
     <string name="database_clean">אין מה לנקות</string>

--- a/i18n/src/commonMain/moko-resources/hi/strings.xml
+++ b/i18n/src/commonMain/moko-resources/hi/strings.xml
@@ -360,7 +360,7 @@
     <string name="last_used_source">आखरी इस्त्तमाल किया गया</string>
     <string name="check_for_updates">अद्यतन के लिए जाँच</string>
     <string name="local_source_help_guide">स्थानीय स्रोत गाइड</string>
-    <string name="restore_duration">%02d मिनट,%02d सेकंड</string>
+    <string name="restore_duration">%1$02d मिनट,%2$02d सेकंड</string>
     <string name="downloaded_only_summary">आपकी पुस्तकालय में सभी आइटम को फ़िल्टर करता है</string>
     <string name="viewer">पढ़न मोड</string>
     <string name="pref_category_for_this_series">इस श्रृंखला के लिए</string>

--- a/i18n/src/commonMain/moko-resources/hu/strings.xml
+++ b/i18n/src/commonMain/moko-resources/hu/strings.xml
@@ -452,7 +452,7 @@
     <string name="information_cloudflare_bypass_failure">Nem sikerült megkerülni a Cloudflare-t</string>
     <string name="pref_landscape_zoom">Automatikusan nagyítsa a széles képeket</string>
     <string name="restore_completed">Helyreállítás befejeződött</string>
-    <string name="restore_duration">%02d perc, %02d másodperc</string>
+    <string name="restore_duration">%1$02d perc, %2$02d másodperc</string>
     <string name="backup_restore_content_full">Előfordulhat, hogy telepítenie kell a hiányzó bővítményeket, majd később be kell jelentkeznie a nyilvántartási szolgáltatásokba a használatukhoz.</string>
     <string name="pref_refresh_library_covers">Könyvtár fedők frissítése</string>
     <string name="pref_dump_crash_logs">Hibaüzenetetek törlése</string>

--- a/i18n/src/commonMain/moko-resources/kk/strings.xml
+++ b/i18n/src/commonMain/moko-resources/kk/strings.xml
@@ -306,7 +306,7 @@
     <string name="color_filter_g_value">Ж</string>
     <string name="color_filter_b_value">К</string>
     <string name="white_background">Ақ</string>
-    <string name="restore_duration">%02d мин, %02d сек</string>
+    <string name="restore_duration">%1$02d мин, %2$02d сек</string>
     <string name="pref_always_show_chapter_transition">Тараулардың ауысуын әрдайым көрсету</string>
     <string name="rotation_force_portrait">Құлыпталған портрет</string>
     <string name="pref_high">Жоғары</string>

--- a/i18n/src/commonMain/moko-resources/kn/strings.xml
+++ b/i18n/src/commonMain/moko-resources/kn/strings.xml
@@ -111,7 +111,7 @@
     <string name="label_settings">ಸಂಯೋಜನೆಗಳು</string>
     <string name="label_more">ಇನ್ನಷ್ಟು</string>
     <string name="name">ಹೆಸರು</string>
-    <string name="restore_duration">%02d ನಿಮಿಷ, %02d ಸೆಕೆಂಡು</string>
+    <string name="restore_duration">%1$02d ನಿಮಿಷ, %2$02d ಸೆಕೆಂಡು</string>
     <string name="restore_completed">ಮರುಸ್ಥಾಪನೆ ಪೂರ್ಣಗೊಂಡಿದೆ</string>
     <string name="backup_created">ಬ್ಯಾಕಪ್ ರಚಿಸಲಾಗಿದೆ</string>
     <string name="pref_backup_interval">ಬ್ಯಾಕಪ್ ಆವರ್ತನ</string>

--- a/i18n/src/commonMain/moko-resources/ko/strings.xml
+++ b/i18n/src/commonMain/moko-resources/ko/strings.xml
@@ -314,7 +314,7 @@
     <string name="label_network">네트워크</string>
     <string name="restoring_backup_canceled">복원 취소</string>
     <string name="creating_backup_error">백업 실패</string>
-    <string name="restore_duration">%02d분 %02d초</string>
+    <string name="restore_duration">%1$02d분 %2$02d초</string>
     <string name="invalid_backup_file">잘못된 백업 파일:</string>
     <string name="pref_category_auto_download">자동 다운로드</string>
     <string name="pref_remove_bookmarked_chapters">북마크 표시된 회차 삭제 허용</string>

--- a/i18n/src/commonMain/moko-resources/lt/strings.xml
+++ b/i18n/src/commonMain/moko-resources/lt/strings.xml
@@ -481,7 +481,7 @@
     <string name="download_queue_size_warning">Įspėjimas: dėl didelių masinių atsisiuntimų šaltiniai gali tapti lėtesni ir (arba) jie blokuoti \"Mihon\". Bakstelėkite , jei norite sužinoti daugiau.</string>
     <string name="pref_disable_battery_optimization">Išjungti akumuliatoriaus optimizavimą</string>
     <string name="restore_completed">Atkūrimas baigtas</string>
-    <string name="restore_duration">%02d min, %02d sek</string>
+    <string name="restore_duration">%1$02d min, %2$02d sek</string>
     <string name="database_clean">Nėra ką išvalyti</string>
     <string name="webview_data_deleted">„WebView“ duomenys išvalyti</string>
     <string name="getting_started_guide">Darbo pradžios vadovas</string>

--- a/i18n/src/commonMain/moko-resources/lv/strings.xml
+++ b/i18n/src/commonMain/moko-resources/lv/strings.xml
@@ -79,7 +79,7 @@
     <string name="creating_backup">Izveido dublējumu</string>
     <string name="backup_choice">Ko vēlaties dublēt?</string>
     <string name="backup_in_progress">Dublēšana jau notiek</string>
-    <string name="restore_duration">%02d min, %02d sec</string>
+    <string name="restore_duration">%1$02d min, %2$02d sec</string>
     <string name="restore_completed">Atjaunošana pabeigta</string>
     <string name="backup_restore_missing_sources">Trūkstošie avoti:</string>
     <string name="invalid_backup_file_missing_manga">Dublējumā nav neviena bibliotēkas ieraksta.</string>

--- a/i18n/src/commonMain/moko-resources/ms/strings.xml
+++ b/i18n/src/commonMain/moko-resources/ms/strings.xml
@@ -358,7 +358,7 @@
     <string name="last_used_source">Terakhir digunakan</string>
     <string name="check_for_updates">Semak untuk kemas kini</string>
     <string name="local_source_help_guide">Panduan penggunaan sumber lokal</string>
-    <string name="restore_duration">%02d minit, %02d saat</string>
+    <string name="restore_duration">%1$02d minit, %2$02d saat</string>
     <string name="downloaded_only_summary">Tapis semua entri di dalam pustaka anda</string>
     <string name="gray_background">Kelabu</string>
     <string name="viewer">Mod membaca</string>

--- a/i18n/src/commonMain/moko-resources/nb-rNO/strings.xml
+++ b/i18n/src/commonMain/moko-resources/nb-rNO/strings.xml
@@ -343,7 +343,7 @@
     <string name="sort_by_upload_date">Etter opplastingsdato</string>
     <string name="last_used_source">Sist brukt</string>
     <string name="tabs_header">Faner</string>
-    <string name="restore_duration">%02d min, %02d sek</string>
+    <string name="restore_duration">%1$02d min, %2$02d sek</string>
     <string name="backup_restore_missing_sources">Manglende kilder:</string>
     <string name="gray_background">Grå</string>
     <string name="action_display_show_tabs">Vis kategorifaner</string>

--- a/i18n/src/commonMain/moko-resources/nn/strings.xml
+++ b/i18n/src/commonMain/moko-resources/nn/strings.xml
@@ -192,7 +192,7 @@
     <string name="invalid_backup_file_missing_manga">Reservekopi inneheld ingen manga.</string>
     <string name="pref_restore_backup_summ">Gjenopprett bibliotek frå reservekopifil</string>
     <string name="restore_completed">Gjenoppretting fullført</string>
-    <string name="restore_duration">%02d min, %02d sek</string>
+    <string name="restore_duration">%1$02d min, %2$02d sek</string>
     <string name="backup_choice">Kva ønskjer du å ta reservekopi av?</string>
     <string name="creating_backup">Lagar reservekopi</string>
     <string name="restoring_backup">Gjenoppretter reservekopi</string>

--- a/i18n/src/commonMain/moko-resources/pt-rBR/strings.xml
+++ b/i18n/src/commonMain/moko-resources/pt-rBR/strings.xml
@@ -358,7 +358,7 @@
     <string name="last_used_source">Última utilizada</string>
     <string name="check_for_updates">Procurar por atualizações</string>
     <string name="local_source_help_guide">Guia sobre a fonte local</string>
-    <string name="restore_duration">%02d min e %02d seg</string>
+    <string name="restore_duration">%1$02d min e %2$02d seg</string>
     <string name="downloaded_only_summary">Filtra todos os itens em sua biblioteca</string>
     <string name="gray_background">Cinza</string>
     <string name="viewer">Modo de leitura</string>

--- a/i18n/src/commonMain/moko-resources/pt/strings.xml
+++ b/i18n/src/commonMain/moko-resources/pt/strings.xml
@@ -361,7 +361,7 @@
     <string name="check_for_updates">Verificar por atualizações</string>
     <string name="licenses">Licenças de código aberto</string>
     <string name="downloaded_only_summary">Filtra todos os itens nasua biblioteca</string>
-    <string name="restore_duration">%02d min, %02d seg</string>
+    <string name="restore_duration">%1$02d min, %2$02d seg</string>
     <string name="gray_background">Cinza</string>
     <string name="viewer">Modo de leitura</string>
     <string name="pref_category_for_this_series">Para esta série</string>

--- a/i18n/src/commonMain/moko-resources/sa/strings.xml
+++ b/i18n/src/commonMain/moko-resources/sa/strings.xml
@@ -319,7 +319,7 @@
     <string name="pref_restore_backup">प्रतिलेखनं समाददातु</string>
     <string name="pref_backup_interval">प्रतिलेखनस्य आवर्तनता</string>
     <string name="backup_in_progress">प्रतिलेखनं पूर्वमेव प्रगतौ अस्ति</string>
-    <string name="restore_duration">%02d निमेषाः %02d क्षणाः च</string>
+    <string name="restore_duration">%1$02d निमेषाः %2$02d क्षणाः च</string>
     <string name="restoring_backup_error">प्रतिलेखनस्य समादानम् अनुत्तीर्णम्</string>
     <string name="creating_backup_error">प्रतिलेखनम् अनुत्तीर्णम्</string>
     <string name="restore_in_progress">प्रतिसंस्कारः पूर्वमेव प्रगत्याम् अस्ति</string>

--- a/i18n/src/commonMain/moko-resources/sah/strings.xml
+++ b/i18n/src/commonMain/moko-resources/sah/strings.xml
@@ -225,7 +225,7 @@
     <string name="creating_backup">Хаппаас куопуйа оҥоһуута</string>
     <string name="backup_choice">Тугу куопуйалаары гынннын?</string>
     <string name="backup_in_progress">Хаппаас куопуйа оҥоруута туола турар</string>
-    <string name="restore_duration">%02d мүнүүтэ %02d сөкүүндэ</string>
+    <string name="restore_duration">%1$02d мүнүүтэ %2$02d сөкүүндэ</string>
     <string name="restore_completed">Төнүҥнэри бүттэ</string>
     <string name="backup_restore_missing_trackers">Трэкэрдар киирбэтилэр:</string>
     <string name="backup_restore_missing_sources">Суох төрүттэр:</string>

--- a/i18n/src/commonMain/moko-resources/sq/strings.xml
+++ b/i18n/src/commonMain/moko-resources/sq/strings.xml
@@ -392,7 +392,7 @@
     <string name="action_track">Pista</string>
     <string name="pref_backup_interval">Frekuenca rezervë</string>
     <string name="backup_restore_missing_trackers">I pa identifikuar ne gjurmuesit:</string>
-    <string name="restore_duration">%02d min, %02d sek</string>
+    <string name="restore_duration">%1$02d min, %2$02d sek</string>
     <string name="restore_miui_warning">Rezervimi/rivendosja mund të mos funksionojë siç duhet nëse Optimizimi MIUI është i çaktivizuar.</string>
     <string name="pref_reset_user_agent_string">Rivendos vargun e parazgjedhur të agjentit të përdoruesit</string>
     <string name="cache_delete_error">Ndodhi një gabim gjatë pastrimit</string>

--- a/i18n/src/commonMain/moko-resources/sr/strings.xml
+++ b/i18n/src/commonMain/moko-resources/sr/strings.xml
@@ -326,7 +326,7 @@
     <string name="restore_in_progress">Враћање је већ у току</string>
     <string name="creating_backup_error">Прављење резервне копије није успело</string>
     <string name="backup_in_progress">Прављење резервне копије је већ у току</string>
-    <string name="restore_duration">%02d мин, %02d сек</string>
+    <string name="restore_duration">%1$02d мин, %2$02d сек</string>
     <string name="pref_webtoon_side_padding">Растојање од ивице</string>
     <string name="pref_category_reading">Читање</string>
     <string name="pref_always_show_chapter_transition">Увек прикажи транзицију поглавља</string>

--- a/i18n/src/commonMain/moko-resources/ta/strings.xml
+++ b/i18n/src/commonMain/moko-resources/ta/strings.xml
@@ -519,7 +519,7 @@
     <string name="backup_restore_missing_trackers">டிராக்கர்கள் உள்நுழையவில்லை:</string>
     <string name="backup_restore_content_full">நீங்கள் காணாமல் போன நீட்டிப்புகளை நிறுவ வேண்டும், பின்னர் அவற்றைப் பயன்படுத்த கண்காணிப்பு சேவைகளில் உள்நுழைய வேண்டும்.</string>
     <string name="restore_completed">மீட்டமை முடிந்தது</string>
-    <string name="restore_duration">%1 $ 02 டி மணித்துளி, %2 $ 02 டி நொடி</string>
+    <string name="restore_duration">%1$02d மணித்துளி, %2$02d நொடி</string>
     <string name="backup_in_progress">காப்புப்பிரதி ஏற்கனவே நடந்து வருகிறது</string>
     <string name="backup_choice">நீங்கள் என்ன காப்புப் பிரதி எடுக்க விரும்புகிறீர்கள்?</string>
     <string name="app_settings">பயன்பாட்டு அமைப்புகள்</string>

--- a/i18n/src/commonMain/moko-resources/th/strings.xml
+++ b/i18n/src/commonMain/moko-resources/th/strings.xml
@@ -453,7 +453,7 @@
     <string name="restore_in_progress">การคืนค่ากําลังดําเนินการอยู่แล้ว</string>
     <string name="creating_backup_error">การสำรองข้อมูลล้มเหลว</string>
     <string name="backup_in_progress">การสำรองข้อมูลกําลังดําเนินการอยู่แล้ว</string>
-    <string name="restore_duration">%02d นาที %02d วินาที</string>
+    <string name="restore_duration">%1$02d นาที %2$02d วินาที</string>
     <string name="backup_restore_content_full">คุณจะต้องติดตั้งส่วนขยายที่ขาดหายไปและลงชื่อเข้าใช้บริการติดตามจึงจะสามารถใช้งานได้</string>
     <string name="backup_restore_missing_trackers">ตัวติดตามไม่ได้เข้าสู่ระบบ:</string>
     <string name="backup_restore_missing_sources">แหล่งที่มาที่หายไป:</string>


### PR DESCRIPTION
## Objective
Unblock PR/release CI by fixing Android string-resource formatting errors caused by non-positional or malformed placeholders in localized i18n files.

## Scope
- Normalize multi-argument localized format placeholders to positional syntax where required by Android resource validation.
- Correct malformed placeholder/percent literals in affected locale entries (including `hr` and `ta`).
- Add changelog note for the fix under `Unreleased`.

## Verification
- `./gradlew spotlessCheck`
- `./gradlew :app:compileStableDebugKotlin`
- `./gradlew :app:assembleStableRelease`

## Risk
- Change scope is limited to localization XML resources and changelog text.
- Main risk is translation-string rendering regressions in specific locales.

## Rollback
Revert this PR commit set to restore previous string resources if any locale formatting regression is reported.

Closes #686
