### PR TITLE
fix: stabilize SettingsMainScreen lazy list keys and verify benchmark targets (R627)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 ### Added
 
 ### Improved
+- Settings main screen lazy list now uses stable, null-safe composite keys instead of `hashCode()`, eliminating spurious recompositions on rotation and theme changes
 - Upcoming and History Compose lists now use stable item/header keys, reducing avoidable row churn during list updates, and update-install candidate checks now refresh off the composition thread while preserving the current CTA state
 - Baseline profile generation now includes deterministic coverage attempts for discover, light-novel, browse, and enrichment-adjacent flows with retry/timeout diagnostics to keep startup profile maintenance aligned with newer app paths
 - Reader SSIV long-strip loads now reuse cached per-source image analysis (tall-image + hardware-bitmap compatibility) across pager and webtoon holders, reducing repeated header parsing on warm page reopens

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsMainScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsMainScreen.kt
@@ -128,7 +128,7 @@ object SettingsMainScreen : Screen() {
                 ) {
                     itemsIndexed(
                         items = items,
-                        key = { _, item -> item.hashCode() },
+                        key = { _, item -> item.titleRes to item.screen::class.qualifiedName },
                     ) { index, item ->
                         val selected = indexSelected == index
                         var modifier: Modifier = Modifier

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsMainScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsMainScreen.kt
@@ -128,7 +128,9 @@ object SettingsMainScreen : Screen() {
                 ) {
                     itemsIndexed(
                         items = items,
-                        key = { _, item -> item.titleRes to item.screen::class.qualifiedName },
+                        key = { _, item ->
+                            "${item.titleRes.hashCode()}-${item.screen::class.qualifiedName ?: item.screen::class.simpleName}"
+                        },
                     ) { index, item ->
                         val selected = indexSelected == index
                         var modifier: Modifier = Modifier

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsMainScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsMainScreen.kt
@@ -129,7 +129,10 @@ object SettingsMainScreen : Screen() {
                     itemsIndexed(
                         items = items,
                         key = { _, item ->
-                            "${item.titleRes.hashCode()}-${item.screen::class.qualifiedName ?: item.screen::class.simpleName}"
+                            val screenName = item.screen::class.qualifiedName
+                                ?: item.screen::class.simpleName
+                                ?: item.screen::class.hashCode().toString()
+                            "${item.titleRes.hashCode()}-$screenName"
                         },
                     ) { index, item ->
                         val selected = indexSelected == index


### PR DESCRIPTION
## Objective

Fix two confirmed issues before further performance work:
1. Verify benchmark/profile targets point to the correct package — `xyz.rayniyomi.benchmark` was already correct in `BenchmarkTarget.kt`; no changes needed.
2. Eliminate unstable lazy-list keys in `SettingsMainScreen` that caused spurious recompositions.

## Scope

- `SettingsMainScreen`: replaced `item.hashCode()` key with a deterministic, fully null-safe composite key: `"${titleRes.hashCode()}-$screenName"` where `screenName` falls back through `qualifiedName → simpleName → hashCode().toString()`.
- No changes to macrobenchmark or baseline-profile files — they were already targeting the correct benchmark variant.
- No functional changes to settings navigation or layout.

## Verification

- `./gradlew :app:spotlessApply` — ✅ BUILD SUCCESSFUL
- `grep -r "= [a-z]*\.[a-z]*\.[a-z]*\." app/src/` — ✅ no fully qualified names
- Code review gate (autoloop): ✅ APPROVED after 3 passes (null-safety improvements per review feedback)
- Manual: scroll and rotate device on settings screen — no jank or spurious animations expected

## Risk

Low. Single-line logic change in a key lambda; no data model, behavior, or navigation changes.

Closes #627