### PR TITLE
perf: improve UI performance in list and update screens (R689)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 
 ### Added
 
+### Improved
+- Upcoming and History Compose lists now use stable item/header keys, reducing avoidable row churn during list updates, and update-install candidate checks now refresh off the composition thread while preserving the current CTA state
+
 ### Fixed
 - Updater now preserves an in-app install path when notification permission is denied on Android 13+, with validated downloaded-APK install actions surfaced in About and New Update details
 - Extension repo restore now skips database insertions for exact duplicate repo records already present in local storage, preventing restore failures from primary-key/unique-key collisions when restoring the same backup more than once

--- a/app/src/main/java/eu/kanade/presentation/history/anime/AnimeHistoryScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/history/anime/AnimeHistoryScreen.kt
@@ -78,7 +78,12 @@ private fun AnimeHistoryScreenContent(
     ) {
         items(
             items = history,
-            key = { "history-${it.hashCode()}" },
+            key = {
+                when (it) {
+                    is AnimeHistoryUiModel.Header -> "history-header-${it.date.toEpochDay()}"
+                    is AnimeHistoryUiModel.Item -> "history-anime-${it.item.id}"
+                }
+            },
             contentType = {
                 when (it) {
                     is AnimeHistoryUiModel.Header -> "header"

--- a/app/src/main/java/eu/kanade/presentation/history/manga/MangaHistoryScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/history/manga/MangaHistoryScreen.kt
@@ -77,7 +77,12 @@ private fun MangaHistoryScreenContent(
     ) {
         items(
             items = history,
-            key = { "history-${it.hashCode()}" },
+            key = {
+                when (it) {
+                    is MangaHistoryUiModel.Header -> "history-header-${it.date.toEpochDay()}"
+                    is MangaHistoryUiModel.Item -> "history-manga-${it.item.id}"
+                }
+            },
             contentType = {
                 when (it) {
                     is MangaHistoryUiModel.Header -> "header"

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/about/AboutScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/about/AboutScreen.kt
@@ -10,9 +10,12 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Public
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
@@ -57,6 +60,8 @@ import uy.kohesive.injekt.api.get
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 object AboutScreen : Screen() {
 
@@ -72,8 +77,11 @@ object AboutScreen : Screen() {
         val updateWorkInfos by context.workManager
             .getWorkInfosForUniqueWorkFlow(AppUpdateDownloadJob.TAG)
             .collectAsStateWithLifecycle(initialValue = emptyList())
-        val hasInstallCandidate = remember(updateWorkInfos) {
-            AppUpdateDownloadJob.hasValidDownloadedUpdate(context)
+        var hasInstallCandidate by remember { mutableStateOf(false) }
+        LaunchedEffect(updateWorkInfos) {
+            hasInstallCandidate = withContext(Dispatchers.IO) {
+                AppUpdateDownloadJob.hasValidDownloadedUpdate(context)
+            }
         }
         val updatePromptPreferences = remember { Injekt.get<UpdatePromptPreferences>() }
         val updateCheckInProgressA11y = stringResource(MR.strings.update_check_in_progress_a11y)

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/about/AboutScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/about/AboutScreen.kt
@@ -47,6 +47,8 @@ import eu.kanade.tachiyomi.util.system.isPreviewBuildType
 import eu.kanade.tachiyomi.util.system.toast
 import eu.kanade.tachiyomi.util.system.updaterEnabled
 import eu.kanade.tachiyomi.util.system.workManager
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.components.LinkIcon
 import tachiyomi.presentation.core.components.ScrollbarLazyColumn
@@ -60,8 +62,6 @@ import uy.kohesive.injekt.api.get
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 
 object AboutScreen : Screen() {
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/more/NewUpdateScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/more/NewUpdateScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -33,6 +34,8 @@ import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.i18n.stringResource
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 class NewUpdateScreen(
     private val versionName: String,
@@ -68,11 +71,14 @@ class NewUpdateScreen(
             .getWorkInfosForUniqueWorkFlow(AppUpdateDownloadJob.TAG)
             .collectAsStateWithLifecycle(initialValue = emptyList())
         var installStateRefreshNonce by remember { mutableStateOf(0) }
-        val hasInstallCandidate = remember(workInfos, installStateRefreshNonce) {
-            AppUpdateDownloadJob.hasValidDownloadedUpdate(
-                context = context,
-                expectedVersion = versionName,
-            )
+        var hasInstallCandidate by remember { mutableStateOf(false) }
+        LaunchedEffect(workInfos, installStateRefreshNonce, versionName) {
+            hasInstallCandidate = withContext(Dispatchers.IO) {
+                AppUpdateDownloadJob.hasValidDownloadedUpdate(
+                    context = context,
+                    expectedVersion = versionName,
+                )
+            }
         }
         var showPermissionDeniedDialog by remember { mutableStateOf(false) }
         var pendingPermissionRequest by remember { mutableStateOf(false) }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/more/NewUpdateScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/more/NewUpdateScreen.kt
@@ -30,12 +30,12 @@ import eu.kanade.tachiyomi.util.system.canPostNotifications
 import eu.kanade.tachiyomi.util.system.openInBrowser
 import eu.kanade.tachiyomi.util.system.toast
 import eu.kanade.tachiyomi.util.system.workManager
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import tachiyomi.i18n.MR
 import tachiyomi.presentation.core.i18n.stringResource
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 
 class NewUpdateScreen(
     private val versionName: String,

--- a/app/src/main/java/mihon/feature/upcoming/anime/UpcomingAnimeScreenContent.kt
+++ b/app/src/main/java/mihon/feature/upcoming/anime/UpcomingAnimeScreenContent.kt
@@ -159,7 +159,12 @@ private fun UpcomingAnimeScreenSmallImpl(
         }
         items(
             items = items,
-            key = { "upcoming-${it.hashCode()}" },
+            key = {
+                when (it) {
+                    is UpcomingAnimeUIModel.Header -> "upcoming-header-${it.date.toEpochDay()}"
+                    is UpcomingAnimeUIModel.Item -> "upcoming-anime-${it.anime.id}"
+                }
+            },
             contentType = {
                 when (it) {
                     is UpcomingAnimeUIModel.Header -> "header"
@@ -211,7 +216,12 @@ private fun UpcomingAnimeScreenLargeImpl(
             FastScrollLazyColumn(state = listState) {
                 items(
                     items = items,
-                    key = { "upcoming-${it.hashCode()}" },
+                    key = {
+                        when (it) {
+                            is UpcomingAnimeUIModel.Header -> "upcoming-header-${it.date.toEpochDay()}"
+                            is UpcomingAnimeUIModel.Item -> "upcoming-anime-${it.anime.id}"
+                        }
+                    },
                     contentType = {
                         when (it) {
                             is UpcomingAnimeUIModel.Header -> "header"

--- a/app/src/main/java/mihon/feature/upcoming/manga/UpcomingMangaScreenContent.kt
+++ b/app/src/main/java/mihon/feature/upcoming/manga/UpcomingMangaScreenContent.kt
@@ -159,7 +159,12 @@ private fun UpcomingMangaScreenSmallImpl(
         }
         items(
             items = items,
-            key = { "upcoming-${it.hashCode()}" },
+            key = {
+                when (it) {
+                    is UpcomingMangaUIModel.Header -> "upcoming-header-${it.date.toEpochDay()}"
+                    is UpcomingMangaUIModel.Item -> "upcoming-manga-${it.manga.id}"
+                }
+            },
             contentType = {
                 when (it) {
                     is UpcomingMangaUIModel.Header -> "header"
@@ -211,7 +216,12 @@ private fun UpcomingMangaScreenLargeImpl(
             FastScrollLazyColumn(state = listState) {
                 items(
                     items = items,
-                    key = { "upcoming-${it.hashCode()}" },
+                    key = {
+                        when (it) {
+                            is UpcomingMangaUIModel.Header -> "upcoming-header-${it.date.toEpochDay()}"
+                            is UpcomingMangaUIModel.Item -> "upcoming-manga-${it.manga.id}"
+                        }
+                    },
                     contentType = {
                         when (it) {
                             is UpcomingMangaUIModel.Header -> "header"


### PR DESCRIPTION
## Objective
Reduce avoidable UI work in a few localized high-traffic Compose surfaces identified during the performance audit.

Closes #689.

## Scope
- replace `hashCode()`-based `LazyList` keys in Upcoming and History screens with stable item/header identity
- move downloaded update artifact checks off the composition thread in the update prompt and About screen
- preserve the previous install-candidate state while async refresh reruns so the CTA does not flicker back to download

## Verification
- `git diff --check`
- `GRADLE_USER_HOME=/Users/rayyacub/.codex/worktrees/998f/rayniyomi/.gradle ./gradlew :app:compileStableDebugKotlin`
- repo pre-push hooks passed: `spotlessCheck`, `:app:compileStableDebugKotlin`
- independent review pass identified and verified the CTA flicker follow-up fix

## Risk
Risk Tier: T2

Moderate but localized. The list-key changes affect Compose item identity in four screens, and the async update-state changes affect install/download CTA behavior in two screens. The main regression risk was temporary CTA state loss during refresh, which is addressed in the final patch.
