### PR TITLE
chore: share track preview fixtures (R660)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Baseline profile CI job now dry-runs `:app:generateBaselineProfile` and verifies `baseline-prof.txt` is committed and non-empty on every PR touching app or macrobenchmark paths.
 
 ### Other
+- Track previews now share sample fixture builders between anime and manga preview providers.
 - Storage preferences now use the concrete Android storage folder provider directly instead of a single-implementation abstraction.
 - Data saver compression bypass logic now uses one shared jpg/gif ignore helper across supported image proxy backends.
 - Added a repeatable installer for the local `autoloop` command used by ticket-gated agent workflows.

--- a/app/src/main/java/eu/kanade/presentation/track/TrackPreviewFixtures.kt
+++ b/app/src/main/java/eu/kanade/presentation/track/TrackPreviewFixtures.kt
@@ -1,0 +1,216 @@
+package eu.kanade.presentation.track
+
+import androidx.compose.ui.tooling.preview.datasource.LoremIpsum
+import eu.kanade.tachiyomi.data.track.model.AnimeTrackSearch
+import eu.kanade.tachiyomi.data.track.model.MangaTrackSearch
+import eu.kanade.tachiyomi.ui.entries.anime.track.AnimeTrackItem
+import eu.kanade.tachiyomi.ui.entries.manga.track.MangaTrackItem
+import eu.kanade.test.DummyTracker
+import tachiyomi.domain.track.anime.model.AnimeTrack
+import tachiyomi.domain.track.manga.model.MangaTrack
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+import java.time.temporal.ChronoUnit
+import java.util.Locale
+import kotlin.random.Random
+
+internal fun previewTrackDateFormat(): DateTimeFormatter =
+    DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM)
+
+internal fun previewAnimeTrackSearches(): Sequence<AnimeTrackSearch> = sequence {
+    while (true) {
+        yield(previewAnimeTrackSearch())
+    }
+}
+
+internal fun previewMangaTrackSearches(): Sequence<MangaTrackSearch> = sequence {
+    while (true) {
+        yield(previewMangaTrackSearch())
+    }
+}
+
+internal fun previewAnimeTrackSearch(): AnimeTrackSearch {
+    val fixture = randomTrackSearchFixture()
+    return AnimeTrackSearch().apply {
+        id = fixture.id
+        anime_id = Random.nextLong()
+        tracker_id = fixture.trackerId
+        remote_id = fixture.remoteId
+        library_id = fixture.libraryId
+        title = fixture.title
+        last_episode_seen = fixture.progress
+        total_episodes = fixture.totalCount
+        score = fixture.score
+        status = fixture.status
+        started_watching_date = 0L
+        finished_watching_date = 0L
+        tracking_url = fixture.trackingUrl
+        cover_url = fixture.coverUrl
+        start_date = fixture.startDate
+        summary = fixture.summary
+        publishing_status = fixture.publishingStatus
+        publishing_type = if (fixture.hasPublishingType) "OVA" else ""
+        artists = fixture.artists
+        authors = fixture.authors
+    }
+}
+
+internal fun previewMangaTrackSearch(): MangaTrackSearch {
+    val fixture = randomTrackSearchFixture()
+    return MangaTrackSearch().apply {
+        id = fixture.id
+        manga_id = Random.nextLong()
+        tracker_id = fixture.trackerId
+        remote_id = fixture.remoteId
+        library_id = fixture.libraryId
+        title = fixture.title
+        last_chapter_read = fixture.progress
+        total_chapters = fixture.totalCount
+        score = fixture.score
+        status = fixture.status
+        started_reading_date = 0L
+        finished_reading_date = 0L
+        tracking_url = fixture.trackingUrl
+        cover_url = fixture.coverUrl
+        start_date = fixture.startDate
+        summary = fixture.summary
+        publishing_status = fixture.publishingStatus
+        publishing_type = if (fixture.hasPublishingType) "Oneshot" else ""
+        artists = fixture.artists
+        authors = fixture.authors
+    }
+}
+
+internal fun previewAnimeTrackItemWithoutTrack(): AnimeTrackItem =
+    AnimeTrackItem(
+        track = null,
+        tracker = previewDummyTracker(
+            id = 1L,
+            name = "Example Tracker",
+        ),
+    )
+
+internal fun previewAnimeTrackItemWithTrack(privateTracking: Boolean = false): AnimeTrackItem =
+    AnimeTrackItem(
+        track = previewAnimeTrack(privateTracking = privateTracking),
+        tracker = previewDummyTracker(
+            id = 2L,
+            name = "Example Tracker 2",
+        ),
+    )
+
+internal fun previewMangaTrackItemWithoutTrack(): MangaTrackItem =
+    MangaTrackItem(
+        track = null,
+        tracker = previewDummyTracker(
+            id = 1L,
+            name = "Example Tracker",
+        ),
+    )
+
+internal fun previewMangaTrackItemWithTrack(privateTracking: Boolean = false): MangaTrackItem =
+    MangaTrackItem(
+        track = previewMangaTrack(privateTracking = privateTracking),
+        tracker = previewDummyTracker(
+            id = 2L,
+            name = "Example Tracker 2",
+        ),
+    )
+
+internal fun previewDummyTracker(
+    id: Long,
+    name: String,
+): DummyTracker =
+    DummyTracker(
+        id = id,
+        name = name,
+    )
+
+internal fun previewAnimeTrack(privateTracking: Boolean = false): AnimeTrack =
+    AnimeTrack(
+        id = 1L,
+        animeId = 2L,
+        trackerId = 3L,
+        remoteId = 4L,
+        libraryId = null,
+        title = "Manage Name On Tracker Site",
+        lastEpisodeSeen = 2.0,
+        totalEpisodes = 12L,
+        status = 1L,
+        score = 2.0,
+        remoteUrl = "https://example.com",
+        startDate = 0L,
+        finishDate = 0L,
+        private = privateTracking,
+    )
+
+internal fun previewMangaTrack(privateTracking: Boolean = false): MangaTrack =
+    MangaTrack(
+        id = 1L,
+        mangaId = 2L,
+        trackerId = 3L,
+        remoteId = 4L,
+        libraryId = null,
+        title = "Manage Name On Tracker Site",
+        lastChapterRead = 2.0,
+        totalChapters = 12L,
+        status = 1L,
+        score = 2.0,
+        remoteUrl = "https://example.com",
+        startDate = 0L,
+        finishDate = 0L,
+        private = privateTracking,
+    )
+
+private data class TrackSearchFixture(
+    val id: Long,
+    val trackerId: Long,
+    val remoteId: Long,
+    val libraryId: Long,
+    val title: String,
+    val progress: Double,
+    val totalCount: Long,
+    val score: Double,
+    val status: Long,
+    val trackingUrl: String,
+    val coverUrl: String,
+    val startDate: String,
+    val summary: String,
+    val publishingStatus: String,
+    val hasPublishingType: Boolean,
+    val artists: List<String>,
+    val authors: List<String>,
+)
+
+private val previewSearchDateFormatter = DateTimeFormatter
+    .ofPattern("yyyy-MM-dd", Locale.getDefault())
+    .withZone(ZoneId.systemDefault())
+
+private fun randomTrackSearchFixture(): TrackSearchFixture =
+    TrackSearchFixture(
+        id = Random.nextLong(),
+        trackerId = Random.nextLong(),
+        remoteId = Random.nextLong(),
+        libraryId = Random.nextLong(),
+        title = previewLorem((1..10).random()).joinToString(),
+        progress = (0..100).random().toDouble(),
+        totalCount = (100L..1000L).random(),
+        score = (0..10).random().toDouble(),
+        status = Random.nextLong(),
+        trackingUrl = "https://example.com/tracker-example",
+        coverUrl = "https://example.com/cover.png",
+        startDate = previewSearchDateFormatter.format(Instant.now().minus((1L..365L).random(), ChronoUnit.DAYS)),
+        summary = previewLorem((0..40).random()).joinToString(),
+        publishingStatus = if (Random.nextBoolean()) "Finished" else "",
+        hasPublishingType = Random.nextBoolean(),
+        artists = randomNames(),
+        authors = randomNames(),
+    )
+
+private fun randomNames(): List<String> =
+    (0..(0..3).random()).map { previewLorem((3..5).random()).joinToString() }
+
+private fun previewLorem(words: Int): Sequence<String> =
+    LoremIpsum(words).values

--- a/app/src/main/java/eu/kanade/presentation/track/anime/AnimeTrackInfoDialogHomePreviewProvider.kt
+++ b/app/src/main/java/eu/kanade/presentation/track/anime/AnimeTrackInfoDialogHomePreviewProvider.kt
@@ -2,53 +2,16 @@ package eu.kanade.presentation.track.anime
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
-import eu.kanade.tachiyomi.ui.entries.anime.track.AnimeTrackItem
-import eu.kanade.test.DummyTracker
-import tachiyomi.domain.track.anime.model.AnimeTrack
-import java.time.format.DateTimeFormatter
-import java.time.format.FormatStyle
+import eu.kanade.presentation.track.previewAnimeTrackItemWithTrack
+import eu.kanade.presentation.track.previewAnimeTrackItemWithoutTrack
+import eu.kanade.presentation.track.previewTrackDateFormat
 
 internal class AnimeTrackInfoDialogHomePreviewProvider :
     PreviewParameterProvider<@Composable () -> Unit> {
 
-    private val aTrack = AnimeTrack(
-        id = 1L,
-        animeId = 2L,
-        trackerId = 3L,
-        remoteId = 4L,
-        libraryId = null,
-        title = "Manage Name On Tracker Site",
-        lastEpisodeSeen = 2.0,
-        totalEpisodes = 12L,
-        status = 1L,
-        score = 2.0,
-        remoteUrl = "https://example.com",
-        startDate = 0L,
-        finishDate = 0L,
-        private = false,
-    )
-    private val privateTrack = aTrack.copy(private = true)
-    private val trackItemWithoutTrack = AnimeTrackItem(
-        track = null,
-        tracker = DummyTracker(
-            id = 1L,
-            name = "Example Tracker",
-        ),
-    )
-    private val trackItemWithTrack = AnimeTrackItem(
-        track = aTrack,
-        tracker = DummyTracker(
-            id = 2L,
-            name = "Example Tracker 2",
-        ),
-    )
-    private val trackItemWithPrivateTrack = AnimeTrackItem(
-        track = privateTrack,
-        tracker = DummyTracker(
-            id = 2L,
-            name = "Example Tracker 2",
-        ),
-    )
+    private val trackItemWithoutTrack = previewAnimeTrackItemWithoutTrack()
+    private val trackItemWithTrack = previewAnimeTrackItemWithTrack()
+    private val trackItemWithPrivateTrack = previewAnimeTrackItemWithTrack(privateTracking = true)
 
     private val trackersWithAndWithoutTrack = @Composable {
         AnimeTrackInfoDialogHome(
@@ -56,7 +19,7 @@ internal class AnimeTrackInfoDialogHomePreviewProvider :
                 trackItemWithoutTrack,
                 trackItemWithTrack,
             ),
-            dateFormat = DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM),
+            dateFormat = previewTrackDateFormat(),
             onStatusClick = {},
             onEpisodeClick = {},
             onScoreClick = {},
@@ -73,7 +36,7 @@ internal class AnimeTrackInfoDialogHomePreviewProvider :
     private val noTrackers = @Composable {
         AnimeTrackInfoDialogHome(
             trackItems = listOf(),
-            dateFormat = DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM),
+            dateFormat = previewTrackDateFormat(),
             onStatusClick = {},
             onEpisodeClick = {},
             onScoreClick = {},
@@ -90,7 +53,7 @@ internal class AnimeTrackInfoDialogHomePreviewProvider :
     private val trackerWithPrivateTracking = @Composable {
         AnimeTrackInfoDialogHome(
             trackItems = listOf(trackItemWithPrivateTrack),
-            dateFormat = DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM),
+            dateFormat = previewTrackDateFormat(),
             onStatusClick = {},
             onEpisodeClick = {},
             onScoreClick = {},

--- a/app/src/main/java/eu/kanade/presentation/track/anime/AnimeTrackerSearchPreviewProvider.kt
+++ b/app/src/main/java/eu/kanade/presentation/track/anime/AnimeTrackerSearchPreviewProvider.kt
@@ -3,18 +3,11 @@ package eu.kanade.presentation.track.anime
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
-import androidx.compose.ui.tooling.preview.datasource.LoremIpsum
-import eu.kanade.tachiyomi.data.track.model.AnimeTrackSearch
-import java.text.SimpleDateFormat
-import java.time.Instant
-import java.time.temporal.ChronoUnit
-import java.util.Date
-import java.util.Locale
-import kotlin.random.Random
+import eu.kanade.presentation.track.previewAnimeTrackSearches
 
 internal class AnimeTrackerSearchPreviewProvider : PreviewParameterProvider<@Composable () -> Unit> {
     private val fullPageWithSecondSelected = @Composable {
-        val items = someTrackSearches().take(30).toList()
+        val items = previewAnimeTrackSearches().take(30).toList()
         AnimeTrackerSearch(
             state = TextFieldState(initialText = "search text"),
             onDispatchQuery = {},
@@ -30,7 +23,7 @@ internal class AnimeTrackerSearchPreviewProvider : PreviewParameterProvider<@Com
         AnimeTrackerSearch(
             state = TextFieldState(),
             onDispatchQuery = {},
-            queryResult = Result.success(someTrackSearches().take(30).toList()),
+            queryResult = Result.success(previewAnimeTrackSearches().take(30).toList()),
             selected = null,
             onSelectedChange = {},
             onConfirmSelection = {},
@@ -51,7 +44,7 @@ internal class AnimeTrackerSearchPreviewProvider : PreviewParameterProvider<@Com
         )
     }
     private val fullPageWithPrivateTracking = @Composable {
-        val items = someTrackSearches().take(30).toList()
+        val items = previewAnimeTrackSearches().take(30).toList()
         AnimeTrackerSearch(
             state = TextFieldState(initialText = "search text"),
             onDispatchQuery = {},
@@ -69,41 +62,4 @@ internal class AnimeTrackerSearchPreviewProvider : PreviewParameterProvider<@Com
         loading,
         fullPageWithPrivateTracking,
     )
-
-    private fun someTrackSearches(): Sequence<AnimeTrackSearch> = sequence {
-        while (true) {
-            yield(randTrackSearch())
-        }
-    }
-
-    private val formatter: SimpleDateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
-
-    private fun randTrackSearch() = AnimeTrackSearch().let {
-        it.id = Random.nextLong()
-        it.anime_id = Random.nextLong()
-        it.tracker_id = Random.nextLong()
-        it.remote_id = Random.nextLong()
-        it.library_id = Random.nextLong()
-        it.title = lorem((1..10).random()).joinToString()
-        it.last_episode_seen = (0..100).random().toDouble()
-        it.total_episodes = (100L..1000L).random()
-        it.score = (0..10).random().toDouble()
-        it.status = Random.nextLong()
-        it.started_watching_date = 0L
-        it.finished_watching_date = 0L
-        it.tracking_url = "https://example.com/tracker-example"
-        it.cover_url = "https://example.com/cover.png"
-        it.start_date = formatter.format(Date.from(Instant.now().minus((1L..365).random(), ChronoUnit.DAYS)))
-        it.summary = lorem((0..40).random()).joinToString()
-        it.publishing_status = if (Random.nextBoolean()) "Finished" else ""
-        it.publishing_type = if (Random.nextBoolean()) "OVA" else ""
-        it.artists = randomNames()
-        it.authors = randomNames()
-        it
-    }
-
-    private fun randomNames(): List<String> = (0..(0..3).random()).map { lorem((3..5).random()).joinToString() }
-
-    private fun lorem(words: Int): Sequence<String> =
-        LoremIpsum(words).values
 }

--- a/app/src/main/java/eu/kanade/presentation/track/manga/MangaTrackInfoDialogHomePreviewProvider.kt
+++ b/app/src/main/java/eu/kanade/presentation/track/manga/MangaTrackInfoDialogHomePreviewProvider.kt
@@ -2,53 +2,16 @@ package eu.kanade.presentation.track.manga
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
-import eu.kanade.tachiyomi.ui.entries.manga.track.MangaTrackItem
-import eu.kanade.test.DummyTracker
-import tachiyomi.domain.track.manga.model.MangaTrack
-import java.time.format.DateTimeFormatter
-import java.time.format.FormatStyle
+import eu.kanade.presentation.track.previewMangaTrackItemWithTrack
+import eu.kanade.presentation.track.previewMangaTrackItemWithoutTrack
+import eu.kanade.presentation.track.previewTrackDateFormat
 
 internal class MangaTrackInfoDialogHomePreviewProvider :
     PreviewParameterProvider<@Composable () -> Unit> {
 
-    private val aTrack = MangaTrack(
-        id = 1L,
-        mangaId = 2L,
-        trackerId = 3L,
-        remoteId = 4L,
-        libraryId = null,
-        title = "Manage Name On Tracker Site",
-        lastChapterRead = 2.0,
-        totalChapters = 12L,
-        status = 1L,
-        score = 2.0,
-        remoteUrl = "https://example.com",
-        startDate = 0L,
-        finishDate = 0L,
-        private = false,
-    )
-    private val privateTrack = aTrack.copy(private = true)
-    private val trackItemWithoutTrack = MangaTrackItem(
-        track = null,
-        tracker = DummyTracker(
-            id = 1L,
-            name = "Example Tracker",
-        ),
-    )
-    private val trackItemWithTrack = MangaTrackItem(
-        track = aTrack,
-        tracker = DummyTracker(
-            id = 2L,
-            name = "Example Tracker 2",
-        ),
-    )
-    private val trackItemWithPrivateTrack = MangaTrackItem(
-        track = privateTrack,
-        tracker = DummyTracker(
-            id = 2L,
-            name = "Example Tracker 2",
-        ),
-    )
+    private val trackItemWithoutTrack = previewMangaTrackItemWithoutTrack()
+    private val trackItemWithTrack = previewMangaTrackItemWithTrack()
+    private val trackItemWithPrivateTrack = previewMangaTrackItemWithTrack(privateTracking = true)
 
     private val trackersWithAndWithoutTrack = @Composable {
         MangaTrackInfoDialogHome(
@@ -56,7 +19,7 @@ internal class MangaTrackInfoDialogHomePreviewProvider :
                 trackItemWithoutTrack,
                 trackItemWithTrack,
             ),
-            dateFormat = DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM),
+            dateFormat = previewTrackDateFormat(),
             onStatusClick = {},
             onChapterClick = {},
             onScoreClick = {},
@@ -73,7 +36,7 @@ internal class MangaTrackInfoDialogHomePreviewProvider :
     private val noTrackers = @Composable {
         MangaTrackInfoDialogHome(
             trackItems = listOf(),
-            dateFormat = DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM),
+            dateFormat = previewTrackDateFormat(),
             onStatusClick = {},
             onChapterClick = {},
             onScoreClick = {},
@@ -90,7 +53,7 @@ internal class MangaTrackInfoDialogHomePreviewProvider :
     private val trackerWithPrivateTracking = @Composable {
         MangaTrackInfoDialogHome(
             trackItems = listOf(trackItemWithPrivateTrack),
-            dateFormat = DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM),
+            dateFormat = previewTrackDateFormat(),
             onStatusClick = {},
             onChapterClick = {},
             onScoreClick = {},

--- a/app/src/main/java/eu/kanade/presentation/track/manga/MangaTrackerSearchPreviewProvider.kt
+++ b/app/src/main/java/eu/kanade/presentation/track/manga/MangaTrackerSearchPreviewProvider.kt
@@ -3,18 +3,11 @@ package eu.kanade.presentation.track.manga
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
-import androidx.compose.ui.tooling.preview.datasource.LoremIpsum
-import eu.kanade.tachiyomi.data.track.model.MangaTrackSearch
-import java.text.SimpleDateFormat
-import java.time.Instant
-import java.time.temporal.ChronoUnit
-import java.util.Date
-import java.util.Locale
-import kotlin.random.Random
+import eu.kanade.presentation.track.previewMangaTrackSearches
 
 internal class MangaTrackerSearchPreviewProvider : PreviewParameterProvider<@Composable () -> Unit> {
     private val fullPageWithSecondSelected = @Composable {
-        val items = someTrackSearches().take(30).toList()
+        val items = previewMangaTrackSearches().take(30).toList()
         MangaTrackerSearch(
             state = TextFieldState(initialText = "search text"),
             onDispatchQuery = {},
@@ -30,7 +23,7 @@ internal class MangaTrackerSearchPreviewProvider : PreviewParameterProvider<@Com
         MangaTrackerSearch(
             state = TextFieldState(),
             onDispatchQuery = {},
-            queryResult = Result.success(someTrackSearches().take(30).toList()),
+            queryResult = Result.success(previewMangaTrackSearches().take(30).toList()),
             selected = null,
             onSelectedChange = {},
             onConfirmSelection = {},
@@ -51,7 +44,7 @@ internal class MangaTrackerSearchPreviewProvider : PreviewParameterProvider<@Com
         )
     }
     private val fullPageWithPrivateTracking = @Composable {
-        val items = someTrackSearches().take(30).toList()
+        val items = previewMangaTrackSearches().take(30).toList()
         MangaTrackerSearch(
             state = TextFieldState(initialText = "search text"),
             onDispatchQuery = {},
@@ -69,41 +62,4 @@ internal class MangaTrackerSearchPreviewProvider : PreviewParameterProvider<@Com
         loading,
         fullPageWithPrivateTracking,
     )
-
-    private fun someTrackSearches(): Sequence<MangaTrackSearch> = sequence {
-        while (true) {
-            yield(randTrackSearch())
-        }
-    }
-
-    private val formatter: SimpleDateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
-
-    private fun randTrackSearch() = MangaTrackSearch().let {
-        it.id = Random.nextLong()
-        it.manga_id = Random.nextLong()
-        it.tracker_id = Random.nextLong()
-        it.remote_id = Random.nextLong()
-        it.library_id = Random.nextLong()
-        it.title = lorem((1..10).random()).joinToString()
-        it.last_chapter_read = (0..100).random().toDouble()
-        it.total_chapters = (100L..1000L).random()
-        it.score = (0..10).random().toDouble()
-        it.status = Random.nextLong()
-        it.started_reading_date = 0L
-        it.finished_reading_date = 0L
-        it.tracking_url = "https://example.com/tracker-example"
-        it.cover_url = "https://example.com/cover.png"
-        it.start_date = formatter.format(Date.from(Instant.now().minus((1L..365).random(), ChronoUnit.DAYS)))
-        it.summary = lorem((0..40).random()).joinToString()
-        it.publishing_status = if (Random.nextBoolean()) "Finished" else ""
-        it.publishing_type = if (Random.nextBoolean()) "Oneshot" else ""
-        it.artists = randomNames()
-        it.authors = randomNames()
-        it
-    }
-
-    private fun randomNames(): List<String> = (0..(0..3).random()).map { lorem((3..5).random()).joinToString() }
-
-    private fun lorem(words: Int): Sequence<String> =
-        LoremIpsum(words).values
 }


### PR DESCRIPTION
## Objective
Share duplicated anime/manga tracking preview fixture setup while keeping the existing Compose preview provider entrypoints in their current packages.

Closes #719

## Scope
- Added an internal `eu.kanade.presentation.track` fixture helper for preview-only lorem/date/name, dummy tracker, track search, and track item construction.
- Updated anime and manga track preview providers to call the shared typed fixture builders instead of owning duplicated local random/sample setup.
- Kept `AnimeTrackerSearchPreviewProvider`, `MangaTrackerSearchPreviewProvider`, `AnimeTrackInfoDialogHomePreviewProvider`, and `MangaTrackInfoDialogHomePreviewProvider` in place.
- Added an Unreleased > Other changelog entry without the ticket number.

## Non-goals
- No generic `PreviewParameterProvider` abstraction.
- No runtime tracker service, repository, sync, or screen-state behavior changes.
- No light novel add-on/plugin changes, including `lightnovel-plugin/` and `feature/novel/`.

## Verification
- `git diff --check` - passed.
- `git diff --cached --check` - passed.
- `rg` source checks confirmed provider classes remain and duplicated local random/sample builders are removed from the anime/manga preview providers.
- `git diff --cached --name-only | rg "^(lightnovel-plugin/|app/src/main/java/eu/kanade/tachiyomi/feature/novel/)"` - no matches.
- `./gradlew spotlessCheck` - passed.
- `./gradlew :app:compileDebugKotlin` - expected repository ambiguity: Gradle reports candidates `compileStableDebugAndroidTestKotlin`, `compileStableDebugKotlin`, and `compileStableDebugUnitTestKotlin`.
- `./gradlew :app:compileStableDebugKotlin` - passed with existing project warnings.
- Pre-push hook reran `spotlessCheck` and `:app:compileStableDebugKotlin` - both passed.

## Code Review
- Self-review completed against R660 scope and acceptance criteria.
- Findings: no critical or important issues. The change is preview-only, provider structure is preserved, and light novel paths are untouched.

## Risk
T1 preview-only cleanup. The changed production artifact surface is limited to Compose preview fixture construction in presentation code; runtime tracking behavior is not modified.

## Rollback
Revert commit `a90345529` to restore the duplicated local preview fixture setup.
