### PR TITLE
test: repair BackupRestorer test fixture after stub repo injection (R696)

### DIFF
--- a/app/src/test/java/eu/kanade/tachiyomi/data/backup/restore/BackupRestorerTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/data/backup/restore/BackupRestorerTest.kt
@@ -25,6 +25,8 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import tachiyomi.domain.source.anime.repository.AnimeStubSourceRepository
+import tachiyomi.domain.source.manga.repository.MangaStubSourceRepository
 import java.util.Date
 
 class BackupRestorerTest {
@@ -133,6 +135,8 @@ class BackupRestorerTest {
             mangaRestorer = mockk<MangaRestorer>(relaxed = true),
             extensionsRestorer = mockk<ExtensionsRestorer>(relaxed = true),
             lightNovelBackupDataSource = mockk<LightNovelBackupDataSource>(relaxed = true),
+            animeStubSourceRepository = mockk<AnimeStubSourceRepository>(relaxed = true),
+            mangaStubSourceRepository = mockk<MangaStubSourceRepository>(relaxed = true),
         )
     }
 


### PR DESCRIPTION
## Objective
Repair the main-branch unit test regression caused by `BackupRestorer` gaining stub source repository dependencies that its test fixture did not provide.

Closes #696.

## Scope
- inject relaxed anime stub source repository doubles into `BackupRestorerTest`
- inject relaxed manga stub source repository doubles into `BackupRestorerTest`
- keep the change test-only with no production behavior changes

## Verification
- `GRADLE_USER_HOME=/Users/rayyacub/Documents/rayniyomi/.gradle ./gradlew :app:testStableDebugUnitTest --tests 'eu.kanade.tachiyomi.data.backup.restore.BackupRestorerTest'`
- `GRADLE_USER_HOME=/Users/rayyacub/Documents/rayniyomi/.gradle ./gradlew :app:testStableDebugUnitTest`

## Risk
Risk Tier: T1

Low. This only updates the test harness so it matches the current constructor contract for `BackupRestorer`.
