### PR TITLE
chore: align native library dependencies for 16 KB pages (R642)

### DIFF
--- a/.github/workflows/build_pull_request.yml
+++ b/.github/workflows/build_pull_request.yml
@@ -151,6 +151,9 @@ jobs:
       - name: Build app
         run: ./gradlew assembleStableRelease --build-cache
 
+      - name: Verify 16 KB native alignment
+        run: ./scripts/verify_16kb_apk.sh app/build/outputs/apk/stable/release/app-stable-arm64-v8a-release-unsigned.apk
+
       - name: Upload APK
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:

--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -70,6 +70,9 @@ jobs:
       - name: Build app
         run: ./gradlew assembleStableRelease -Penable-updater
 
+      - name: Verify 16 KB native alignment
+        run: ./scripts/verify_16kb_apk.sh app/build/outputs/apk/stable/release/app-stable-arm64-v8a-release-unsigned.apk
+
       - name: Upload APK
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:

--- a/buildSrc/src/main/kotlin/mihon/buildlogic/AndroidConfig.kt
+++ b/buildSrc/src/main/kotlin/mihon/buildlogic/AndroidConfig.kt
@@ -4,11 +4,11 @@ import org.gradle.api.JavaVersion as GradleJavaVersion
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget as KotlinJvmTarget
 
 object AndroidConfig {
-    const val COMPILE_SDK = 36
+    const val COMPILE_SDK = 37
     const val TARGET_SDK = 36
     const val MIN_SDK = 26
     const val NDK = "27.1.12297006"
-    const val BUILD_TOOLS = "36.0.0"
+    const val BUILD_TOOLS = "37.0.0"
 
     // https://youtrack.jetbrains.com/issue/KT-66995/JvmTarget-and-JavaVersion-compatibility-for-easier-JVM-version-setup
     val JavaVersion = GradleJavaVersion.VERSION_17

--- a/gradle/aniyomi.versions.toml
+++ b/gradle/aniyomi.versions.toml
@@ -2,7 +2,7 @@
 aniyomi-mpv-lib = "1.18.n"
 arthenica-smartexceptions = "0.2.1"
 constraint-layout = "1.1.0"
-ffmpeg-kit = "1.18"
+ffmpeg-kit = "6.1.1"
 media = "1.7.1"
 seeker = "1.2.2"
 truetypeparser = "2.1.4"
@@ -11,7 +11,7 @@ truetypeparser = "2.1.4"
 aniyomi-mpv = { module = "com.github.aniyomiorg:aniyomi-mpv-lib", version.ref = "aniyomi-mpv-lib" }
 arthenica-smartexceptions = { module = "com.arthenica:smart-exception-java", version.ref = "arthenica-smartexceptions" }
 compose-constraintlayout = { module = "androidx.constraintlayout:constraintlayout-compose", version.ref = "constraint-layout" }
-ffmpeg-kit = { module = "com.github.jmir1:ffmpeg-kit", version.ref = "ffmpeg-kit" }
+ffmpeg-kit = { module = "com.moizhassan.ffmpeg:ffmpeg-kit-16kb", version.ref = "ffmpeg-kit" }
 mediasession = { module = "androidx.media:media", version.ref = "media" }
 seeker = { module = "io.github.2307vivek:seeker", version.ref = "seeker" }
 truetypeparser = { module = "io.github.yubyf:truetypeparser-light", version.ref = "truetypeparser" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,17 +31,17 @@ play-services-cast-framework = { module = "com.google.android.gms:play-services-
 
 conscrypt-android = "org.conscrypt:conscrypt-android:2.5.3"
 
-quickjs-android = "app.cash.quickjs:quickjs-android:0.9.2"
+quickjs-android = "com.github.zhanghai.quickjs-java:quickjs-android:547f5b1597"
 
 jsoup = "org.jsoup:jsoup:1.22.1"
 
 disklrucache = "com.jakewharton:disklrucache:2.0.2"
 unifile = "com.github.tachiyomiorg:unifile:a9de196cc7"
-libarchive = "me.zhanghai.android.libarchive:library:1.1.4"
+libarchive = "me.zhanghai.android.libarchive:library:1.1.6"
 
 sqlite-framework = { module = "androidx.sqlite:sqlite-framework", version.ref = "sqlite" }
 sqlite-ktx = { module = "androidx.sqlite:sqlite-ktx", version.ref = "sqlite" }
-sqlite-android = "com.github.requery:sqlite-android:3.45.0"
+sqlite-android = "com.github.requery:sqlite-android:3.49.0"
 
 preferencektx = "androidx.preference:preference-ktx:1.2.1"
 
@@ -54,7 +54,7 @@ coil-compose = { module = "io.coil-kt.coil3:coil-compose" }
 coil-network-okhttp = { module = "io.coil-kt.coil3:coil-network-okhttp" }
 
 subsamplingscaleimageview = "com.github.tachiyomiorg:subsampling-scale-image-view:66e0db195d"
-image-decoder = "com.github.tachiyomiorg:image-decoder:41c059e540"
+image-decoder = "com.github.mihonapp:image-decoder:e03b81e18a"
 
 natural-comparator = "com.github.gpanther:java-nat-sort:natural-comparator-1.1"
 

--- a/scripts/verify_16kb_apk.sh
+++ b/scripts/verify_16kb_apk.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: $0 <apk-path>" >&2
+    exit 1
+fi
+
+APK_PATH=$1
+
+if [[ ! -f "$APK_PATH" ]]; then
+    echo "APK not found: $APK_PATH" >&2
+    exit 1
+fi
+
+find_zipalign() {
+    if [[ -n "${ANDROID_SDK_ROOT:-}" ]]; then
+        find "$ANDROID_SDK_ROOT/build-tools" -path '*/zipalign' -type f 2>/dev/null | sort -V | tail -n 1
+        return
+    fi
+
+    if [[ -n "${ANDROID_HOME:-}" ]]; then
+        find "$ANDROID_HOME/build-tools" -path '*/zipalign' -type f 2>/dev/null | sort -V | tail -n 1
+        return
+    fi
+}
+
+find_llvm_objdump() {
+    if command -v llvm-objdump >/dev/null 2>&1; then
+        command -v llvm-objdump
+        return
+    fi
+
+    if command -v xcrun >/dev/null 2>&1 && xcrun --find llvm-objdump >/dev/null 2>&1; then
+        xcrun --find llvm-objdump
+        return
+    fi
+
+    if [[ -n "${ANDROID_NDK_ROOT:-}" ]]; then
+        find "$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt" -path '*/bin/llvm-objdump' -type f 2>/dev/null | head -n 1
+        return
+    fi
+
+    if [[ -n "${ANDROID_SDK_ROOT:-}" ]]; then
+        find "$ANDROID_SDK_ROOT/ndk" -path '*/toolchains/llvm/prebuilt/*/bin/llvm-objdump' -type f 2>/dev/null | head -n 1
+        return
+    fi
+}
+
+ZIPALIGN=$(find_zipalign)
+OBJDUMP=$(find_llvm_objdump)
+
+if [[ -z "${ZIPALIGN:-}" ]]; then
+    echo "Unable to locate zipalign" >&2
+    exit 1
+fi
+
+if [[ -z "${OBJDUMP:-}" ]]; then
+    echo "Unable to locate llvm-objdump" >&2
+    exit 1
+fi
+
+echo "Using zipalign: $ZIPALIGN"
+echo "Using llvm-objdump: $OBJDUMP"
+
+"$ZIPALIGN" -c -P 16 -v 4 "$APK_PATH"
+
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+unzip -q "$APK_PATH" 'lib/arm64-v8a/*.so' -d "$TMP_DIR"
+
+ARM64_LIST=$(mktemp)
+trap 'rm -rf "$TMP_DIR" "$ARM64_LIST"' EXIT
+find "$TMP_DIR/lib/arm64-v8a" -type f -name '*.so' | sort > "$ARM64_LIST"
+
+if [[ ! -s "$ARM64_LIST" ]]; then
+    echo "No arm64-v8a native libraries found in $APK_PATH" >&2
+    exit 1
+fi
+
+printf 'arm64-v8a libraries:\n'
+while IFS= read -r so_file; do
+    printf ' - %s\n' "${so_file##*/}"
+done < "$ARM64_LIST"
+
+while IFS= read -r so_file; do
+    if ! "$OBJDUMP" -p "$so_file" | awk '/LOAD/ { if ($0 !~ /align 2\*\*14/) exit 1 } END { exit 0 }'; then
+        echo "16 KB alignment check failed for $(basename "$so_file")" >&2
+        exit 1
+    fi
+done < "$ARM64_LIST"
+
+echo "All packaged arm64-v8a native libraries are 16 KB aligned."


### PR DESCRIPTION
## Ticket
- ID: R642
- Priority: P2
- Risk Tier: T2
- GitHub Issue: Closes #471

## Objective
- Ship 16 KB page-size aligned native dependency artifacts so Rayniyomi no longer packages misaligned `arm64-v8a` native libraries for Android 15+ devices.

## Scope
- Bump affected native dependency artifacts:
  - `me.zhanghai.android.libarchive:library` `1.1.4` -> `1.1.6`
  - `com.github.requery:sqlite-android` `3.45.0` -> `3.49.0`
  - `com.github.tachiyomiorg:image-decoder:41c059e540` -> `com.github.mihonapp:image-decoder:e03b81e18a`
  - `app.cash.quickjs:quickjs-android:0.9.2` -> `com.github.zhanghai.quickjs-java:quickjs-android:547f5b1597`
  - `com.github.jmir1:ffmpeg-kit:1.18` -> `com.moizhassan.ffmpeg:ffmpeg-kit-16kb:6.1.1`
- Move compile SDK/build tools to 37/37.0.0 so the aligned Mihon image-decoder AAR is consumed without suppressing AAR metadata checks.
- Add a checked-in APK verifier and wire it into PR/push release builds to enforce `zipalign -P 16` plus `arm64-v8a` ELF `LOAD ... align 2**14` checks.

## Non-goals
- No app logic refactor.
- No native source vendoring.
- No FFmpegKit call-site changes.
- No `CHANGELOG.md` edit.

## Files Changed
- Version catalogs for native dependency swaps.
- Android build SDK constants.
- GitHub build workflows.
- `scripts/verify_16kb_apk.sh` for APK-level native alignment verification.

## Verification
- Commands run:
  - `./gradlew spotlessCheck :app:checkStableDebugAarMetadata :app:compileStableDebugKotlin :app:assembleDebug`
  - `./gradlew :app:assembleStableRelease`
  - `./scripts/verify_16kb_apk.sh app/build/outputs/apk/stable/release/app-stable-arm64-v8a-release-unsigned.apk`
  - `git diff --check`
  - pre-push hook reran `./gradlew spotlessCheck`
  - pre-push hook reran `./gradlew :app:compileStableDebugKotlin`
- Results:
  - Build and metadata checks passed without `android.experimental.disableCompileSdkChecks`.
  - Release APK `zipalign -c -P 16 -v 4` passed.
  - All packaged release `lib/arm64-v8a/*.so` files reported 16 KB `LOAD` alignment.
  - Packaged release `arm64-v8a` inventory included `libarchive-jni.so`, `libffmpegkit.so`, `libffmpegkit_abidetect.so`, FFmpeg component libs, `libimagedecoder.so`, `libquickjs.so`, and `libsqlite3x.so`.
  - FFmpegKit artifact checksum: `ffmpeg-kit-16kb-6.1.1.aar` SHA-256 `5b8da42b87d2e63292112f81c2611d4c208bade75c591426cae0d4c5c959d522`.
- Not tested:
  - Real 16 KB emulator/device runtime smoke was not completed. `sdkmanager` reported the `system-images;android-36;google_apis_ps16k;arm64-v8a` package installed, but the expected system image directory was absent, so the temporary AVD could not boot. No physical 16 KB device was attached.

## Risk
- Main risk is behavioral drift from replacing prebuilt native suppliers, especially FFmpegKit.
- Mitigations:
  - Kept app code and FFmpegKit call sites unchanged.
  - Verified compile/API compatibility through the app build.
  - Added CI-level APK alignment checks to prevent future native artifact regressions.
  - Independent review flagged the compileSdk metadata workaround and missing CI gate; this PR addresses both by using compileSdk 37 and adding the verifier workflow step.

## SLO Impact
- Startup/native-load reliability should improve on 16 KB page-size devices.
- No expected user-facing behavior or performance change on existing supported devices.

## Rollback
- Revert this PR to restore the prior dependency coordinates and compile SDK/build tools.
- If only one native artifact regresses, roll back that catalog entry and rerun `scripts/verify_16kb_apk.sh` before shipping.

## Release Notes
- Updates native dependency artifacts for Android 16 KB page-size device compatibility. No direct user-facing feature change.

## Checklist
- [x] Naming conventions followed (use "Rayniyomi" in user-facing text, see [naming conventions](../docs/governance/naming-conventions.md))
- [x] Branch rebased on latest main and verification re-run (see [rebase policy](../docs/governance/agent-workflow.md#rebase-before-merge-policy-r45))
- [x] New coroutine scopes have documented owner and cancellation path
- [x] No new `runBlocking` on UI/main thread paths

## Definition of Done (DoD)
- [x] Acceptance criteria met and non-goals respected
- [x] Verification matrix completed (Risk Tier: T2)
- [x] Self-review completed
- [x] Rebased on latest `main` and revalidated (mandatory for merge)
- [ ] Sprint board updated (branch, commit, checks, PR link)
- [x] Release notes drafted (if applicable)

## Fork Compliance Checklist (for new forks only)
If you are creating a new fork of this project, ensure the following:
- [ ] **App Identity**: Changed app name from "Aniyomi" to your fork name
- [ ] **App Icon**: Replaced launcher icon assets with fork-specific icons
- [ ] **Application ID**: Changed `applicationId` in `app/build.gradle.kts` from `xyz.rayniyomi` to your unique ID
- [ ] **Update Checker**: Configured `AppUpdateChecker.kt` to point to your fork's repository
- [ ] **Analytics**: Either disabled Firebase Analytics or configured with your own `google-services.json`
- [ ] **Crash Reporting**: Either disabled ACRA crash reporting or configured with your own endpoint credentials

See [CONTRIBUTING.md](../CONTRIBUTING.md) Forks section for details.
