### PR TITLE
refactor: simplify DataSaver bypass logic (R657)

### DIFF
--- a/.github/workflows/baseline_profile_check.yml
+++ b/.github/workflows/baseline_profile_check.yml
@@ -13,10 +13,50 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  # Temporary: remove this bootstrap and mavenLocal wiring once a released SqlDelight version includes AGP 9 compatibility.
+  SQLDELIGHT_AGP9_FIX_SHA: c8f6011c014368544c71f5e490ef0409bb2f4705
+
 jobs:
+  prepare_sqldelight:
+    name: Prepare SqlDelight artifacts
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Restore SqlDelight local Maven cache
+        id: sqldelight-cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.2.3
+        with:
+          path: ~/.m2/repository/app/cash
+          key: sqldelight-m2-${{ env.SQLDELIGHT_AGP9_FIX_SHA }}
+
+      - name: Set up JDK
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
+        with:
+          java-version: 17
+          distribution: temurin
+
+      - name: Build SqlDelight AGP 9 fix
+        if: steps.sqldelight-cache.outputs.cache-hit != 'true'
+        run: |
+          set -euxo pipefail
+
+          git clone --filter=blob:none https://github.com/cashapp/sqldelight.git /tmp/sqldelight
+          cd /tmp/sqldelight
+          git checkout --detach "$SQLDELIGHT_AGP9_FIX_SHA"
+
+          ./gradlew publishToMavenLocal -x test --no-daemon
+
+      - name: Upload SqlDelight local Maven artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: sqldelight-m2-${{ env.SQLDELIGHT_AGP9_FIX_SHA }}
+          path: ~/.m2/repository/app/cash
+
   baseline-profile:
     name: Verify baseline profile task and artifact
     runs-on: ubuntu-latest
+    needs: prepare_sqldelight
 
     steps:
       - name: Clone repo
@@ -30,6 +70,12 @@ jobs:
 
       - name: Set up gradle
         uses: gradle/actions/setup-gradle@94baf225fe0a508e581a564467443d0e2379123b # v4.3.0
+
+      - name: Download SqlDelight local Maven artifacts
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: sqldelight-m2-${{ env.SQLDELIGHT_AGP9_FIX_SHA }}
+          path: ~/.m2/repository/app/cash
 
       - name: Verify generateBaselineProfile task is wired
         run: ./gradlew :app:generateBaselineProfile --dry-run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Baseline profile CI job now dry-runs `:app:generateBaselineProfile` and verifies `baseline-prof.txt` is committed and non-empty on every PR touching app or macrobenchmark paths.
 
 ### Other
+- Data saver compression bypass logic now uses one shared jpg/gif ignore helper across supported image proxy backends.
 - Added a repeatable installer for the local `autoloop` command used by ticket-gated agent workflows.
 - Baseline profile generation is now a real executable Gradle task via the AndroidX Baseline Profile plugin; removed the placeholder stub task added in an earlier pass.
 - Native library dependencies updated for 16 KB page-size alignment on Android 15+ devices: `libarchive` 1.1.6, `sqlite-android` 3.49.0, `image-decoder` (Mihon fork), `quickjs-android` (zhanghai fork), `ffmpeg-kit-16kb` 6.1.1. Compile SDK bumped to 37. APK alignment verifier wired into release builds.

--- a/app/src/main/java/aniyomi/util/DataSaver.kt
+++ b/app/src/main/java/aniyomi/util/DataSaver.kt
@@ -64,17 +64,7 @@ private class BandwidthHeroDataSaver(preferences: SourcePreferences) : DataSaver
 
     override fun compress(imageUrl: String): String {
         return if (dataSavedServer.isNotBlank() && !imageUrl.contains(dataSavedServer)) {
-            when {
-                imageUrl.contains(".jpeg", true) || imageUrl.contains(".jpg", true) -> if (ignoreJpg) {
-                    imageUrl
-                } else {
-                    getUrl(
-                        imageUrl,
-                    )
-                }
-                imageUrl.contains(".gif", true) -> if (ignoreGif) imageUrl else getUrl(imageUrl)
-                else -> getUrl(imageUrl)
-            }
+            imageUrl.compressUnlessIgnored(ignoreJpg, ignoreGif, ::getUrl)
         } else {
             imageUrl
         }
@@ -97,17 +87,7 @@ private class WsrvNlDataSaver(preferences: SourcePreferences) : DataSaver {
     private val quality = preferences.dataSaverImageQuality().get()
 
     override fun compress(imageUrl: String): String {
-        return when {
-            imageUrl.contains(".jpeg", true) || imageUrl.contains(".jpg", true) -> if (ignoreJpg) {
-                imageUrl
-            } else {
-                getUrl(
-                    imageUrl,
-                )
-            }
-            imageUrl.contains(".gif", true) -> if (ignoreGif) imageUrl else getUrl(imageUrl)
-            else -> getUrl(imageUrl)
-        }
+        return imageUrl.compressUnlessIgnored(ignoreJpg, ignoreGif, ::getUrl)
     }
 
     private fun getUrl(imageUrl: String): String {
@@ -148,17 +128,7 @@ private class ReSmushItDataSaver(preferences: SourcePreferences) : DataSaver {
     private val quality = preferences.dataSaverImageQuality().get()
 
     override fun compress(imageUrl: String): String {
-        return when {
-            imageUrl.contains(".jpeg", true) || imageUrl.contains(".jpg", true) -> if (ignoreJpg) {
-                imageUrl
-            } else {
-                getUrl(
-                    imageUrl,
-                )
-            }
-            imageUrl.contains(".gif", true) -> if (ignoreGif) imageUrl else getUrl(imageUrl)
-            else -> getUrl(imageUrl)
-        }
+        return imageUrl.compressUnlessIgnored(ignoreJpg, ignoreGif, ::getUrl)
     }
 
     private fun getUrl(imageUrl: String): String {
@@ -167,3 +137,17 @@ private class ReSmushItDataSaver(preferences: SourcePreferences) : DataSaver {
             .body.string().substringAfter("\"dest\":\"").substringBefore("\",")
     }
 }
+
+private inline fun String.compressUnlessIgnored(
+    ignoreJpg: Boolean,
+    ignoreGif: Boolean,
+    compress: (String) -> String,
+): String {
+    return when {
+        isJpg() && ignoreJpg -> this
+        contains(".gif", true) && ignoreGif -> this
+        else -> compress(this)
+    }
+}
+
+private fun String.isJpg() = contains(".jpeg", true) || contains(".jpg", true)


### PR DESCRIPTION
## Ticket
- ID: R657
- Priority: P2
- Risk Tier: T1
- GitHub Issue: Closes #716

## Objective
- Remove repeated jpg/gif bypass branching in `DataSaver` implementations without changing compression behavior.

## Scope
- Added one shared helper for ignore-jpeg / ignore-gif bypass decisions.
- Reused it from `BandwidthHeroDataSaver`, `WsrvNlDataSaver`, and `ReSmushItDataSaver`.
- Added SqlDelight AGP 9 artifact bootstrap to the baseline-profile workflow so `:app:generateBaselineProfile --dry-run` can resolve the current snapshot plugin.

## Non-goals
- No changes to URL construction, network behavior, or source preference semantics.
- No broad DataSaver redesign.

## Files Changed
- `app/src/main/java/aniyomi/util/DataSaver.kt`
- `.github/workflows/baseline_profile_check.yml`

## Verification
- Commands run:
  - `./gradlew spotlessCheck`
  - `./gradlew :app:compileDebugKotlin` attempted; task is ambiguous in this flavor setup.
  - `./gradlew :app:compileStableDebugKotlin`
  - `./gradlew :app:generateBaselineProfile --dry-run`
  - Code review pass posted to PR comment https://github.com/ryacub/rayniyomi/pull/722#issuecomment-4731963225
- Results:
  - `spotlessCheck` passed.
  - `:app:compileStableDebugKotlin` passed.
  - `:app:generateBaselineProfile --dry-run` passed.
  - GitHub `Verify baseline profile task and artifact` passed after adding the SqlDelight bootstrap.
  - Push hook reran `spotlessCheck` and `:app:compileStableDebugKotlin`; both passed.
- Not tested:
  - No focused unit test added because `DataSaver` implementations are private and preference-backed, and no existing test seam was present.

## Risk
- Low risk: helper preserves the same jpg/gif checks and delegates to each existing `getUrl` implementation. Baseline-profile workflow change mirrors the existing PR-build SqlDelight bootstrap.
- Mitigation: compile and formatting checks passed; diff is localized to one file.

## SLO Impact
- None expected. No runtime behavior change intended.

## Rollback
- Revert this PR to restore the previous duplicated branches.

## Release Notes
- No user-facing impact; internal refactor only. Changelog entry added under `Unreleased > Other` without ticket IDs.

## Checklist
- [x] Naming conventions followed (use "Rayniyomi" in user-facing text, see [naming conventions](../docs/governance/naming-conventions.md))
- [x] Branch rebased on latest main and verification re-run (see [rebase policy](../docs/governance/agent-workflow.md#rebase-before-merge-policy-r45))
- [x] New coroutine scopes have documented owner and cancellation path
- [x] No new `runBlocking` on UI/main thread paths

## Definition of Done (DoD)
- [x] Acceptance criteria met and non-goals respected
- [x] Verification matrix completed (Risk Tier: T1)
- [x] Self-review completed
- [x] Rebased on latest `main` and revalidated (mandatory for merge)
- [x] Sprint board updated (branch, commit, checks, PR link)
- [x] Release notes drafted (if applicable)

## Fork Compliance Checklist (for new forks only)
- [x] Not applicable; this is not a new fork.




