### PR TITLE
chore: restore autoloop CLI availability (R650)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 ### CI
 
 ### Other
+- Added a repeatable installer for the local `autoloop` command used by ticket-gated agent workflows.
 
 
 ## [0.18.1.162] - 2026-05-06

--- a/scripts/install-autoloop-cli.sh
+++ b/scripts/install-autoloop-cli.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+AUTOLOOP_HOME="${AUTOLOOP_HOME:-/Users/rayyacub/.config/skillshare/skills/autoloop-codex}"
+RUNNER="$AUTOLOOP_HOME/scripts/autoloop_runner.py"
+COMMAND_NAME="autoloop"
+
+fail() {
+  printf 'install-autoloop-cli: %s\n' "$*" >&2
+  exit 1
+}
+
+is_on_path() {
+  case ":$PATH:" in
+    *":$1:"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+select_install_dir() {
+  if [[ -n "${AUTOLOOP_INSTALL_DIR:-}" ]]; then
+    printf '%s\n' "$AUTOLOOP_INSTALL_DIR"
+    return
+  fi
+
+  local candidates=(
+    "/opt/homebrew/bin"
+    "/usr/local/bin"
+    "$HOME/.local/bin"
+    "$HOME/bin"
+  )
+
+  local candidate
+  for candidate in "${candidates[@]}"; do
+    if [[ -d "$candidate" && -w "$candidate" && -x "$candidate" ]] && is_on_path "$candidate"; then
+      printf '%s\n' "$candidate"
+      return
+    fi
+  done
+
+  fail "no writable install directory found on PATH; set AUTOLOOP_INSTALL_DIR"
+}
+
+[[ -f "$RUNNER" ]] || fail "runner not found at $RUNNER"
+python3 "$RUNNER" --help >/dev/null || fail "runner help failed at $RUNNER"
+
+INSTALL_DIR="$(select_install_dir)"
+mkdir -p "$INSTALL_DIR"
+[[ -d "$INSTALL_DIR" && -w "$INSTALL_DIR" ]] || fail "install directory is not writable: $INSTALL_DIR"
+
+WRAPPER="$INSTALL_DIR/$COMMAND_NAME"
+cat >"$WRAPPER" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+AUTOLOOP_HOME="\${AUTOLOOP_HOME:-$AUTOLOOP_HOME}"
+exec python3 "\$AUTOLOOP_HOME/scripts/autoloop_runner.py" "\$@"
+EOF
+chmod 0755 "$WRAPPER"
+
+if ! is_on_path "$INSTALL_DIR"; then
+  fail "installed $WRAPPER, but $INSTALL_DIR is not on PATH"
+fi
+
+RESOLVED="$(command -v "$COMMAND_NAME" || true)"
+[[ "$RESOLVED" == "$WRAPPER" ]] || fail "PATH resolves $COMMAND_NAME to '${RESOLVED:-<missing>}' instead of $WRAPPER"
+"$COMMAND_NAME" --help >/dev/null || fail "$COMMAND_NAME --help failed after install"
+
+printf 'Installed %s\n' "$WRAPPER"

--- a/scripts/tests/test_install_autoloop_cli.py
+++ b/scripts/tests/test_install_autoloop_cli.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INSTALLER = REPO_ROOT / "scripts" / "install-autoloop-cli.sh"
+
+
+class InstallAutoloopCliTest(unittest.TestCase):
+    def _make_fake_home(self, tmpdir: Path, *, help_fails: bool = False) -> Path:
+        home = tmpdir / "autoloop-home"
+        scripts = home / "scripts"
+        scripts.mkdir(parents=True)
+        runner = scripts / "autoloop_runner.py"
+        help_block = (
+            "if '--help' in sys.argv:\n"
+            "    print('fake help')\n"
+            "    raise SystemExit(0)\n"
+        )
+        if help_fails:
+            help_block = (
+                "if '--help' in sys.argv:\n"
+                "    print('broken help', file=sys.stderr)\n"
+                "    raise SystemExit(12)\n"
+            )
+        runner.write_text(
+            "#!/usr/bin/env python3\n"
+            "import sys\n"
+            f"{help_block}"
+            "print('|'.join(sys.argv[1:]))\n",
+            encoding="utf-8",
+        )
+        runner.chmod(0o755)
+        return home
+
+    def _run_installer(
+        self,
+        tmpdir: Path,
+        *,
+        autoloop_home: Path | None = None,
+        install_dir: Path | None = None,
+        path_prefix: list[Path] | None = None,
+        set_install_dir: bool = True,
+        append_system_path: bool = True,
+    ) -> subprocess.CompletedProcess[str]:
+        if install_dir is None:
+            install_dir = tmpdir / "bin"
+            install_dir.mkdir()
+        env = os.environ.copy()
+        if set_install_dir:
+            env["AUTOLOOP_INSTALL_DIR"] = str(install_dir)
+        else:
+            env.pop("AUTOLOOP_INSTALL_DIR", None)
+        prefixes = path_prefix if path_prefix is not None else [install_dir]
+        path_parts = [*(str(path) for path in prefixes)]
+        if append_system_path:
+            path_parts.append(env["PATH"])
+        env["PATH"] = os.pathsep.join(path_parts)
+        if autoloop_home is not None:
+            env["AUTOLOOP_HOME"] = str(autoloop_home)
+        return subprocess.run(
+            [str(INSTALLER)],
+            cwd=REPO_ROOT,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def test_installs_executable_wrapper_and_forwards_arguments(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp)
+            autoloop_home = self._make_fake_home(tmpdir)
+
+            result = self._run_installer(tmpdir, autoloop_home=autoloop_home)
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            wrapper = tmpdir / "bin" / "autoloop"
+            self.assertTrue(wrapper.exists())
+            self.assertTrue(wrapper.stat().st_mode & stat.S_IXUSR)
+
+            env = os.environ.copy()
+            env["PATH"] = f"{wrapper.parent}{os.pathsep}{env['PATH']}"
+            env["AUTOLOOP_HOME"] = str(autoloop_home)
+            forwarded = subprocess.run(
+                ["autoloop", "preflight", "650", "--phase", "plan"],
+                env=env,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(forwarded.returncode, 0, forwarded.stderr)
+            self.assertIn("preflight|650|--phase|plan", forwarded.stdout)
+
+    def test_fails_when_runner_is_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp)
+            missing_home = tmpdir / "missing-autoloop-home"
+
+            result = self._run_installer(tmpdir, autoloop_home=missing_home)
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("runner not found", result.stderr)
+
+    def test_fails_when_runner_help_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp)
+            autoloop_home = self._make_fake_home(tmpdir, help_fails=True)
+
+            result = self._run_installer(tmpdir, autoloop_home=autoloop_home)
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("runner help failed", result.stderr)
+
+    def test_fails_when_explicit_install_dir_is_not_on_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp)
+            autoloop_home = self._make_fake_home(tmpdir)
+            install_dir = tmpdir / "not-on-path"
+            install_dir.mkdir()
+            path_dir = tmpdir / "path-bin"
+            path_dir.mkdir()
+
+            result = self._run_installer(
+                tmpdir,
+                autoloop_home=autoloop_home,
+                install_dir=install_dir,
+                path_prefix=[path_dir],
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("is not on PATH", result.stderr)
+
+    def test_fails_when_no_writable_path_candidate_exists(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp)
+            autoloop_home = self._make_fake_home(tmpdir)
+            tool_dir = tmpdir / "tools"
+            tool_dir.mkdir()
+            for tool in ("bash", "python3"):
+                source = shutil.which(tool)
+                self.assertIsNotNone(source)
+                (tool_dir / tool).symlink_to(source)
+            empty_path = tmpdir / "empty-path"
+            empty_path.mkdir()
+
+            result = self._run_installer(
+                tmpdir,
+                autoloop_home=autoloop_home,
+                path_prefix=[tool_dir, empty_path],
+                set_install_dir=False,
+                append_system_path=False,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("no writable install directory found on PATH", result.stderr)
+
+    def test_fails_when_path_resolves_to_different_autoloop(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmpdir = Path(tmp)
+            autoloop_home = self._make_fake_home(tmpdir)
+            install_dir = tmpdir / "install-bin"
+            install_dir.mkdir()
+            conflict_dir = tmpdir / "conflict-bin"
+            conflict_dir.mkdir()
+            conflict = conflict_dir / "autoloop"
+            conflict.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+            conflict.chmod(0o755)
+
+            result = self._run_installer(
+                tmpdir,
+                autoloop_home=autoloop_home,
+                install_dir=install_dir,
+                path_prefix=[conflict_dir, install_dir],
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("PATH resolves autoloop", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Ticket
- ID: R650
- Priority: P2
- Risk Tier: T1
- GitHub Issue: Closes #636

## Objective
- Restore `autoloop` as a real shell command for ticket-gated agent workflows, instead of relying on ad hoc aliases or direct Python runner calls.

## Scope
- Add a repeatable installer for the local `autoloop` command shim.
- Add focused unittest coverage for successful install, argument forwarding, and installer failure paths.
- Add one changelog bullet for the tooling fix.

## Non-goals
- No Android app/runtime behavior changes.
- No shell profile mutation, Homebrew formula, or vendoring of autoloop source into Rayniyomi.

## Files Changed
- `scripts/install-autoloop-cli.sh`
- `scripts/tests/test_install_autoloop_cli.py`
- `CHANGELOG.md`

## Verification
- Commands run:
  - `./scripts/install-autoloop-cli.sh`
  - `command -v autoloop`
  - `autoloop --help`
  - `autoloop --root "$PWD/.autoloop-codex" path-check --repo "$PWD"`
  - `python3 -m unittest scripts/tests/test_install_autoloop_cli.py`
  - `git diff --check`
  - `autoloop --root "$PWD/.autoloop-codex" preflight R650 --phase plan --repo "$PWD" --plan-file plan.md`
  - `autoloop --root "$PWD/.autoloop-codex" verify-claims R650 --phase plan --claims-file "$PWD/.autoloop-codex/reviews/R650-plan-claims.json" --repo "$PWD"`
  - `autoloop --root "$PWD/.autoloop-codex" enforce-gates R650 --phase plan`
  - `autoloop --root "$PWD/.autoloop-codex" preflight R650 --phase implementation --repo "$PWD"`
  - `autoloop --root "$PWD/.autoloop-codex" enforce-gates R650 --phase implementation`
  - `./gradlew spotlessCheck --console=plain`
  - `./gradlew :app:compileDebugKotlin --console=plain`
  - `./gradlew :app:compileStableDebugKotlin --console=plain`
- Results:
  - `autoloop` resolves to `/opt/homebrew/bin/autoloop`.
  - Installer unittest suite passed: 6 tests.
  - Plan gates passed after independent review.
  - Implementation gates passed after independent implementation/final review.
  - `spotlessCheck` passed.
  - `:app:compileDebugKotlin` is ambiguous in `:app` with Gradle candidates `compileStableDebugAndroidTestKotlin`, `compileStableDebugKotlin`, and `compileStableDebugUnitTestKotlin`.
  - `:app:compileStableDebugKotlin` passed and also passed in the pre-push hook.
- Not tested:
  - Android runtime behavior; not applicable for this tooling-only ticket.

## Risk
- Low risk. The PR adds a developer tooling installer and tests only.
- Main risk is overwriting an existing `autoloop` binary on PATH; the installer verifies the resolved command path after writing and tests cover conflicting PATH resolution.

## SLO Impact
- None. This does not affect app runtime behavior or user-facing service paths.

## Rollback
- Revert this PR to remove the installer, tests, and changelog entry.
- If a local shim needs immediate removal, delete `/opt/homebrew/bin/autoloop` or reinstall it with the desired `AUTOLOOP_HOME`.

## Release Notes
- Added a repeatable installer for the local `autoloop` command used by ticket-gated agent workflows.

## Checklist
- [x] Naming conventions followed (use "Rayniyomi" in user-facing text, see [naming conventions](../docs/governance/naming-conventions.md))
- [x] Branch rebased on latest main and verification re-run (see [rebase policy](../docs/governance/agent-workflow.md#rebase-before-merge-policy-r45))
- [x] New coroutine scopes have documented owner and cancellation path
- [x] No new `runBlocking` on UI/main thread paths

## Definition of Done (DoD)
- [x] Acceptance criteria met and non-goals respected
- [x] Verification matrix completed (Risk Tier: T1)
- [x] Self-review completed
- [x] Rebased on latest `main` and revalidated (mandatory for merge)
- [ ] Sprint board updated (branch, commit, checks, PR link)
- [x] Release notes drafted (if applicable)
