### PR TITLE
feat: migrate fork-owned custom back interceptors to predictive back (R645)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 
 ### Improved
 - Settings main screen lazy list now uses stable, null-safe composite keys instead of `hashCode()`, eliminating spurious recompositions on rotation and theme changes
+- Fork-owned custom back interceptors now use predictive-back gesture handling where Rayniyomi owns the commit/cancel behavior.
 - Upcoming and History Compose lists now use stable item/header keys, reducing avoidable row churn during list updates, and update-install candidate checks now refresh off the composition thread while preserving the current CTA state
 - Baseline profile generation now includes deterministic coverage attempts for discover, light-novel, browse, and enrichment-adjacent flows with retry/timeout diagnostics to keep startup profile maintenance aligned with newer app paths
 - Reader SSIV long-strip loads now reuse cached per-source image analysis (tall-image + hardware-bitmap compatibility) across pager and webtoon holders, reducing repeated header parsing on warm page reopens

--- a/app/src/main/java/eu/kanade/presentation/components/PredictiveBackHandlerCompat.kt
+++ b/app/src/main/java/eu/kanade/presentation/components/PredictiveBackHandlerCompat.kt
@@ -1,0 +1,16 @@
+package eu.kanade.presentation.components
+
+import androidx.activity.compose.PredictiveBackHandler
+import androidx.compose.runtime.Composable
+import kotlinx.coroutines.flow.collect
+
+@Composable
+fun PredictiveBackHandlerCompat(
+    enabled: Boolean = true,
+    onBack: () -> Unit,
+) {
+    PredictiveBackHandler(enabled = enabled) { progress ->
+        progress.collect { }
+        onBack()
+    }
+}

--- a/app/src/main/java/eu/kanade/presentation/more/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/onboarding/OnboardingScreen.kt
@@ -1,6 +1,5 @@
 package eu.kanade.presentation.more.onboarding
 
-import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -17,6 +16,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import eu.kanade.presentation.components.PredictiveBackHandlerCompat
 import soup.compose.material.motion.animation.materialSharedAxisX
 import soup.compose.material.motion.animation.rememberSlideDistance
 import tachiyomi.i18n.MR
@@ -42,7 +42,7 @@ fun OnboardingScreen(
     }
     val isLastStep = currentStep == steps.lastIndex
 
-    BackHandler(enabled = currentStep != 0, onBack = { currentStep-- })
+    PredictiveBackHandlerCompat(enabled = currentStep != 0, onBack = { currentStep-- })
 
     InfoScreen(
         icon = Icons.Outlined.RocketLaunch,

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/player/editor/codeeditor/CodeEditScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/player/editor/codeeditor/CodeEditScreen.kt
@@ -1,6 +1,5 @@
 package eu.kanade.presentation.more.settings.screen.player.editor.codeeditor
 
-import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
@@ -41,6 +40,7 @@ import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import eu.kanade.presentation.components.AppBar
 import eu.kanade.presentation.components.AppBarActions
+import eu.kanade.presentation.components.PredictiveBackHandlerCompat
 import eu.kanade.presentation.more.settings.screen.player.editor.components.UnsavedChangesDialog
 import eu.kanade.presentation.util.Screen
 import kotlinx.collections.immutable.persistentListOf
@@ -63,7 +63,7 @@ class CodeEditScreen(private val filePath: String) : Screen() {
         val dialogShown by screenModel.dialogShown.collectAsStateWithLifecycle()
         val hasModified by screenModel.hasModified.collectAsStateWithLifecycle()
 
-        BackHandler(enabled = hasModified) {
+        PredictiveBackHandlerCompat(enabled = hasModified) {
             screenModel.showDialog(CodeEditDialogs.GoBack)
         }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/more/OnboardingScreen.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/more/OnboardingScreen.kt
@@ -1,6 +1,5 @@
 package eu.kanade.tachiyomi.ui.more
 
-import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -8,6 +7,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import cafe.adriel.voyager.navigator.LocalNavigator
 import cafe.adriel.voyager.navigator.currentOrThrow
 import eu.kanade.domain.base.BasePreferences
+import eu.kanade.presentation.components.PredictiveBackHandlerCompat
 import eu.kanade.presentation.more.onboarding.OnboardingScreen
 import eu.kanade.presentation.more.settings.screen.SearchableSettings
 import eu.kanade.presentation.more.settings.screen.SettingsDataScreen
@@ -34,7 +34,7 @@ class OnboardingScreen : Screen() {
 
         val restoreSettingKey = stringResource(SettingsDataScreen.restorePreferenceKeyString)
 
-        BackHandler(
+        PredictiveBackHandlerCompat(
             enabled = !shownOnboardingFlow,
             onBack = {
                 // Prevent exiting if onboarding hasn't been completed


### PR DESCRIPTION
## Ticket
- ID: R645
- Priority: P2
- Risk Tier: T1
- GitHub Issue: Closes #455

## Objective
- Reframe predictive back support around fork-owned custom back interception instead of a broad grep-driven `BackHandler` replacement.
- Ensure migrated custom handlers commit only after the predictive-back gesture completes while cancellation avoids state mutation.

## Scope
- Added `PredictiveBackHandlerCompat`, an app-local wrapper around AndroidX `PredictiveBackHandler`.
- Migrated three fork-owned custom back interceptors:
  - onboarding step back: completed back decrements the onboarding step
  - onboarding host guard: completed back remains consumed before onboarding completion
  - player settings code editor dirty state: completed back opens the existing unsaved-changes dialog
- Updated issue #455 title/body to the first-principles governance scope.
- Added exactly one changelog bullet.
- Dependency status: no dependency changes; `androidx.activity:activity-compose:1.13.0` is already present and provides `PredictiveBackHandler`.

## Non-goals
- No Reader/player playback changes.
- No shared upstream screen migration.
- No normal navigation-stack migration.
- No custom progress animation work.

## Files Changed
- `app/src/main/java/eu/kanade/presentation/components/PredictiveBackHandlerCompat.kt`
- `app/src/main/java/eu/kanade/presentation/more/onboarding/OnboardingScreen.kt`
- `app/src/main/java/eu/kanade/tachiyomi/ui/more/OnboardingScreen.kt`
- `app/src/main/java/eu/kanade/presentation/more/settings/screen/player/editor/codeeditor/CodeEditScreen.kt`
- `CHANGELOG.md`

## Verification
- Commands run:
  - `rg -n "BackHandler|PredictiveBackHandler" app source-local core presentation-core presentation-widget domain data lightnovel-plugin lightnovel-contract -g '*.kt'`
  - `git diff --check`
  - `./gradlew spotlessCheck --console=plain`
  - `./gradlew :app:compileDebugKotlin --console=plain`
  - `./gradlew :app:compileStableDebugKotlin --console=plain`
  - `./gradlew :app:assembleStableDebug --console=plain`
  - `adb devices -l`
  - `avdmanager list avd`
  - `sdkmanager --sdk_root=/Users/rayyacub/Library/Android/sdk --install 'system-images;android-36;google_apis_ps16k;arm64-v8a' --verbose`
  - `sdkmanager --sdk_root=/Users/rayyacub/Library/Android/sdk --install 'system-images;android-33;google_apis;arm64-v8a' --verbose`
  - `emulator -avd R642_16kb_API36 -no-snapshot -no-audio -no-boot-anim`
  - `emulator -avd R645_API33_GoogleApis -no-snapshot -no-audio -no-boot-anim`
  - autoloop plan preflight/claims/gates: passed
  - autoloop implementation preflight/claims: passed
  - independent implementation/final review: completed before runtime retest and found only the now-resolved runtime evidence gap
- Results:
  - `spotlessCheck`: passed.
  - `:app:compileDebugKotlin`: expected repo task ambiguity; Gradle reports candidates `compileStableDebugAndroidTestKotlin`, `compileStableDebugKotlin`, and `compileStableDebugUnitTestKotlin`.
  - `:app:compileStableDebugKotlin`: passed.
  - `:app:assembleStableDebug`: passed.
  - `git diff --check`: passed.
  - Static audit completed; remaining legacy handlers are documented below.
  - Repaired the previously broken `R642_16kb_API36` AVD by reinstalling `system-images;android-36;google_apis_ps16k;arm64-v8a` with explicit `--sdk_root`; the emulator now boots and reports `getconf PAGE_SIZE = 16384`.
- Runtime evidence:
  - API 36, `R642_16kb_API36`, gesture navigation, 16 KB page-size emulator:
    - `adb shell getprop ro.build.version.sdk` -> `36`
    - `adb shell getconf PAGE_SIZE` -> `16384`
    - installed `app-stable-universal-debug.apk`, cleared `xyz.rayniyomi.dev`, launched onboarding
    - onboarding Storage step visible after tapping `Next`
    - cancellation edge case: `input touchscreen motionevent DOWN/MOVE/CANCEL` from left edge left the UI on the Storage step; no step decrement occurred
    - completed gesture: `input touchscreen motionevent DOWN/MOVE/UP` from left edge returned the UI to the Theme step
  - API 36, `R645_API36_PlayStore`, gesture navigation:
    - `adb shell getprop ro.build.version.sdk` -> `36`
    - `adb shell settings get secure navigation_mode` -> `2`
    - onboarding Storage step visible after tapping `Next`
    - cancellation edge case: `DOWN/MOVE/CANCEL` left the UI on the Storage step
    - completed gesture: `DOWN/MOVE/UP` returned the UI to the Theme step
    - first-step host guard: completed back gesture left `MainActivity` resumed and Theme onboarding visible
  - API 33, `R645_API33_GoogleApis`, gesture navigation:
    - `adb shell getprop ro.build.version.sdk` -> `33`
    - `adb shell settings get secure navigation_mode` -> `2`
    - onboarding Storage step visible after tapping `Next`
    - `adb shell input keyevent 4` returned to Theme step, preserving legacy back behavior below Android 14
    - first-step host guard: `adb shell input keyevent 4` left `MainActivity` resumed and Theme onboarding visible

### Back Handler Audit
| Path | Status | Reason |
| --- | --- | --- |
| `app/src/main/java/eu/kanade/presentation/more/onboarding/OnboardingScreen.kt` | migrated | fork-owned onboarding step custom back behavior |
| `app/src/main/java/eu/kanade/tachiyomi/ui/more/OnboardingScreen.kt` | migrated | fork-owned onboarding completion guard |
| `app/src/main/java/eu/kanade/presentation/more/settings/screen/player/editor/codeeditor/CodeEditScreen.kt` | migrated | fork-owned dirty-editor confirmation behavior |
| `app/src/main/java/eu/kanade/presentation/player/components/PlayerSheet.kt` | excluded | player playback surface, explicitly out of scope |
| `app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/components/panels/SubtitleSettingsPanel.kt` | excluded | player playback controls, explicitly out of scope |
| `presentation-core/src/main/java/tachiyomi/presentation/core/components/AdaptiveSheet.kt` | excluded | shared core component; component-level predictive-back design should be separate |
| `app/src/main/java/eu/kanade/presentation/components/AdaptiveSheet.kt` | excluded | shared app sheet navigation wrapper; broader component migration should be separate |
| `app/src/main/java/eu/kanade/presentation/entries/anime/AnimeScreen.kt` | excluded | entry/shared upstream screen behavior, not scoped to this governance ticket |
| `app/src/main/java/eu/kanade/presentation/entries/manga/MangaScreen.kt` | excluded | entry/shared upstream screen behavior, not scoped to this governance ticket |
| `app/src/main/java/eu/kanade/tachiyomi/ui/library/anime/AnimeLibraryTab.kt` | excluded | library shared selection/search behavior, not Rayniyomi-only custom interception |
| `app/src/main/java/eu/kanade/tachiyomi/ui/library/manga/MangaLibraryTab.kt` | excluded | library shared selection/search behavior, not Rayniyomi-only custom interception |
| `app/src/main/java/eu/kanade/tachiyomi/ui/home/HomeScreen.kt` | excluded | root navigation behavior, not a fork-owned custom interceptor |
| `app/src/main/java/eu/kanade/presentation/updates/anime/AnimeUpdatesScreen.kt` | excluded | shared selection-mode behavior, not scoped |
| `app/src/main/java/eu/kanade/presentation/updates/manga/MangaUpdatesScreen.kt` | excluded | shared selection-mode behavior, not scoped |

## Risk
- Main behavioral risk is predictive-back gesture lifecycle timing. Mitigation: wrapper calls `onBack()` only after the progress flow completes, so coroutine cancellation skips state mutation.
- Runtime checks now cover Android 14+ predictive-back commit/cancel, a repaired 16 KB API 36 emulator, Android 13 parity, and the onboarding first-step back-consumption guard.

## SLO Impact
- No expected SLO impact. This changes UI back-interception behavior only and adds no I/O, network, or background work.

## Rollback
- Revert this PR to restore the prior `BackHandler` call sites and remove the wrapper/changelog bullet.

## Release Notes
- Fork-owned custom back interceptors now use predictive-back gesture handling where Rayniyomi owns the commit/cancel behavior.

## Checklist
- [x] Naming conventions followed (use "Rayniyomi" in user-facing text, see [naming conventions](../docs/governance/naming-conventions.md))
- [ ] Branch rebased on latest main and verification re-run (see [rebase policy](../docs/governance/agent-workflow.md#rebase-before-merge-policy-r45))
- [x] New coroutine scopes have documented owner and cancellation path
- [x] No new `runBlocking` on UI/main thread paths

## Definition of Done (DoD)
- [x] Acceptance criteria met and non-goals respected
- [x] Verification matrix completed (Risk Tier: T1)
- [x] Self-review completed
- [ ] Rebased on latest `main` and revalidated (mandatory for merge)
- [ ] Sprint board updated (branch, commit, checks, PR link)
- [x] Release notes drafted (if applicable)

## Fork Compliance Checklist (for new forks only)
- [ ] Not applicable; this PR does not create a new fork.

