### PR TITLE
fix: replace ReaderViewModel loader null assertion with checkNotNull (R444)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 
 ### Fixed
 - Missing-extension sources now preserve readable stub source names from runtime and backup metadata (fallback to raw source ID only when metadata is unavailable), for both manga and anime source flows.
+- Reader initialization now guards chapter loading with a descriptive `checkNotNull` for `ChapterLoader`, replacing an unsafe null assertion crash path in `ReaderViewModel`.
 
 ### Changed
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -251,7 +251,12 @@ class ReaderViewModel @JvmOverloads constructor(
                     chapterListManager.chapterId = chapterId
                     chapterListManager.initChapterList(manga)
 
-                    loadChapter(loader!!, chapterListManager.getChapterById(chapterId))
+                    loadChapter(
+                        checkNotNull(loader) {
+                            "ChapterLoader must be initialized in init(mangaId, initialChapterId) before loadChapter()"
+                        },
+                        chapterListManager.getChapterById(chapterId),
+                    )
                     Result.success(true)
                 } else {
                     // Unlikely but okay

--- a/app/src/test/java/eu/kanade/tachiyomi/data/backup/restore/BackupRestorerTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/data/backup/restore/BackupRestorerTest.kt
@@ -25,6 +25,8 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import tachiyomi.domain.source.anime.repository.AnimeStubSourceRepository
+import tachiyomi.domain.source.manga.repository.MangaStubSourceRepository
 import java.util.Date
 
 class BackupRestorerTest {
@@ -133,6 +135,8 @@ class BackupRestorerTest {
             mangaRestorer = mockk<MangaRestorer>(relaxed = true),
             extensionsRestorer = mockk<ExtensionsRestorer>(relaxed = true),
             lightNovelBackupDataSource = mockk<LightNovelBackupDataSource>(relaxed = true),
+            animeStubSourceRepository = mockk<AnimeStubSourceRepository>(relaxed = true),
+            mangaStubSourceRepository = mockk<MangaStubSourceRepository>(relaxed = true),
         )
     }
 


### PR DESCRIPTION
## Objective
Replace the unsafe `loader!!` chapter-load path in `ReaderViewModel.init(...)` with a descriptive null guard so failures are actionable.

## Scope
- Replaced the targeted `loader!!` call with `checkNotNull(loader)` and a message tied to the real initializer (`init(mangaId, initialChapterId)`).
- Added one changelog bullet for this PR scope.
- Updated `BackupRestorerTest` constructor setup to inject new stub-source repository dependencies so the required stable debug unit-test gate passes.

## Verification
- `./gradlew spotlessCheck`
- `./gradlew :app:compileStableDebugKotlin`
- `./gradlew :app:testStableDebugUnitTest`
- `autoloop preflight R444 --phase plan --repo <worktree> --plan-file plan.md`
- `autoloop verify-claims R444 --phase plan --claims-file .autoloop-codex/reviews/R444-plan-claims.json --repo <worktree>`
- `autoloop enforce-gates R444 --phase plan`
- `autoloop verify-claims R444 --phase implementation --claims-file .autoloop-codex/reviews/R444-impl-claims.json --repo <worktree>`
- `autoloop preflight R444 --phase implementation --repo <worktree>`
- `autoloop enforce-gates R444 --phase implementation`
- `autoloop doctor R444 --strict`

## Risk
- Low functional risk for reader flow: targeted precondition hardening only.
- Minor test-scope risk: test helper injection update in `BackupRestorerTest` to align with current constructor dependencies.

Closes #444
