### PR TITLE
fix: persist stub source metadata fallback (R646)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Upcoming and History Compose lists now use stable item/header keys, reducing avoidable row churn during list updates, and update-install candidate checks now refresh off the composition thread while preserving the current CTA state
 
 ### Fixed
+- Missing-extension sources now preserve readable stub source names from runtime and backup metadata (fallback to raw source ID only when metadata is unavailable), for both manga and anime source flows.
 
 ### Changed
 

--- a/app/src/main/java/eu/kanade/domain/DomainModule.kt
+++ b/app/src/main/java/eu/kanade/domain/DomainModule.kt
@@ -400,7 +400,7 @@ class DomainModule : InjektModule {
         addSingletonFactory<MangaUpdatesRepository> { MangaUpdatesRepositoryImpl(get()) }
         addFactory { GetMangaUpdates(get()) }
 
-        addSingletonFactory<AnimeSourceRepository> { AnimeSourceRepositoryImpl(get(), get()) }
+        addSingletonFactory<AnimeSourceRepository> { AnimeSourceRepositoryImpl(get(), get(), get()) }
         addSingletonFactory<AnimeStubSourceRepository> { AnimeStubSourceRepositoryImpl(get()) }
         addFactory { GetEnabledAnimeSources(get(), get(), get()) }
         addFactory { CheckAnimeSourceHealth(get(), get<AnimeSourceHealthChecker>()) }
@@ -411,7 +411,7 @@ class DomainModule : InjektModule {
         addFactory { ToggleAnimeSource(get()) }
         addFactory { ToggleAnimeSourcePin(get()) }
 
-        addSingletonFactory<MangaSourceRepository> { MangaSourceRepositoryImpl(get(), get()) }
+        addSingletonFactory<MangaSourceRepository> { MangaSourceRepositoryImpl(get(), get(), get()) }
         addSingletonFactory<MangaStubSourceRepository> { MangaStubSourceRepositoryImpl(get()) }
         addSingletonFactory<SourceHealthRepository> { SourceHealthRepositoryImpl(get()) }
         addSingletonFactory { RunSourceHealthCheck(get()) }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/BackupRestorer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/restore/BackupRestorer.kt
@@ -6,12 +6,14 @@ import eu.kanade.tachiyomi.data.backup.BackupDecoder
 import eu.kanade.tachiyomi.data.backup.BackupNotifier
 import eu.kanade.tachiyomi.data.backup.lightnovel.LightNovelBackupDataSource
 import eu.kanade.tachiyomi.data.backup.models.BackupAnime
+import eu.kanade.tachiyomi.data.backup.models.BackupAnimeSource
 import eu.kanade.tachiyomi.data.backup.models.BackupCategory
 import eu.kanade.tachiyomi.data.backup.models.BackupCustomButtons
 import eu.kanade.tachiyomi.data.backup.models.BackupExtension
 import eu.kanade.tachiyomi.data.backup.models.BackupExtensionRepos
 import eu.kanade.tachiyomi.data.backup.models.BackupManga
 import eu.kanade.tachiyomi.data.backup.models.BackupPreference
+import eu.kanade.tachiyomi.data.backup.models.BackupSource
 import eu.kanade.tachiyomi.data.backup.models.BackupSourcePreferences
 import eu.kanade.tachiyomi.data.backup.restore.restorers.AnimeCategoriesRestorer
 import eu.kanade.tachiyomi.data.backup.restore.restorers.AnimeExtensionRepoRestorer
@@ -32,8 +34,12 @@ import kotlinx.coroutines.launch
 import logcat.LogPriority
 import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.core.common.util.system.logcat
+import tachiyomi.domain.source.anime.repository.AnimeStubSourceRepository
+import tachiyomi.domain.source.manga.repository.MangaStubSourceRepository
 import tachiyomi.i18n.MR
 import tachiyomi.i18n.aniyomi.AYMR
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
 import java.text.SimpleDateFormat
 import java.util.Collections
 import java.util.Date
@@ -54,6 +60,8 @@ class BackupRestorer(
     private val mangaRestorer: MangaRestorer = MangaRestorer(),
     private val extensionsRestorer: ExtensionsRestorer = ExtensionsRestorer(context),
     private val lightNovelBackupDataSource: LightNovelBackupDataSource = LightNovelBackupDataSource(context),
+    private val animeStubSourceRepository: AnimeStubSourceRepository = Injekt.get(),
+    private val mangaStubSourceRepository: MangaStubSourceRepository = Injekt.get(),
 ) {
     companion object {
         internal const val RESTORE_ERROR_LOG_FILENAME = "rayniyomi_restore_error.txt"
@@ -99,6 +107,11 @@ class BackupRestorer(
         animeSourceMapping = backupAnimeMaps.associate { it.sourceId to it.name }
         val backupMangaMaps = backup.backupSources
         mangaSourceMapping = backupMangaMaps.associate { it.sourceId to it.name }
+
+        hydrateStubSourceMetadata(
+            backupAnimeSources = backupAnimeMaps,
+            backupMangaSources = backupMangaMaps,
+        )
 
         if (options.libraryEntries) {
             restoreAmount += backup.backupManga.size + backup.backupAnime.size
@@ -158,6 +171,30 @@ class BackupRestorer(
             }
 
             // TODO: optionally trigger online library + tracker update
+        }
+    }
+
+    private suspend fun hydrateStubSourceMetadata(
+        backupAnimeSources: List<BackupAnimeSource>,
+        backupMangaSources: List<BackupSource>,
+    ) {
+        backupAnimeSources.forEach { source ->
+            if (source.name.isNotBlank()) {
+                animeStubSourceRepository.upsertStubAnimeSource(
+                    id = source.sourceId,
+                    lang = "",
+                    name = source.name,
+                )
+            }
+        }
+        backupMangaSources.forEach { source ->
+            if (source.name.isNotBlank()) {
+                mangaStubSourceRepository.upsertStubMangaSource(
+                    id = source.sourceId,
+                    lang = "",
+                    name = source.name,
+                )
+            }
         }
     }
 

--- a/data/src/main/java/tachiyomi/data/source/anime/AnimeSourceRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/source/anime/AnimeSourceRepositoryImpl.kt
@@ -11,16 +11,19 @@ import tachiyomi.data.handlers.anime.AnimeDatabaseHandler
 import tachiyomi.domain.source.anime.model.StubAnimeSource
 import tachiyomi.domain.source.anime.repository.AnimeSourcePagingSourceType
 import tachiyomi.domain.source.anime.repository.AnimeSourceRepository
+import tachiyomi.domain.source.anime.repository.AnimeStubSourceRepository
 import tachiyomi.domain.source.anime.service.AnimeSourceManager
 import tachiyomi.domain.source.anime.model.AnimeSource as DomainSource
 
 class AnimeSourceRepositoryImpl(
     private val sourceManager: AnimeSourceManager,
     private val handler: AnimeDatabaseHandler,
+    private val stubSourceRepository: AnimeStubSourceRepository,
 ) : AnimeSourceRepository {
 
     override fun getAnimeSources(): Flow<List<DomainSource>> {
         return sourceManager.catalogueSources.map { sources ->
+            sources.forEach { stubSourceRepository.upsertStubAnimeSource(it.id, it.lang, it.name) }
             sources.map {
                 mapSourceToDomainSource(it).copy(
                     supportsLatest = it.supportsLatest,
@@ -31,6 +34,7 @@ class AnimeSourceRepositoryImpl(
 
     override fun getOnlineAnimeSources(): Flow<List<DomainSource>> {
         return sourceManager.catalogueSources.map { sources ->
+            sources.forEach { stubSourceRepository.upsertStubAnimeSource(it.id, it.lang, it.name) }
             sources
                 .filterIsInstance<AnimeHttpSource>()
                 .map(::mapSourceToDomainSource)
@@ -45,6 +49,9 @@ class AnimeSourceRepositoryImpl(
             .map {
                 it.map { (sourceId, count) ->
                     val source = sourceManager.getOrStub(sourceId)
+                    if (source.name.isNotBlank() || source.lang.isNotBlank()) {
+                        stubSourceRepository.upsertStubAnimeSource(source.id, source.lang, source.name)
+                    }
                     val domainSource = mapSourceToDomainSource(source).copy(
                         isStub = source is StubAnimeSource,
                     )

--- a/data/src/main/java/tachiyomi/data/source/manga/MangaSourceRepositoryImpl.kt
+++ b/data/src/main/java/tachiyomi/data/source/manga/MangaSourceRepositoryImpl.kt
@@ -11,6 +11,7 @@ import tachiyomi.data.handlers.manga.MangaDatabaseHandler
 import tachiyomi.domain.source.manga.model.MangaSourceWithCount
 import tachiyomi.domain.source.manga.model.StubMangaSource
 import tachiyomi.domain.source.manga.repository.MangaSourceRepository
+import tachiyomi.domain.source.manga.repository.MangaStubSourceRepository
 import tachiyomi.domain.source.manga.repository.SourcePagingSourceType
 import tachiyomi.domain.source.manga.service.MangaSourceManager
 import tachiyomi.domain.source.manga.model.Source as DomainSource
@@ -18,10 +19,12 @@ import tachiyomi.domain.source.manga.model.Source as DomainSource
 class MangaSourceRepositoryImpl(
     private val sourceManager: MangaSourceManager,
     private val handler: MangaDatabaseHandler,
+    private val stubSourceRepository: MangaStubSourceRepository,
 ) : MangaSourceRepository {
 
     override fun getMangaSources(): Flow<List<DomainSource>> {
         return sourceManager.catalogueSources.map { sources ->
+            sources.forEach { stubSourceRepository.upsertStubMangaSource(it.id, it.lang, it.name) }
             sources.map {
                 mapSourceToDomainSource(it).copy(
                     supportsLatest = it.supportsLatest,
@@ -32,6 +35,7 @@ class MangaSourceRepositoryImpl(
 
     override fun getOnlineMangaSources(): Flow<List<DomainSource>> {
         return sourceManager.catalogueSources.map { sources ->
+            sources.forEach { stubSourceRepository.upsertStubMangaSource(it.id, it.lang, it.name) }
             sources
                 .filterIsInstance<HttpSource>()
                 .map(::mapSourceToDomainSource)
@@ -46,6 +50,9 @@ class MangaSourceRepositoryImpl(
             .map {
                 it.map { (sourceId, count) ->
                     val source = sourceManager.getOrStub(sourceId)
+                    if (source.name.isNotBlank() || source.lang.isNotBlank()) {
+                        stubSourceRepository.upsertStubMangaSource(source.id, source.lang, source.name)
+                    }
                     val domainSource = mapSourceToDomainSource(source).copy(
                         isStub = source is StubMangaSource,
                     )
@@ -60,6 +67,9 @@ class MangaSourceRepositoryImpl(
         return sourceIdWithNonLibraryManga.map { sourceId ->
             sourceId.map { (sourceId, count) ->
                 val source = sourceManager.getOrStub(sourceId)
+                if (source.name.isNotBlank() || source.lang.isNotBlank()) {
+                    stubSourceRepository.upsertStubMangaSource(source.id, source.lang, source.name)
+                }
                 val domainSource = mapSourceToDomainSource(source).copy(
                     isStub = source is StubMangaSource,
                 )


### PR DESCRIPTION
## Objective
Persist stub source metadata so missing extensions show readable source names instead of raw source IDs whenever metadata is available.

## Scope
- Persist known source metadata `(source_id, name, lang)` from manga/anime source repository flows into stub source repositories.
- Preserve precedence behavior:
  - runtime installed source metadata wins,
  - persisted stub metadata is used when runtime source is unavailable,
  - raw ID fallback is used only when both are unavailable.
- Hydrate stub source metadata during restore from existing backup source maps (`sourceId` + `name`).
- Update dependency wiring for repository constructor changes.
- Add one scoped changelog bullet.

## Verification
- `./gradlew spotlessCheck`
- `./gradlew :app:compileStableDebugKotlin`
- `autoloop preflight R646 --phase implementation --repo .`
- `autoloop verify-claims R646 --phase implementation --claims-file .autoloop-codex/reviews/R646-impl-claims.json --repo .`
- `autoloop enforce-gates R646 --phase implementation`
- `autoloop doctor R646 --strict`

## Risk
- Low to moderate: source metadata writes now occur in source repository read flows; behavior is guarded to avoid persisting blank placeholder stubs.
- Restore hydration uses current backup schema fields only (`sourceId`, `name`) and does not add speculative schema changes.
- If runtime metadata is present, it continues to take precedence over persisted stub values.

Closes #646
