### PR TITLE
fix: restore non-blocking startup during migrations (R712)

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
@@ -156,10 +156,6 @@ class MainActivity : BaseActivity() {
         // Prevent splash screen showing up on configuration changes
         val splashScreen = if (isLaunch) installSplashScreen() else null
 
-        // Keep splash screen visible until migration completes
-        var migrationComplete = false
-        splashScreen?.setKeepOnScreenCondition { !migrationComplete }
-
         super.onCreate(savedInstanceState)
 
         // Register ActivityResultLauncher for external player
@@ -191,18 +187,6 @@ class MainActivity : BaseActivity() {
         }
 
         setComposeContent {
-            var didMigration by remember { mutableStateOf(false) }
-            var migrationChecked by remember { mutableStateOf(false) }
-
-            LaunchedEffect(Unit) {
-                didMigration = Migrator.await()
-                Migrator.release()
-                migrationChecked = true
-                migrationComplete = true
-            }
-
-            if (!migrationChecked) return@setComposeContent
-
             val context = LocalContext.current
 
             var incognito by remember { mutableStateOf(getMangaIncognitoState.await(null)) }
@@ -322,7 +306,14 @@ class MainActivity : BaseActivity() {
                 ShowOnboarding()
             }
 
-            var showChangelog by remember { mutableStateOf(didMigration && !BuildConfig.DEBUG) }
+            var showChangelog by remember { mutableStateOf(false) }
+            LaunchedEffect(Unit) {
+                val didMigration = Migrator.await()
+                if (shouldShowPostMigrationChangelog(didMigration, BuildConfig.DEBUG)) {
+                    showChangelog = true
+                }
+                Migrator.release()
+            }
             if (showChangelog) {
                 AlertDialog(
                     onDismissRequest = { showChangelog = false },
@@ -672,6 +663,10 @@ class MainActivity : BaseActivity() {
             )
         }
     }
+}
+
+internal fun shouldShowPostMigrationChangelog(didMigration: Boolean, isDebugBuild: Boolean): Boolean {
+    return didMigration && !isDebugBuild
 }
 
 private fun splashMinDuration() = if (BuildConfig.BUILD_TYPE == "benchmark") 0L else SPLASH_MIN_DURATION

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/main/MainActivityStartupMigrationTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/main/MainActivityStartupMigrationTest.kt
@@ -1,0 +1,58 @@
+package eu.kanade.tachiyomi.ui.main
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import java.nio.file.Paths
+import kotlin.text.Charsets.UTF_8
+
+class MainActivityStartupMigrationTest {
+
+    @Test
+    fun `startup composition is not gated on migration completion`() {
+        val source = loadMainActivitySource()
+
+        assertFalse(
+            source.contains("migrationChecked"),
+            "MainActivity must not keep composition behind a migrationChecked state gate",
+        )
+        assertFalse(
+            source.contains("return@setComposeContent"),
+            "MainActivity must not return from setComposeContent while waiting on migration",
+        )
+    }
+
+    @Test
+    fun `successful migration shows changelog in release builds`() {
+        assertTrue(shouldShowPostMigrationChangelog(didMigration = true, isDebugBuild = false))
+    }
+
+    @Test
+    fun `successful migration does not show changelog in debug builds`() {
+        assertFalse(shouldShowPostMigrationChangelog(didMigration = true, isDebugBuild = true))
+    }
+
+    @Test
+    fun `failed or noop migration does not show changelog`() {
+        assertFalse(shouldShowPostMigrationChangelog(didMigration = false, isDebugBuild = false))
+        assertFalse(shouldShowPostMigrationChangelog(didMigration = false, isDebugBuild = true))
+    }
+
+    private fun loadMainActivitySource(): String {
+        val moduleRelative = Paths.get(
+            "src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt",
+        )
+        val rootRelative = Paths.get(
+            "app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt",
+        )
+        val sourcePath = when {
+            Files.exists(moduleRelative) -> moduleRelative
+            Files.exists(rootRelative) -> rootRelative
+            else -> throw java.nio.file.NoSuchFileException(
+                "Could not find MainActivity.kt from module or repo root paths",
+            )
+        }
+        return String(Files.readAllBytes(sourcePath), UTF_8)
+    }
+}


### PR DESCRIPTION
## Objective
Restore interactive startup while migrations continue in the background. `MainActivity` should no longer withhold its first composition until `Migrator.await()` completes, while successful release migrations still trigger the changelog later in the session.

Closes #712

## Scope
- Remove the migration-completion composition gate and redundant migration splash condition.
- Preserve the existing timed `ready` splash behavior.
- Await migration completion only to decide delayed changelog visibility.
- Add focused regression coverage for the startup gate and changelog decision.

## Verification
- `./gradlew :app:testDebugUnitTest --tests eu.kanade.tachiyomi.ui.main.MainActivityStartupMigrationTest`
- `./gradlew :app:testStableDebugUnitTest --tests mihon.core.migration.MigratorTest`
- `./gradlew :app:testStableDebugUnitTest --tests eu.kanade.tachiyomi.AppStartupOptimizationTest`
- Pre-push: `spotlessCheck`
- Pre-push: `:app:compileStableDebugKotlin`
- Device-only startup smoke and macrobenchmark were not run because `adb devices` reported no attached target.

## Risk
Risk Tier: T3. The change alters startup ordering around migration completion. Existing migration execution and selection are unchanged; the primary risk is delayed changelog presentation or lifecycle cancellation during an activity recreation.

## Rollback
Revert commit `570398b73` to restore the previous migration-gated composition behavior. This requires no data migration or preference cleanup because the PR does not modify migration state, ordering, or persisted schemas.
