### PR TITLE
feat: make Shikimori tracker search GraphQL-backed (R340)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 ### Added
 
 ### Improved
+- Shikimori tracker search now uses GraphQL-backed media data and safer nullable chapter/episode mapping while preserving REST compatibility for list sync.
 - Settings main screen lazy list now uses stable, null-safe composite keys instead of `hashCode()`, eliminating spurious recompositions on rotation and theme changes
 - Fork-owned custom back interceptors now use predictive-back gesture handling where Rayniyomi owns the commit/cancel behavior.
 - Upcoming and History Compose lists now use stable item/header keys, reducing avoidable row churn during list updates, and update-install candidate checks now refresh off the composition thread while preserving the current CTA state

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/shikimori/ShikimoriApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/shikimori/ShikimoriApi.kt
@@ -7,10 +7,15 @@ import eu.kanade.tachiyomi.data.database.models.manga.MangaTrack
 import eu.kanade.tachiyomi.data.track.model.AnimeTrackSearch
 import eu.kanade.tachiyomi.data.track.model.MangaTrackSearch
 import eu.kanade.tachiyomi.data.track.shikimori.dto.SMAddEntryResponse
-import eu.kanade.tachiyomi.data.track.shikimori.dto.SMEntry
+import eu.kanade.tachiyomi.data.track.shikimori.dto.SMGraphQLResponse
 import eu.kanade.tachiyomi.data.track.shikimori.dto.SMOAuth
 import eu.kanade.tachiyomi.data.track.shikimori.dto.SMUser
 import eu.kanade.tachiyomi.data.track.shikimori.dto.SMUserListEntry
+import eu.kanade.tachiyomi.data.track.shikimori.dto.requireData
+import eu.kanade.tachiyomi.data.track.shikimori.dto.shikimoriAnimeByIdPayload
+import eu.kanade.tachiyomi.data.track.shikimori.dto.shikimoriAnimeSearchPayload
+import eu.kanade.tachiyomi.data.track.shikimori.dto.shikimoriMangaByIdPayload
+import eu.kanade.tachiyomi.data.track.shikimori.dto.shikimoriMangaSearchPayload
 import eu.kanade.tachiyomi.network.DELETE
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
@@ -123,45 +128,42 @@ class ShikimoriApi(
 
     suspend fun search(search: String): List<MangaTrackSearch> {
         return withIOContext {
-            val url = "$API_URL/mangas".toUri().buildUpon()
-                .appendQueryParameter("order", "popularity")
-                .appendQueryParameter("search", search)
-                .appendQueryParameter("limit", "20")
-                .build()
             with(json) {
-                authClient.newCall(GET(url.toString()))
+                authClient.newCall(graphQLRequest(shikimoriMangaSearchPayload(search)))
                     .awaitSuccess()
-                    .parseAs<List<SMEntry>>()
-                    .map { it.toMangaTrack(trackId) }
+                    .parseAs<SMGraphQLResponse>()
+                    .requireData()
+                    .mangas
+                    .orEmpty()
+                    .mapNotNull { it.toMangaTrack(trackId) }
             }
         }
     }
 
     suspend fun searchAnime(search: String): List<AnimeTrackSearch> {
         return withIOContext {
-            val url = "$API_URL/animes".toUri().buildUpon()
-                .appendQueryParameter("order", "popularity")
-                .appendQueryParameter("search", search)
-                .appendQueryParameter("limit", "20")
-                .build()
             with(json) {
-                authClient.newCall(GET(url.toString()))
+                authClient.newCall(graphQLRequest(shikimoriAnimeSearchPayload(search)))
                     .awaitSuccess()
-                    .parseAs<List<SMEntry>>()
-                    .map { it.toAnimeTrack(trackId) }
+                    .parseAs<SMGraphQLResponse>()
+                    .requireData()
+                    .animes
+                    .orEmpty()
+                    .mapNotNull { it.toAnimeTrack(trackId) }
             }
         }
     }
 
     suspend fun findLibManga(track: MangaTrack, userId: String): MangaTrack? {
         return withIOContext {
-            val urlMangas = "$API_URL/mangas".toUri().buildUpon()
-                .appendPath(track.remote_id.toString())
-                .build()
             val manga = with(json) {
-                authClient.newCall(GET(urlMangas.toString()))
+                authClient.newCall(graphQLRequest(shikimoriMangaByIdPayload(track.remote_id)))
                     .awaitSuccess()
-                    .parseAs<SMEntry>()
+                    .parseAs<SMGraphQLResponse>()
+                    .requireData()
+                    .mangas
+                    .orEmpty()
+                    .firstOrNull()
             }
 
             val url = "$API_URL/v2/user_rates".toUri().buildUpon()
@@ -178,26 +180,27 @@ class ShikimoriApi(
                             throw Exception("Too many manga in response")
                         }
                         entries
-                            .map { it.toMangaTrack(trackId, manga) }
+                            .map { it.toMangaTrack(trackId, track.remote_id, manga) }
                             .firstOrNull()
                     }
             }
         }
     }
 
-    suspend fun findLibAnime(track: AnimeTrack, user_id: String): AnimeTrack? {
+    suspend fun findLibAnime(track: AnimeTrack, userId: String): AnimeTrack? {
         return withIOContext {
-            val urlAnimes = "$API_URL/animes".toUri().buildUpon()
-                .appendPath(track.remote_id.toString())
-                .build()
             val anime = with(json) {
-                authClient.newCall(GET(urlAnimes.toString()))
+                authClient.newCall(graphQLRequest(shikimoriAnimeByIdPayload(track.remote_id)))
                     .awaitSuccess()
-                    .parseAs<SMEntry>()
+                    .parseAs<SMGraphQLResponse>()
+                    .requireData()
+                    .animes
+                    .orEmpty()
+                    .firstOrNull()
             }
 
             val url = "$API_URL/v2/user_rates".toUri().buildUpon()
-                .appendQueryParameter("user_id", user_id)
+                .appendQueryParameter("user_id", userId)
                 .appendQueryParameter("target_id", track.remote_id.toString())
                 .appendQueryParameter("target_type", "Anime")
                 .build()
@@ -207,10 +210,10 @@ class ShikimoriApi(
                     .parseAs<List<SMUserListEntry>>()
                     .let { entries ->
                         if (entries.size > 1) {
-                            throw Exception("Too many manga in response")
+                            throw Exception("Too many anime in response")
                         }
                         entries
-                            .map { it.toAnimeTrack(trackId, anime) }
+                            .map { it.toAnimeTrack(trackId, track.remote_id, anime) }
                             .firstOrNull()
                     }
             }
@@ -247,9 +250,15 @@ class ShikimoriApi(
             .build(),
     )
 
+    private fun graphQLRequest(payload: String) = POST(
+        GRAPHQL_URL,
+        body = payload.toRequestBody(jsonMime),
+    )
+
     companion object {
         const val BASE_URL = "https://shikimori.one"
         private const val API_URL = "$BASE_URL/api"
+        private const val GRAPHQL_URL = "https://shikimori.io/api/graphql"
         private const val OAUTH_URL = "$BASE_URL/oauth/token"
         private const val LOGIN_URL = "$BASE_URL/oauth/authorize"
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/shikimori/ShikimoriUtils.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/shikimori/ShikimoriUtils.kt
@@ -10,7 +10,7 @@ fun MangaTrack.toShikimoriStatus() = when (status) {
     Shikimori.DROPPED -> "dropped"
     Shikimori.PLAN_TO_READ -> "planned"
     Shikimori.REREADING -> "rewatching"
-    else -> throw NotImplementedError("Unknown status: $status")
+    else -> throw IllegalArgumentException("Unknown Shikimori manga status: $status")
 }
 
 fun AnimeTrack.toShikimoriStatus() = when (status) {
@@ -20,7 +20,7 @@ fun AnimeTrack.toShikimoriStatus() = when (status) {
     Shikimori.DROPPED -> "dropped"
     Shikimori.PLAN_TO_READ -> "planned"
     Shikimori.REREADING -> "rewatching"
-    else -> throw NotImplementedError("Unknown status: $status")
+    else -> throw IllegalArgumentException("Unknown Shikimori anime status: $status")
 }
 
 fun toTrackStatus(status: String) = when (status) {
@@ -30,5 +30,5 @@ fun toTrackStatus(status: String) = when (status) {
     "dropped" -> Shikimori.DROPPED
     "planned" -> Shikimori.PLAN_TO_READ
     "rewatching" -> Shikimori.REREADING
-    else -> throw NotImplementedError("Unknown status: $status")
+    else -> throw IllegalArgumentException("Unknown Shikimori remote status: $status")
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/shikimori/dto/SMEntry.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/shikimori/dto/SMEntry.kt
@@ -24,7 +24,7 @@ data class SMEntry(
         return MangaTrackSearch.create(trackId).apply {
             remote_id = this@SMEntry.id
             title = name
-            total_chapters = chapters!!
+            total_chapters = chapters ?: 0L
             cover_url = ShikimoriApi.BASE_URL + image.preview
             summary = ""
             score = this@SMEntry.score
@@ -39,7 +39,7 @@ data class SMEntry(
         return AnimeTrackSearch.create(trackId).apply {
             remote_id = this@SMEntry.id
             title = name
-            total_episodes = episodes!!
+            total_episodes = episodes ?: 0L
             cover_url = ShikimoriApi.BASE_URL + image.preview
             summary = ""
             score = this@SMEntry.score

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/shikimori/dto/SMGraphQL.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/shikimori/dto/SMGraphQL.kt
@@ -1,0 +1,217 @@
+package eu.kanade.tachiyomi.data.track.shikimori.dto
+
+import eu.kanade.tachiyomi.data.track.model.AnimeTrackSearch
+import eu.kanade.tachiyomi.data.track.model.MangaTrackSearch
+import eu.kanade.tachiyomi.data.track.shikimori.ShikimoriApi
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonObject
+
+@Serializable
+internal data class SMGraphQLResponse(
+    val data: SMGraphQLData? = null,
+    val errors: List<SMGraphQLError> = emptyList(),
+)
+
+@Serializable
+internal data class SMGraphQLData(
+    val mangas: List<SMGraphQLEntry> = emptyList(),
+    val animes: List<SMGraphQLEntry> = emptyList(),
+)
+
+@Serializable
+internal data class SMGraphQLError(
+    val message: String,
+)
+
+@Serializable
+internal data class SMGraphQLEntry(
+    val id: String,
+    val name: String,
+    val url: String,
+    val score: Double = 0.0,
+    val status: String = "",
+    val kind: String = "",
+    val chapters: Long? = null,
+    val episodes: Long? = null,
+    val poster: SMGraphQLPoster? = null,
+    val airedOn: SMGraphQLDate? = null,
+) {
+    fun toMangaTrack(trackId: Long): MangaTrackSearch? {
+        val mediaId = id.toLongOrNull() ?: return null
+        return MangaTrackSearch.create(trackId).apply {
+            remote_id = mediaId
+            title = name
+            total_chapters = chapters ?: 0L
+            cover_url = poster.toCoverUrl()
+            summary = ""
+            score = this@SMGraphQLEntry.score
+            tracking_url = url.toShikimoriUrl()
+            publishing_status = this@SMGraphQLEntry.status
+            publishing_type = this@SMGraphQLEntry.kind
+            start_date = airedOn?.date.orEmpty()
+        }
+    }
+
+    fun toAnimeTrack(trackId: Long): AnimeTrackSearch? {
+        val mediaId = id.toLongOrNull() ?: return null
+        return AnimeTrackSearch.create(trackId).apply {
+            remote_id = mediaId
+            title = name
+            total_episodes = episodes ?: 0L
+            cover_url = poster.toCoverUrl()
+            summary = ""
+            score = this@SMGraphQLEntry.score
+            tracking_url = url.toShikimoriUrl()
+            publishing_status = this@SMGraphQLEntry.status
+            publishing_type = this@SMGraphQLEntry.kind
+            start_date = airedOn?.date.orEmpty()
+        }
+    }
+}
+
+@Serializable
+internal data class SMGraphQLPoster(
+    val mainUrl: String? = null,
+    val originalUrl: String? = null,
+)
+
+@Serializable
+internal data class SMGraphQLDate(
+    val date: String? = null,
+)
+
+internal fun shikimoriMangaSearchPayload(query: String): String {
+    return shikimoriGraphQLPayload(
+        """
+        |query SearchManga(${'$'}query: String!) {
+            |mangas(search: ${'$'}query, order: popularity, limit: 20) {
+                |id
+                |name
+                |url
+                |score
+                |status
+                |kind
+                |chapters
+                |poster {
+                    |mainUrl
+                    |originalUrl
+                |}
+                |airedOn {
+                    |date
+                |}
+            |}
+        |}
+        """.trimMargin(),
+        query,
+    )
+}
+
+internal fun shikimoriAnimeSearchPayload(query: String): String {
+    return shikimoriGraphQLPayload(
+        """
+        |query SearchAnime(${'$'}query: String!) {
+            |animes(search: ${'$'}query, order: popularity, limit: 20) {
+                |id
+                |name
+                |url
+                |score
+                |status
+                |kind
+                |episodes
+                |poster {
+                    |mainUrl
+                    |originalUrl
+                |}
+                |airedOn {
+                    |date
+                |}
+            |}
+        |}
+        """.trimMargin(),
+        query,
+    )
+}
+
+internal fun shikimoriMangaByIdPayload(id: Long): String {
+    return shikimoriGraphQLPayload(
+        """
+        |query MangaById(${'$'}id: String!) {
+            |mangas(ids: ${'$'}id, limit: 1) {
+                |id
+                |name
+                |url
+                |score
+                |status
+                |kind
+                |chapters
+                |poster {
+                    |mainUrl
+                    |originalUrl
+                |}
+                |airedOn {
+                    |date
+                |}
+            |}
+        |}
+        """.trimMargin(),
+        id.toString(),
+    )
+}
+
+internal fun shikimoriAnimeByIdPayload(id: Long): String {
+    return shikimoriGraphQLPayload(
+        """
+        |query AnimeById(${'$'}id: String!) {
+            |animes(ids: ${'$'}id, limit: 1) {
+                |id
+                |name
+                |url
+                |score
+                |status
+                |kind
+                |episodes
+                |poster {
+                    |mainUrl
+                    |originalUrl
+                |}
+                |airedOn {
+                    |date
+                |}
+            |}
+        |}
+        """.trimMargin(),
+        id.toString(),
+    )
+}
+
+internal fun SMGraphQLResponse.requireData(): SMGraphQLData {
+    data?.let { return it }
+    val errorMessage = errors.joinToString("; ") { it.message }.ifBlank { "empty response" }
+    throw IllegalStateException("Shikimori GraphQL response did not include data: $errorMessage")
+}
+
+private fun shikimoriGraphQLPayload(query: String, searchOrId: String): String {
+    return buildJsonObject {
+        put("query", query)
+        putJsonObject("variables") {
+            put("query", searchOrId)
+            put("id", searchOrId)
+        }
+    }.toString()
+}
+
+private fun SMGraphQLPoster?.toCoverUrl(): String {
+    return this?.mainUrl?.ifBlank { null }
+        ?: this?.originalUrl?.ifBlank { null }
+        ?: ""
+}
+
+private fun String.toShikimoriUrl(): String {
+    return if (startsWith("http://") || startsWith("https://")) {
+        this
+    } else {
+        ShikimoriApi.BASE_URL + this
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/shikimori/dto/SMUserListEntry.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/shikimori/dto/SMUserListEntry.kt
@@ -14,29 +14,31 @@ data class SMUserListEntry(
     val score: Int,
     val status: String,
 ) {
-    fun toMangaTrack(trackId: Long, manga: SMEntry): MangaTrack {
+    internal fun toMangaTrack(trackId: Long, mediaId: Long, manga: SMGraphQLEntry?): MangaTrack {
+        val searchTrack = manga?.toMangaTrack(trackId)
         return MangaTrack.create(trackId).apply {
-            title = manga.name
-            remote_id = this@SMUserListEntry.id
-            total_chapters = manga.chapters!!
+            title = searchTrack?.title.orEmpty()
+            remote_id = searchTrack?.remote_id ?: mediaId
+            total_chapters = searchTrack?.total_chapters ?: 0L
             library_id = this@SMUserListEntry.id
             last_chapter_read = this@SMUserListEntry.chapters
             score = this@SMUserListEntry.score.toDouble()
             status = toTrackStatus(this@SMUserListEntry.status)
-            tracking_url = ShikimoriApi.BASE_URL + manga.url
+            tracking_url = searchTrack?.tracking_url ?: ShikimoriApi.BASE_URL
         }
     }
 
-    fun toAnimeTrack(trackId: Long, anime: SMEntry): AnimeTrack {
+    internal fun toAnimeTrack(trackId: Long, mediaId: Long, anime: SMGraphQLEntry?): AnimeTrack {
+        val searchTrack = anime?.toAnimeTrack(trackId)
         return AnimeTrack.create(trackId).apply {
-            title = anime.name
-            remote_id = this@SMUserListEntry.id
-            total_episodes = anime.episodes!!
+            title = searchTrack?.title.orEmpty()
+            remote_id = searchTrack?.remote_id ?: mediaId
+            total_episodes = searchTrack?.total_episodes ?: 0L
             library_id = this@SMUserListEntry.id
             last_episode_seen = this@SMUserListEntry.episodes
             score = this@SMUserListEntry.score.toDouble()
             status = toTrackStatus(this@SMUserListEntry.status)
-            tracking_url = ShikimoriApi.BASE_URL + anime.url
+            tracking_url = searchTrack?.tracking_url ?: ShikimoriApi.BASE_URL
         }
     }
 }

--- a/app/src/test/java/eu/kanade/tachiyomi/data/track/shikimori/ShikimoriMappingTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/data/track/shikimori/ShikimoriMappingTest.kt
@@ -1,0 +1,157 @@
+package eu.kanade.tachiyomi.data.track.shikimori
+
+import eu.kanade.tachiyomi.data.track.shikimori.dto.SMGraphQLEntry
+import eu.kanade.tachiyomi.data.track.shikimori.dto.SMGraphQLPoster
+import eu.kanade.tachiyomi.data.track.shikimori.dto.SMGraphQLResponse
+import eu.kanade.tachiyomi.data.track.shikimori.dto.SMUserListEntry
+import eu.kanade.tachiyomi.data.track.shikimori.dto.requireData
+import eu.kanade.tachiyomi.data.track.shikimori.dto.shikimoriAnimeSearchPayload
+import eu.kanade.tachiyomi.data.track.shikimori.dto.shikimoriMangaSearchPayload
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+
+class ShikimoriMappingTest {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun `GraphQL manga search maps nullable chapters safely`() {
+        val response = json.decodeFromString<SMGraphQLResponse>(
+            """
+            {
+              "data": {
+                "mangas": [{
+                  "id": "11",
+                  "name": "Naruto",
+                  "url": "https://shikimori.io/mangas/z11-naruto",
+                  "score": 8.08,
+                  "status": "released",
+                  "kind": "manga",
+                  "chapters": null,
+                  "poster": { "mainUrl": "https://img.example/main.webp" },
+                  "airedOn": { "date": "1999-09-21" }
+                }]
+              }
+            }
+            """.trimIndent(),
+        )
+
+        val track = response.data!!.mangas.single().toMangaTrack(trackId = 4L)!!
+
+        track.remote_id shouldBe 11L
+        track.title shouldBe "Naruto"
+        track.total_chapters shouldBe 0L
+        track.cover_url shouldBe "https://img.example/main.webp"
+        track.tracking_url shouldBe "https://shikimori.io/mangas/z11-naruto"
+        track.publishing_status shouldBe "released"
+        track.publishing_type shouldBe "manga"
+        track.start_date shouldBe "1999-09-21"
+    }
+
+    @Test
+    fun `GraphQL anime search maps nullable episodes safely`() {
+        val response = json.decodeFromString<SMGraphQLResponse>(
+            """
+            {
+              "data": {
+                "animes": [{
+                  "id": "20",
+                  "name": "Naruto",
+                  "url": "/animes/z20-naruto",
+                  "score": 8.02,
+                  "status": "released",
+                  "kind": "tv",
+                  "episodes": null,
+                  "poster": { "originalUrl": "https://img.example/original.jpg" },
+                  "airedOn": { "date": "2002-10-03" }
+                }]
+              }
+            }
+            """.trimIndent(),
+        )
+
+        val track = response.data!!.animes.single().toAnimeTrack(trackId = 4L)!!
+
+        track.remote_id shouldBe 20L
+        track.title shouldBe "Naruto"
+        track.total_episodes shouldBe 0L
+        track.cover_url shouldBe "https://img.example/original.jpg"
+        track.tracking_url shouldBe "https://shikimori.one/animes/z20-naruto"
+        track.publishing_status shouldBe "released"
+        track.publishing_type shouldBe "tv"
+        track.start_date shouldBe "2002-10-03"
+    }
+
+    @Test
+    fun `user rate mapping keeps media id and user rate id distinct`() {
+        val manga = SMGraphQLEntry(
+            id = "11",
+            name = "Naruto",
+            url = "https://shikimori.io/mangas/z11-naruto",
+            chapters = 700,
+            poster = SMGraphQLPoster(mainUrl = "https://img.example/main.webp"),
+        )
+        val userRate = SMUserListEntry(
+            id = 555L,
+            chapters = 12.0,
+            episodes = 0.0,
+            score = 9,
+            status = "watching",
+        )
+
+        val track = userRate.toMangaTrack(trackId = 4L, mediaId = 11L, manga = manga)
+
+        track.remote_id shouldBe 11L
+        track.library_id shouldBe 555L
+        track.last_chapter_read shouldBe 12.0
+        track.total_chapters shouldBe 700L
+        track.status shouldBe Shikimori.READING
+    }
+
+    @Test
+    fun `status conversion covers known Shikimori statuses`() {
+        toTrackStatus("watching") shouldBe Shikimori.READING
+        toTrackStatus("completed") shouldBe Shikimori.COMPLETED
+        toTrackStatus("on_hold") shouldBe Shikimori.ON_HOLD
+        toTrackStatus("dropped") shouldBe Shikimori.DROPPED
+        toTrackStatus("planned") shouldBe Shikimori.PLAN_TO_READ
+        toTrackStatus("rewatching") shouldBe Shikimori.REREADING
+    }
+
+    @Test
+    fun `GraphQL search payloads target expected media fields`() {
+        shikimoriMangaSearchPayload("naruto").let { payload ->
+            payload.contains("mangas(search: \$query") shouldBe true
+            payload.contains("\"query\":\"naruto\"") shouldBe true
+            payload.contains("chapters") shouldBe true
+        }
+
+        shikimoriAnimeSearchPayload("naruto").let { payload ->
+            payload.contains("animes(search: \$query") shouldBe true
+            payload.contains("\"query\":\"naruto\"") shouldBe true
+            payload.contains("episodes") shouldBe true
+        }
+    }
+
+    @Test
+    fun `GraphQL error-only response throws with remote message`() {
+        val response = json.decodeFromString<SMGraphQLResponse>(
+            """
+            {
+              "errors": [{
+                "message": "Field 'unknown' doesn't exist on type 'Query'"
+              }]
+            }
+            """.trimIndent(),
+        )
+
+        val exception = assertThrows(IllegalStateException::class.java) {
+            response.requireData()
+        }
+
+        exception.message shouldBe
+            "Shikimori GraphQL response did not include data: Field 'unknown' doesn't exist on type 'Query'"
+    }
+}


### PR DESCRIPTION
## Ticket
- ID: R340
- Priority: P2
- Risk Tier: T2
- GitHub Issue: Closes #340

## Objective
- Complete the Shikimori tracker media/search path with GraphQL-backed data so tracker search no longer depends on the deprecated REST media endpoints.

## Scope
- Route Shikimori manga/anime search and media lookup through `https://shikimori.io/api/graphql`.
- Parse the GraphQL response envelope explicitly, including `errors`, so error-only responses fail with a clear diagnostic instead of silently returning empty results.
- Keep OAuth, `users/whoami`, and `v2/user_rates` create/update/find/delete on REST as an explicit compatibility path.
- Preserve tracker ID `4L` and existing public tracker/UI contracts.
- Fix Shikimori ID mapping so `remote_id` remains the media id and `library_id` remains the user-rate id.
- Replace nullable chapter/episode force unwraps with safe `0` fallbacks.
- Add focused mapper/query/status unit coverage.

## Non-goals
- No database schema changes.
- No production UI refactor.
- No full user-rate GraphQL migration in this PR; follow-up #706 tracks REST removal after parity validation.
- No fork-owned OAuth credential registration in this PR; follow-up #707 tracks that separately.

## Files Changed
- `app/src/main/java/eu/kanade/tachiyomi/data/track/shikimori/` GraphQL request routing and status diagnostics.
- `app/src/main/java/eu/kanade/tachiyomi/data/track/shikimori/dto/` GraphQL DTO/query/mapping support and safer REST DTO mapping.
- `app/src/test/java/eu/kanade/tachiyomi/data/track/shikimori/` mapper/query/status tests.
- `CHANGELOG.md` one release-note bullet.

## Verification
- Commands run:
  - `./gradlew :app:compileDebugKotlin`
  - `./gradlew spotlessCheck :app:compileStableDebugKotlin :app:testDebugUnitTest --tests '*Shikimori*'`
  - `./gradlew spotlessCheck`
  - `./gradlew :app:compileStableDebugKotlin`
  - Autoloop plan and implementation gates, including independent implementation review.
- Results:
  - `:app:compileDebugKotlin` is ambiguous in `:app` (`compileStableDebugKotlin`, `compileStableDebugUnitTestKotlin`, `compileStableDebugAndroidTestKotlin` candidates), so `:app:compileStableDebugKotlin` was used as the deterministic compile substitute.
  - `spotlessCheck` passed.
  - `:app:compileStableDebugKotlin` passed.
  - `:app:testDebugUnitTest --tests '*Shikimori*'` passed, including Shikimori mapping/error-envelope tests and existing Shikimori User-Agent test.
  - Live unauthenticated GraphQL smoke against `https://shikimori.io/api/graphql` returned HTTP 200 with Naruto anime/manga sample data; `https://shikimori.one/api/graphql` redirects to `.io`.
- Not tested:
  - Authenticated OAuth/user-rate smoke was skipped because fork-owned Shikimori credentials are not available in this environment.

## Risk
- Main regression risk is Shikimori response-shape drift. Mitigation: GraphQL DTOs ignore unknown fields, nullable counts fall back to `0`, malformed media ids are skipped from search results, error-only GraphQL responses throw a clear diagnostic, and REST user-rate sync remains unchanged.
- REST user-rate compatibility remains intentionally to avoid risking list sync without authenticated parity proof. Follow-up #706 tracks eventual removal.
- OAuth still uses current credentials/path. Follow-up #707 tracks fork-owned credential registration.

## SLO Impact
- Tracker search/list lookup performs one GraphQL request for media data and retains existing REST requests for user-rate sync. Expected impact is neutral; GraphQL media payloads are narrower than the deprecated REST media response path.

## Rollback
- Revert this single commit to restore REST media/search behavior and prior Shikimori DTO mappings.

## Release Notes
- Shikimori tracker search now uses GraphQL-backed media data and safer nullable chapter/episode mapping while preserving REST compatibility for list sync.

## Checklist
- [x] Naming conventions followed (use "Rayniyomi" in user-facing text, see [naming conventions](../docs/governance/naming-conventions.md))
- [x] Branch rebased on latest main and verification re-run (see [rebase policy](../docs/governance/agent-workflow.md#rebase-before-merge-policy-r45))
- [x] New coroutine scopes have documented owner and cancellation path
- [x] No new `runBlocking` on UI/main thread paths

## Definition of Done (DoD)
- [x] Acceptance criteria met and non-goals respected
- [x] Verification matrix completed (Risk Tier: T2)
- [x] Self-review completed
- [x] Rebased on latest `main` and revalidated (mandatory for merge)
- [ ] Sprint board updated (branch, commit, checks, PR link)
- [x] Release notes drafted (if applicable)

## Fork Compliance Checklist (for new forks only)
Not applicable; this PR does not create a new fork.

