### PR TITLE
test: repair repository source manager Flow stubbing (R693)

### DIFF
--- a/data/src/test/java/tachiyomi/data/source/anime/AnimeSourceRepositoryImplTest.kt
+++ b/data/src/test/java/tachiyomi/data/source/anime/AnimeSourceRepositoryImplTest.kt
@@ -7,11 +7,14 @@ import io.kotest.matchers.shouldBe
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
 import tachiyomi.data.handlers.anime.AnimeDatabaseHandler
+import tachiyomi.domain.source.anime.model.StubAnimeSource
 import tachiyomi.domain.source.anime.repository.AnimeStubSourceRepository
 import tachiyomi.domain.source.anime.service.AnimeSourceManager
 
@@ -20,9 +23,7 @@ class AnimeSourceRepositoryImplTest {
     @Test
     fun `getAnimeSources upserts known runtime metadata`() = runBlocking {
         val source = mockAnimeCatalogueSource(id = 1L, lang = "en", name = "Runtime Anime", supportsLatest = true)
-        val sourceManager = mockk<AnimeSourceManager> {
-            every { catalogueSources } returns flowOf(listOf(source))
-        }
+        val sourceManager = TestAnimeSourceManager(listOf(source))
         val stubRepo = mockk<AnimeStubSourceRepository>(relaxed = true)
 
         val repository = AnimeSourceRepositoryImpl(
@@ -45,9 +46,7 @@ class AnimeSourceRepositoryImplTest {
         val catalogueSource =
             mockAnimeCatalogueSource(id = 10L, lang = "ja", name = "Catalogue Only", supportsLatest = false)
         val httpSource = mockAnimeHttpSource(id = 11L, lang = "en", name = "Http Anime")
-        val sourceManager = mockk<AnimeSourceManager> {
-            every { catalogueSources } returns flowOf(listOf(catalogueSource, httpSource))
-        }
+        val sourceManager = TestAnimeSourceManager(listOf(catalogueSource, httpSource))
         val stubRepo = mockk<AnimeStubSourceRepository>(relaxed = true)
 
         val repository = AnimeSourceRepositoryImpl(
@@ -88,5 +87,22 @@ class AnimeSourceRepositoryImplTest {
             every { this@apply.lang } returns lang
             every { this@apply.name } returns name
         }
+    }
+
+    private class TestAnimeSourceManager(
+        private val sources: List<AnimeCatalogueSource>,
+    ) : AnimeSourceManager {
+        override val isInitialized = MutableStateFlow(true)
+        override val catalogueSources: Flow<List<AnimeCatalogueSource>> = flowOf(sources)
+
+        override fun get(sourceKey: Long) = sources.firstOrNull { it.id == sourceKey }
+
+        override fun getOrStub(sourceKey: Long) = get(sourceKey) ?: error("Unknown source id: $sourceKey")
+
+        override fun getOnlineSources(): List<AnimeHttpSource> = sources.filterIsInstance<AnimeHttpSource>()
+
+        override fun getCatalogueSources(): List<AnimeCatalogueSource> = sources
+
+        override fun getStubSources(): List<StubAnimeSource> = emptyList()
     }
 }

--- a/data/src/test/java/tachiyomi/data/source/manga/MangaSourceRepositoryImplTest.kt
+++ b/data/src/test/java/tachiyomi/data/source/manga/MangaSourceRepositoryImplTest.kt
@@ -7,11 +7,14 @@ import io.kotest.matchers.shouldBe
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
 import tachiyomi.data.handlers.manga.MangaDatabaseHandler
+import tachiyomi.domain.source.manga.model.StubMangaSource
 import tachiyomi.domain.source.manga.repository.MangaStubSourceRepository
 import tachiyomi.domain.source.manga.service.MangaSourceManager
 
@@ -20,9 +23,7 @@ class MangaSourceRepositoryImplTest {
     @Test
     fun `getMangaSources upserts known runtime metadata`() = runBlocking {
         val source = mockCatalogueSource(id = 1L, lang = "en", name = "Runtime Manga", supportsLatest = true)
-        val sourceManager = mockk<MangaSourceManager> {
-            every { catalogueSources } returns flowOf(listOf(source))
-        }
+        val sourceManager = TestMangaSourceManager(listOf(source))
         val stubRepo = mockk<MangaStubSourceRepository>(relaxed = true)
 
         val repository = MangaSourceRepositoryImpl(
@@ -45,9 +46,7 @@ class MangaSourceRepositoryImplTest {
         val catalogueSource =
             mockCatalogueSource(id = 10L, lang = "ja", name = "Catalogue Only", supportsLatest = false)
         val httpSource = mockHttpSource(id = 11L, lang = "en", name = "Http Source")
-        val sourceManager = mockk<MangaSourceManager> {
-            every { catalogueSources } returns flowOf(listOf(catalogueSource, httpSource))
-        }
+        val sourceManager = TestMangaSourceManager(listOf(catalogueSource, httpSource))
         val stubRepo = mockk<MangaStubSourceRepository>(relaxed = true)
 
         val repository = MangaSourceRepositoryImpl(
@@ -88,5 +87,22 @@ class MangaSourceRepositoryImplTest {
             every { this@apply.lang } returns lang
             every { this@apply.name } returns name
         }
+    }
+
+    private class TestMangaSourceManager(
+        private val sources: List<CatalogueSource>,
+    ) : MangaSourceManager {
+        override val isInitialized = MutableStateFlow(true)
+        override val catalogueSources: Flow<List<CatalogueSource>> = flowOf(sources)
+
+        override fun get(sourceKey: Long) = sources.firstOrNull { it.id == sourceKey }
+
+        override fun getOrStub(sourceKey: Long) = get(sourceKey) ?: error("Unknown source id: $sourceKey")
+
+        override fun getOnlineSources(): List<HttpSource> = sources.filterIsInstance<HttpSource>()
+
+        override fun getCatalogueSources(): List<CatalogueSource> = sources
+
+        override fun getStubSources(): List<StubMangaSource> = emptyList()
     }
 }


### PR DESCRIPTION
## Objective
Repair the test-only regression introduced by PR #691 so the repository source metadata coverage actually passes CI on main.

Closes #693.

## Scope
- replace brittle MockK `catalogueSources` property stubs with explicit fake anime source managers
- replace brittle MockK `catalogueSources` property stubs with explicit fake manga source managers
- keep the change test-only with no production behavior changes

## Verification
- `GRADLE_USER_HOME=/Users/rayyacub/.codex/worktrees/r646-fix/.gradle ./gradlew :data:testDebugUnitTest --tests '*SourceRepositoryImplTest'`

## Risk
Risk Tier: T1

Low. This only changes unit tests and removes the generic-erasure failure mode from the mocks used in those tests.
