### PR TITLE
perf: cache SSIV image analysis for warm reader loads (R487)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 
 ### Improved
 - Upcoming and History Compose lists now use stable item/header keys, reducing avoidable row churn during list updates, and update-install candidate checks now refresh off the composition thread while preserving the current CTA state
+- Reader SSIV long-strip loads now reuse cached per-source image analysis (tall-image + hardware-bitmap compatibility) across pager and webtoon holders, reducing repeated header parsing on warm page reopens
 
 ### Fixed
 - Missing-extension sources now preserve readable stub source names from runtime and backup metadata (fallback to raw source ID only when metadata is unavailable), for both manga and anime source flows.

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/ReaderPageImageView.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/ReaderPageImageView.kt
@@ -7,6 +7,7 @@ import android.graphics.drawable.Animatable
 import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
 import android.util.AttributeSet
+import android.util.LruCache
 import android.view.GestureDetector
 import android.view.MotionEvent
 import android.view.View
@@ -314,17 +315,16 @@ open class ReaderPageImageView @JvmOverloads constructor(
                 isVisible = true
             }
             is BufferedSource -> {
-                // Performance optimization: single header read for both checks when needed
+                val analysis = getOrAnalyzeImageForReader(data, config.sourceCacheKey)
+
                 if (!isWebtoon || alwaysDecodeLongStripWithSSIV) {
                     // Use SSIV path without checking if tall
-                    setHardwareConfig(ImageUtil.canUseHardwareBitmap(data))
+                    setHardwareConfig(analysis.canUseHardwareBitmap)
                     setImage(ImageSource.inputStream(data.inputStream()))
                     isVisible = true
                     return@apply
                 }
 
-                // Webtoon mode: analyze image once for both tall check and hardware bitmap compatibility
-                val analysis = ImageUtil.analyzeImageForReader(data)
                 if (analysis.isTallImage) {
                     setHardwareConfig(analysis.canUseHardwareBitmap)
                     setImage(ImageSource.inputStream(data.inputStream()))
@@ -441,6 +441,7 @@ open class ReaderPageImageView @JvmOverloads constructor(
         val cropBorders: Boolean = false,
         val zoomStartPosition: ZoomStartPosition = ZoomStartPosition.CENTER,
         val landscapeZoom: Boolean = false,
+        val sourceCacheKey: String? = null,
     )
 
     enum class ZoomStartPosition {
@@ -448,6 +449,24 @@ open class ReaderPageImageView @JvmOverloads constructor(
         CENTER,
         RIGHT,
     }
+
+    private fun getOrAnalyzeImageForReader(
+        imageSource: BufferedSource,
+        sourceCacheKey: String?,
+    ): ImageUtil.ImageAnalysis {
+        val cachedAnalysis = sourceCacheKey?.let(ssivSourceAnalysisCache::get)
+        if (cachedAnalysis != null) {
+            return cachedAnalysis
+        }
+
+        val analysis = ImageUtil.analyzeImageForReader(imageSource)
+        if (sourceCacheKey != null) {
+            ssivSourceAnalysisCache.put(sourceCacheKey, analysis)
+        }
+        return analysis
+    }
 }
 
 private const val MAX_ZOOM_SCALE = 5F
+private const val SSIV_SOURCE_ANALYSIS_CACHE_SIZE = 200
+private val ssivSourceAnalysisCache = LruCache<String, ImageUtil.ImageAnalysis>(SSIV_SOURCE_ANALYSIS_CACHE_SIZE)

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
@@ -174,6 +174,7 @@ class PagerPageHolder(
                         cropBorders = viewer.config.imageCropBorders,
                         zoomStartPosition = viewer.config.imageZoomType,
                         landscapeZoom = viewer.config.landscapeZoom,
+                        sourceCacheKey = item.imageUrl ?: item.url,
                     ),
                 )
                 if (!isAnimated) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerPageHolder.kt
@@ -152,6 +152,7 @@ class PagerPageHolder(
         progressIndicator?.setProgress(0)
 
         val streamFn = page.stream ?: return
+        val sourceCacheKey = buildSourceCacheKey(item)
 
         try {
             val (source, isAnimated, background) = withIOContext {
@@ -174,7 +175,7 @@ class PagerPageHolder(
                         cropBorders = viewer.config.imageCropBorders,
                         zoomStartPosition = viewer.config.imageZoomType,
                         landscapeZoom = viewer.config.landscapeZoom,
-                        sourceCacheKey = item.imageUrl ?: item.url,
+                        sourceCacheKey = sourceCacheKey,
                     ),
                 )
                 if (!isAnimated) {
@@ -245,6 +246,19 @@ class PagerPageHolder(
     private fun onPageSplit(page: ReaderPage) {
         val newPage = InsertPage(page)
         viewer.onPageSplit(page, newPage)
+    }
+
+    private fun buildSourceCacheKey(page: ReaderPage): String {
+        val base = page.imageUrl ?: page.url
+        return buildString {
+            append(base)
+            append("|rotate=").append(viewer.config.dualPageRotateToFit)
+            append("|rotateInvert=").append(viewer.config.dualPageRotateToFitInvert)
+            append("|split=").append(viewer.config.dualPageSplit)
+            append("|invert=").append(viewer.config.dualPageInvert)
+            append("|insert=").append(page is InsertPage)
+            append("|l2r=").append(viewer is L2RPagerViewer)
+        }
     }
 
     /**

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonPageHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonPageHolder.kt
@@ -212,6 +212,7 @@ class WebtoonPageHolder(
                         zoomDuration = viewer.config.doubleTapAnimDuration,
                         minimumScaleType = SubsamplingScaleImageView.SCALE_TYPE_FIT_WIDTH,
                         cropBorders = viewer.config.imageCropBorders,
+                        sourceCacheKey = page?.imageUrl ?: page?.url,
                     ),
                 )
                 removeErrorLayout()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonPageHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/webtoon/WebtoonPageHolder.kt
@@ -196,7 +196,9 @@ class WebtoonPageHolder(
     private suspend fun setImage() {
         progressIndicator.setProgress(0)
 
-        val streamFn = page?.stream ?: return
+        val currentPage = page ?: return
+        val streamFn = currentPage.stream ?: return
+        val sourceCacheKey = buildSourceCacheKey(currentPage)
 
         try {
             val (source, isAnimated) = withIOContext {
@@ -212,7 +214,7 @@ class WebtoonPageHolder(
                         zoomDuration = viewer.config.doubleTapAnimDuration,
                         minimumScaleType = SubsamplingScaleImageView.SCALE_TYPE_FIT_WIDTH,
                         cropBorders = viewer.config.imageCropBorders,
-                        sourceCacheKey = page?.imageUrl ?: page?.url,
+                        sourceCacheKey = sourceCacheKey,
                     ),
                 )
                 removeErrorLayout()
@@ -248,6 +250,17 @@ class WebtoonPageHolder(
             ImageUtil.rotateImage(imageSource, rotation)
         } else {
             imageSource
+        }
+    }
+
+    private fun buildSourceCacheKey(page: ReaderPage): String {
+        val base = page.imageUrl ?: page.url
+        return buildString {
+            append(base)
+            append("|rotate=").append(viewer.config.dualPageRotateToFit)
+            append("|rotateInvert=").append(viewer.config.dualPageRotateToFitInvert)
+            append("|split=").append(viewer.config.dualPageSplit)
+            append("|invert=").append(viewer.config.dualPageInvert)
         }
     }
 


### PR DESCRIPTION
## Objective
Reduce repeated SSIV image-header analysis work on repeated reader page loads in the long-strip path, while preserving existing SSIV/non-SSIV behavior.

Closes #487

## Scope
- Added a small in-memory analysis cache (keyed by page source identity string) in `ReaderPageImageView` for `ImageUtil.analyzeImageForReader(...)` results.
- Reused cached analysis for:
  - SSIV path hardware bitmap compatibility (`canUseHardwareBitmap`)
  - Webtoon tall-image SSIV selection checks.
- Wired `sourceCacheKey` from pager/webtoon page holders using `imageUrl ?: url`.
- Added one changelog bullet in `Unreleased > Improved`.

Out of scope:
- No Coil/Okio pipeline changes.
- No non-long-strip reader flow changes.
- No reader architecture refactors.

## Verification
- `./gradlew spotlessCheck` ✅
- `./gradlew :app:compileStableDebugKotlin` ✅
- Note: repository hook command `:app:compileDebugKotlin` is ambiguous in this project; `:app:compileStableDebugKotlin` is the stable equivalent used by existing CI/local hooks.

Benchmark protocol for follow-up evidence (requested in ticket plan):
- Fixed emulator/device image + chapter set.
- 10 cold + 10 warm samples, discard warm-up, report median and p95 before/after.

## Risk
- Low/medium: cache key collisions could reuse analysis for different images if identical key string is reused.
- Mitigation: key uses page-level source URL fields (`imageUrl ?: url`), and fallback path still computes analysis if key is absent.
- Rollback: single-commit revert (`R487: cache SSIV image analysis for repeated reader loads`).
