### PR TITLE
refactor: consolidate category interactors (R661)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Baseline profile CI job now dry-runs `:app:generateBaselineProfile` and verifies `baseline-prof.txt` is committed and non-empty on every PR touching app or macrobenchmark paths.
 
 ### Other
+- Category interactors now share common domain mechanics while keeping anime and manga entrypoints separate.
 - Track previews now share sample fixture builders between anime and manga preview providers.
 - Storage preferences now use the concrete Android storage folder provider directly instead of a single-implementation abstraction.
 - Data saver compression bypass logic now uses one shared jpg/gif ignore helper across supported image proxy backends.

--- a/domain/src/main/java/tachiyomi/domain/category/anime/interactor/CreateAnimeCategoryWithName.kt
+++ b/domain/src/main/java/tachiyomi/domain/category/anime/interactor/CreateAnimeCategoryWithName.kt
@@ -1,45 +1,28 @@
 package tachiyomi.domain.category.anime.interactor
 
-import logcat.LogPriority
-import tachiyomi.core.common.util.lang.withNonCancellableContext
-import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.category.anime.repository.AnimeCategoryRepository
-import tachiyomi.domain.category.model.Category
+import tachiyomi.domain.category.interactor.asCategoryRepositoryOps
 import tachiyomi.domain.library.service.LibraryPreferences
+import tachiyomi.domain.category.interactor.CreateCategoryWithName as SharedCreateCategoryWithName
 
 class CreateAnimeCategoryWithName(
     private val categoryRepository: AnimeCategoryRepository,
     private val preferences: LibraryPreferences,
 ) {
 
-    private val initialFlags: Long
-        get() {
+    private val createCategory = SharedCreateCategoryWithName(
+        repository = categoryRepository.asCategoryRepositoryOps(),
+        initialFlags = {
             val sort = preferences.animeSortingMode().get()
-            return sort.type.flag or sort.direction.flag
-        }
+            sort.type.flag or sort.direction.flag
+        },
+    )
 
-    suspend fun await(name: String, parentId: Long? = null): Result = withNonCancellableContext {
-        val categories = categoryRepository.getAllAnimeCategories()
-        val validatedParentId = parentId?.let { id ->
-            categories.find { it.id == id && it.parentId == null }?.id
-                ?: return@withNonCancellableContext Result.InvalidParent
-        }
-        val nextOrder = categories.maxOfOrNull { it.order }?.plus(1) ?: 0
-        val newCategory = Category(
-            id = 0,
-            name = name,
-            order = nextOrder,
-            flags = initialFlags,
-            hidden = false,
-            parentId = validatedParentId,
-        )
-
-        try {
-            categoryRepository.insertAnimeCategory(newCategory)
-            Result.Success
-        } catch (e: Exception) {
-            logcat(LogPriority.ERROR, e)
-            Result.InternalError(e)
+    suspend fun await(name: String, parentId: Long? = null): Result {
+        return when (val result = createCategory.await(name, parentId)) {
+            SharedCreateCategoryWithName.Result.Success -> Result.Success
+            SharedCreateCategoryWithName.Result.InvalidParent -> Result.InvalidParent
+            is SharedCreateCategoryWithName.Result.InternalError -> Result.InternalError(result.error)
         }
     }
 

--- a/domain/src/main/java/tachiyomi/domain/category/anime/interactor/DeleteAnimeCategory.kt
+++ b/domain/src/main/java/tachiyomi/domain/category/anime/interactor/DeleteAnimeCategory.kt
@@ -1,10 +1,8 @@
 package tachiyomi.domain.category.anime.interactor
 
-import logcat.LogPriority
-import tachiyomi.core.common.util.lang.withNonCancellableContext
-import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.category.anime.repository.AnimeCategoryRepository
-import tachiyomi.domain.category.model.CategoryUpdate
+import tachiyomi.domain.category.interactor.DeleteCategory
+import tachiyomi.domain.category.interactor.asCategoryRepositoryOps
 import tachiyomi.domain.download.service.DownloadPreferences
 import tachiyomi.domain.library.service.LibraryPreferences
 
@@ -14,49 +12,22 @@ class DeleteAnimeCategory(
     private val downloadPreferences: DownloadPreferences,
 ) {
 
-    suspend fun await(categoryId: Long) = withNonCancellableContext {
-        try {
-            categoryRepository.deleteAnimeCategory(categoryId)
-        } catch (e: Exception) {
-            logcat(LogPriority.ERROR, e)
-            return@withNonCancellableContext Result.InternalError(e)
-        }
-
-        val categories = categoryRepository.getAllAnimeCategories()
-        val updates = categories.mapIndexed { index, category ->
-            CategoryUpdate(
-                id = category.id,
-                order = index.toLong(),
-                parentId = if (category.parentId == categoryId) null else category.parentId,
-                updateParentId = category.parentId == categoryId,
-            )
-        }
-
-        val defaultCategory = libraryPreferences.defaultAnimeCategory().get()
-        if (defaultCategory == categoryId.toInt()) {
-            libraryPreferences.defaultAnimeCategory().delete()
-        }
-
-        val categoryPreferences = listOf(
+    private val deleteCategory = DeleteCategory(
+        repository = categoryRepository.asCategoryRepositoryOps(),
+        defaultCategory = libraryPreferences.defaultAnimeCategory(),
+        categoryPreferences = listOf(
             libraryPreferences.animeUpdateCategories(),
             libraryPreferences.animeUpdateCategoriesExclude(),
             downloadPreferences.removeExcludeAnimeCategories(),
             downloadPreferences.downloadNewEpisodeCategories(),
             downloadPreferences.downloadNewEpisodeCategoriesExclude(),
-        )
-        val categoryIdString = categoryId.toString()
-        categoryPreferences.forEach { preference ->
-            val ids = preference.get()
-            if (categoryIdString !in ids) return@forEach
-            preference.set(ids.minus(categoryIdString))
-        }
+        ),
+    )
 
-        try {
-            categoryRepository.updatePartialAnimeCategories(updates)
-            Result.Success
-        } catch (e: Exception) {
-            logcat(LogPriority.ERROR, e)
-            Result.InternalError(e)
+    suspend fun await(categoryId: Long): Result {
+        return when (val result = deleteCategory.await(categoryId)) {
+            DeleteCategory.Result.Success -> Result.Success
+            is DeleteCategory.Result.InternalError -> Result.InternalError(result.error)
         }
     }
 

--- a/domain/src/main/java/tachiyomi/domain/category/anime/interactor/GetAnimeCategories.kt
+++ b/domain/src/main/java/tachiyomi/domain/category/anime/interactor/GetAnimeCategories.kt
@@ -1,26 +1,21 @@
 package tachiyomi.domain.category.anime.interactor
 
-import kotlinx.coroutines.flow.Flow
 import tachiyomi.domain.category.anime.repository.AnimeCategoryRepository
+import tachiyomi.domain.category.interactor.GetCategories
+import tachiyomi.domain.category.interactor.asCategoryRepositoryOps
 import tachiyomi.domain.category.model.Category
 
 class GetAnimeCategories(
     private val categoryRepository: AnimeCategoryRepository,
 ) {
 
-    fun subscribe(): Flow<List<Category>> {
-        return categoryRepository.getAllAnimeCategoriesAsFlow()
-    }
+    private val getCategories = GetCategories(categoryRepository.asCategoryRepositoryOps())
 
-    fun subscribe(animeId: Long): Flow<List<Category>> {
-        return categoryRepository.getCategoriesByAnimeIdAsFlow(animeId)
-    }
+    fun subscribe() = getCategories.subscribe()
 
-    suspend fun await(): List<Category> {
-        return categoryRepository.getAllAnimeCategories()
-    }
+    fun subscribe(animeId: Long) = getCategories.subscribe(animeId)
 
-    suspend fun await(animeId: Long): List<Category> {
-        return categoryRepository.getCategoriesByAnimeId(animeId)
-    }
+    suspend fun await(): List<Category> = getCategories.await()
+
+    suspend fun await(animeId: Long): List<Category> = getCategories.await(animeId)
 }

--- a/domain/src/main/java/tachiyomi/domain/category/anime/interactor/GetVisibleAnimeCategories.kt
+++ b/domain/src/main/java/tachiyomi/domain/category/anime/interactor/GetVisibleAnimeCategories.kt
@@ -1,25 +1,20 @@
 package tachiyomi.domain.category.anime.interactor
 
-import kotlinx.coroutines.flow.Flow
 import tachiyomi.domain.category.anime.repository.AnimeCategoryRepository
+import tachiyomi.domain.category.interactor.GetVisibleCategories
+import tachiyomi.domain.category.interactor.asCategoryRepositoryOps
 import tachiyomi.domain.category.model.Category
 
 class GetVisibleAnimeCategories(
     private val categoryRepository: AnimeCategoryRepository,
 ) {
-    fun subscribe(): Flow<List<Category>> {
-        return categoryRepository.getAllVisibleAnimeCategoriesAsFlow()
-    }
+    private val getVisibleCategories = GetVisibleCategories(categoryRepository.asCategoryRepositoryOps())
 
-    fun subscribe(animeId: Long): Flow<List<Category>> {
-        return categoryRepository.getVisibleCategoriesByAnimeIdAsFlow(animeId)
-    }
+    fun subscribe() = getVisibleCategories.subscribe()
 
-    suspend fun await(): List<Category> {
-        return categoryRepository.getAllVisibleAnimeCategories()
-    }
+    fun subscribe(animeId: Long) = getVisibleCategories.subscribe(animeId)
 
-    suspend fun await(animeId: Long): List<Category> {
-        return categoryRepository.getVisibleCategoriesByAnimeId(animeId)
-    }
+    suspend fun await(): List<Category> = getVisibleCategories.await()
+
+    suspend fun await(animeId: Long): List<Category> = getVisibleCategories.await(animeId)
 }

--- a/domain/src/main/java/tachiyomi/domain/category/anime/interactor/HideAnimeCategory.kt
+++ b/domain/src/main/java/tachiyomi/domain/category/anime/interactor/HideAnimeCategory.kt
@@ -1,28 +1,20 @@
 package tachiyomi.domain.category.anime.interactor
 
-import logcat.LogPriority
-import tachiyomi.core.common.util.lang.withNonCancellableContext
-import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.category.anime.repository.AnimeCategoryRepository
+import tachiyomi.domain.category.interactor.HideCategory
+import tachiyomi.domain.category.interactor.asCategoryRepositoryOps
 import tachiyomi.domain.category.model.Category
-import tachiyomi.domain.category.model.CategoryUpdate
 
 class HideAnimeCategory(
     private val categoryRepository: AnimeCategoryRepository,
 ) {
 
-    suspend fun await(category: Category) = withNonCancellableContext {
-        val update = CategoryUpdate(
-            id = category.id,
-            hidden = !category.hidden,
-        )
+    private val hideCategory = HideCategory(categoryRepository.asCategoryRepositoryOps())
 
-        try {
-            categoryRepository.updatePartialAnimeCategory(update)
-            RenameAnimeCategory.Result.Success
-        } catch (e: Exception) {
-            logcat(LogPriority.ERROR, e)
-            Result.InternalError(e)
+    suspend fun await(category: Category): Result {
+        return when (val result = hideCategory.await(category)) {
+            HideCategory.Result.Success -> Result.Success
+            is HideCategory.Result.InternalError -> Result.InternalError(result.error)
         }
     }
 

--- a/domain/src/main/java/tachiyomi/domain/category/anime/interactor/RenameAnimeCategory.kt
+++ b/domain/src/main/java/tachiyomi/domain/category/anime/interactor/RenameAnimeCategory.kt
@@ -1,28 +1,20 @@
 package tachiyomi.domain.category.anime.interactor
 
-import logcat.LogPriority
-import tachiyomi.core.common.util.lang.withNonCancellableContext
-import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.category.anime.repository.AnimeCategoryRepository
+import tachiyomi.domain.category.interactor.RenameCategory
+import tachiyomi.domain.category.interactor.asCategoryRepositoryOps
 import tachiyomi.domain.category.model.Category
-import tachiyomi.domain.category.model.CategoryUpdate
 
 class RenameAnimeCategory(
     private val categoryRepository: AnimeCategoryRepository,
 ) {
 
-    suspend fun await(categoryId: Long, name: String) = withNonCancellableContext {
-        val update = CategoryUpdate(
-            id = categoryId,
-            name = name,
-        )
+    private val renameCategory = RenameCategory(categoryRepository.asCategoryRepositoryOps())
 
-        try {
-            categoryRepository.updatePartialAnimeCategory(update)
-            Result.Success
-        } catch (e: Exception) {
-            logcat(LogPriority.ERROR, e)
-            Result.InternalError(e)
+    suspend fun await(categoryId: Long, name: String): Result {
+        return when (val result = renameCategory.await(categoryId, name)) {
+            RenameCategory.Result.Success -> Result.Success
+            is RenameCategory.Result.InternalError -> Result.InternalError(result.error)
         }
     }
 

--- a/domain/src/main/java/tachiyomi/domain/category/anime/interactor/ReorderAnimeCategory.kt
+++ b/domain/src/main/java/tachiyomi/domain/category/anime/interactor/ReorderAnimeCategory.kt
@@ -2,45 +2,25 @@ package tachiyomi.domain.category.anime.interactor
 
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import logcat.LogPriority
 import tachiyomi.core.common.util.lang.withNonCancellableContext
-import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.category.anime.repository.AnimeCategoryRepository
+import tachiyomi.domain.category.interactor.ReorderCategory
+import tachiyomi.domain.category.interactor.asCategoryRepositoryOps
 import tachiyomi.domain.category.model.Category
-import tachiyomi.domain.category.model.CategoryUpdate
 
 class ReorderAnimeCategory(
     private val categoryRepository: AnimeCategoryRepository,
 ) {
 
     private val mutex = Mutex()
+    private val reorderCategory = ReorderCategory(categoryRepository.asCategoryRepositoryOps())
 
     suspend fun await(category: Category, newIndex: Int) = withNonCancellableContext {
         mutex.withLock {
-            val categories = categoryRepository.getAllAnimeCategories()
-                .filterNot(Category::isSystemCategory)
-                .toMutableList()
-
-            val currentIndex = categories.indexOfFirst { it.id == category.id }
-            if (currentIndex == -1) {
-                return@withNonCancellableContext Result.Unchanged
-            }
-
-            try {
-                categories.add(newIndex, categories.removeAt(currentIndex))
-
-                val updates = categories.mapIndexed { index, category ->
-                    CategoryUpdate(
-                        id = category.id,
-                        order = index.toLong(),
-                    )
-                }
-
-                categoryRepository.updatePartialAnimeCategories(updates)
-                Result.Success
-            } catch (e: Exception) {
-                logcat(LogPriority.ERROR, e)
-                Result.InternalError(e)
+            when (val result = reorderCategory.await(category, newIndex)) {
+                ReorderCategory.Result.Success -> Result.Success
+                ReorderCategory.Result.Unchanged -> Result.Unchanged
+                is ReorderCategory.Result.InternalError -> Result.InternalError(result.error)
             }
         }
     }

--- a/domain/src/main/java/tachiyomi/domain/category/anime/interactor/ResetAnimeCategoryFlags.kt
+++ b/domain/src/main/java/tachiyomi/domain/category/anime/interactor/ResetAnimeCategoryFlags.kt
@@ -1,7 +1,8 @@
 package tachiyomi.domain.category.anime.interactor
 
 import tachiyomi.domain.category.anime.repository.AnimeCategoryRepository
-import tachiyomi.domain.category.model.CategoryUpdate
+import tachiyomi.domain.category.interactor.ResetCategoryFlags
+import tachiyomi.domain.category.interactor.asCategoryRepositoryOps
 import tachiyomi.domain.library.model.plus
 import tachiyomi.domain.library.service.LibraryPreferences
 
@@ -10,17 +11,10 @@ class ResetAnimeCategoryFlags(
     private val categoryRepository: AnimeCategoryRepository,
 ) {
 
-    private val sortMask = 0b01111100L
+    private val resetCategoryFlags = ResetCategoryFlags(categoryRepository.asCategoryRepositoryOps())
 
     suspend fun await() {
         val sort = preferences.animeSortingMode().get()
-        val updates = categoryRepository.getAllAnimeCategories().map {
-            // Reset only sort mode bits; keep auxiliary flags such as alphabetical category sorting.
-            CategoryUpdate(
-                id = it.id,
-                flags = (it.flags and sortMask.inv()) + sort.type + sort.direction,
-            )
-        }
-        categoryRepository.updatePartialAnimeCategories(updates)
+        resetCategoryFlags.await(sort.type + sort.direction)
     }
 }

--- a/domain/src/main/java/tachiyomi/domain/category/anime/interactor/SetAnimeCategories.kt
+++ b/domain/src/main/java/tachiyomi/domain/category/anime/interactor/SetAnimeCategories.kt
@@ -1,18 +1,15 @@
 package tachiyomi.domain.category.anime.interactor
 
-import logcat.LogPriority
-import tachiyomi.core.common.util.system.logcat
+import tachiyomi.domain.category.interactor.SetEntryCategories
 import tachiyomi.domain.entries.anime.repository.AnimeRepository
 
 class SetAnimeCategories(
     private val animeRepository: AnimeRepository,
 ) {
 
+    private val setEntryCategories = SetEntryCategories(animeRepository::setAnimeCategories)
+
     suspend fun await(animeId: Long, categoryIds: List<Long>) {
-        try {
-            animeRepository.setAnimeCategories(animeId, categoryIds)
-        } catch (e: Exception) {
-            logcat(LogPriority.ERROR, e)
-        }
+        setEntryCategories.await(animeId, categoryIds)
     }
 }

--- a/domain/src/main/java/tachiyomi/domain/category/anime/interactor/SetAnimeCategoryAlphabeticalSort.kt
+++ b/domain/src/main/java/tachiyomi/domain/category/anime/interactor/SetAnimeCategoryAlphabeticalSort.kt
@@ -1,25 +1,17 @@
 package tachiyomi.domain.category.anime.interactor
 
 import tachiyomi.domain.category.anime.repository.AnimeCategoryRepository
-import tachiyomi.domain.category.model.CategoryFlags
-import tachiyomi.domain.category.model.CategoryUpdate
+import tachiyomi.domain.category.interactor.SetCategoryAlphabeticalSort
+import tachiyomi.domain.category.interactor.asCategoryRepositoryOps
 
 class SetAnimeCategoryAlphabeticalSort(
     private val categoryRepository: AnimeCategoryRepository,
 ) {
 
+    private val setCategoryAlphabeticalSort =
+        SetCategoryAlphabeticalSort(categoryRepository.asCategoryRepositoryOps())
+
     suspend fun await(enabled: Boolean) {
-        val updates = categoryRepository.getAllAnimeCategories().map { category ->
-            val updatedFlags = if (enabled) {
-                category.flags or CategoryFlags.CATEGORY_FLAG_SORT_ALPHABETICAL
-            } else {
-                category.flags and CategoryFlags.CATEGORY_FLAG_SORT_ALPHABETICAL.inv()
-            }
-            CategoryUpdate(
-                id = category.id,
-                flags = updatedFlags,
-            )
-        }
-        categoryRepository.updatePartialAnimeCategories(updates)
+        setCategoryAlphabeticalSort.await(enabled)
     }
 }

--- a/domain/src/main/java/tachiyomi/domain/category/anime/interactor/SetAnimeDisplayMode.kt
+++ b/domain/src/main/java/tachiyomi/domain/category/anime/interactor/SetAnimeDisplayMode.kt
@@ -1,5 +1,6 @@
 package tachiyomi.domain.category.anime.interactor
 
+import tachiyomi.domain.category.interactor.SetCategoryDisplayMode
 import tachiyomi.domain.library.model.LibraryDisplayMode
 import tachiyomi.domain.library.service.LibraryPreferences
 
@@ -7,7 +8,9 @@ class SetAnimeDisplayMode(
     private val preferences: LibraryPreferences,
 ) {
 
+    private val setCategoryDisplayMode = SetCategoryDisplayMode(preferences)
+
     fun await(display: LibraryDisplayMode) {
-        preferences.displayMode().set(display)
+        setCategoryDisplayMode.await(display)
     }
 }

--- a/domain/src/main/java/tachiyomi/domain/category/anime/interactor/SetSortModeForAnimeCategory.kt
+++ b/domain/src/main/java/tachiyomi/domain/category/anime/interactor/SetSortModeForAnimeCategory.kt
@@ -1,10 +1,10 @@
 package tachiyomi.domain.category.anime.interactor
 
 import tachiyomi.domain.category.anime.repository.AnimeCategoryRepository
+import tachiyomi.domain.category.interactor.asCategoryRepositoryOps
+import tachiyomi.domain.category.interactor.setSortModeForCategory
 import tachiyomi.domain.category.model.Category
-import tachiyomi.domain.category.model.CategoryUpdate
 import tachiyomi.domain.library.anime.model.AnimeLibrarySort
-import tachiyomi.domain.library.model.plus
 import tachiyomi.domain.library.service.LibraryPreferences
 import kotlin.random.Random
 
@@ -13,6 +13,7 @@ class SetSortModeForAnimeCategory(
     private val categoryRepository: AnimeCategoryRepository,
 ) {
 
+    private val categoryOps = categoryRepository.asCategoryRepositoryOps()
     private val sortMask: Long = AnimeLibrarySort.Type.Alphabetical.mask or AnimeLibrarySort.Direction.Ascending.mask
 
     suspend fun await(
@@ -20,28 +21,17 @@ class SetSortModeForAnimeCategory(
         type: AnimeLibrarySort.Type,
         direction: AnimeLibrarySort.Direction,
     ) {
-        val category = categoryId?.let { categoryRepository.getAnimeCategory(it) }
-        val flags = ((category?.flags ?: 0L) and sortMask.inv()) + type + direction
-        if (type == AnimeLibrarySort.Type.Random) {
-            preferences.randomAnimeSortSeed().set(Random.nextInt())
-        }
-        if (category != null && preferences.categorizedDisplaySettings().get()) {
-            categoryRepository.updatePartialAnimeCategory(
-                CategoryUpdate(
-                    id = category.id,
-                    flags = flags,
-                ),
-            )
-        } else {
-            preferences.animeSortingMode().set(AnimeLibrarySort(type, direction))
-            val updates = categoryRepository.getAllAnimeCategories().map {
-                CategoryUpdate(
-                    id = it.id,
-                    flags = (it.flags and sortMask.inv()) + type + direction,
-                )
-            }
-            categoryRepository.updatePartialAnimeCategories(updates)
-        }
+        setSortModeForCategory(
+            repository = categoryOps,
+            categoryId = categoryId,
+            type = type,
+            direction = direction,
+            sortMask = sortMask,
+            categorizedDisplaySettings = preferences.categorizedDisplaySettings().get(),
+            isRandomSort = type == AnimeLibrarySort.Type.Random,
+            onRandomSortSelected = { preferences.randomAnimeSortSeed().set(Random.nextInt()) },
+            onGlobalSortSelected = { preferences.animeSortingMode().set(AnimeLibrarySort(type, direction)) },
+        )
     }
 
     suspend fun await(

--- a/domain/src/main/java/tachiyomi/domain/category/anime/interactor/UpdateAnimeCategory.kt
+++ b/domain/src/main/java/tachiyomi/domain/category/anime/interactor/UpdateAnimeCategory.kt
@@ -1,19 +1,20 @@
 package tachiyomi.domain.category.anime.interactor
 
-import tachiyomi.core.common.util.lang.withNonCancellableContext
 import tachiyomi.domain.category.anime.repository.AnimeCategoryRepository
+import tachiyomi.domain.category.interactor.UpdateCategory
+import tachiyomi.domain.category.interactor.asCategoryRepositoryOps
 import tachiyomi.domain.category.model.CategoryUpdate
 
 class UpdateAnimeCategory(
     private val categoryRepository: AnimeCategoryRepository,
 ) {
 
-    suspend fun await(payload: CategoryUpdate): Result = withNonCancellableContext {
-        try {
-            categoryRepository.updatePartialAnimeCategory(payload)
-            Result.Success
-        } catch (e: Exception) {
-            Result.Error(e)
+    private val updateCategory = UpdateCategory(categoryRepository.asCategoryRepositoryOps())
+
+    suspend fun await(payload: CategoryUpdate): Result {
+        return when (val result = updateCategory.await(payload)) {
+            UpdateCategory.Result.Success -> Result.Success
+            is UpdateCategory.Result.InternalError -> Result.Error(result.error)
         }
     }
 

--- a/domain/src/main/java/tachiyomi/domain/category/interactor/CategoryInteractors.kt
+++ b/domain/src/main/java/tachiyomi/domain/category/interactor/CategoryInteractors.kt
@@ -1,0 +1,315 @@
+package tachiyomi.domain.category.interactor
+
+import logcat.LogPriority
+import tachiyomi.core.common.preference.Preference
+import tachiyomi.core.common.util.lang.withNonCancellableContext
+import tachiyomi.core.common.util.system.logcat
+import tachiyomi.domain.category.model.Category
+import tachiyomi.domain.category.model.CategoryFlags
+import tachiyomi.domain.category.model.CategoryUpdate
+import tachiyomi.domain.library.model.Flag
+import tachiyomi.domain.library.model.LibraryDisplayMode
+import tachiyomi.domain.library.model.plus
+import tachiyomi.domain.library.service.LibraryPreferences
+
+internal class GetCategories(
+    private val repository: CategoryRepositoryOps,
+) {
+    fun subscribe() = repository.getAllCategoriesAsFlow()
+
+    fun subscribe(entryId: Long) = repository.getCategoriesByEntryIdAsFlow(entryId)
+
+    suspend fun await(): List<Category> = repository.getAllCategories()
+
+    suspend fun await(entryId: Long): List<Category> = repository.getCategoriesByEntryId(entryId)
+}
+
+internal class GetVisibleCategories(
+    private val repository: CategoryRepositoryOps,
+) {
+    fun subscribe() = repository.getAllVisibleCategoriesAsFlow()
+
+    fun subscribe(entryId: Long) = repository.getVisibleCategoriesByEntryIdAsFlow(entryId)
+
+    suspend fun await(): List<Category> = repository.getAllVisibleCategories()
+
+    suspend fun await(entryId: Long): List<Category> = repository.getVisibleCategoriesByEntryId(entryId)
+}
+
+internal class CreateCategoryWithName(
+    private val repository: CategoryRepositoryOps,
+    private val initialFlags: () -> Long,
+) {
+    suspend fun await(name: String, parentId: Long? = null): Result = withNonCancellableContext {
+        val categories = repository.getAllCategories()
+        val validatedParentId = parentId?.let { id ->
+            categories.find { it.id == id && it.parentId == null }?.id
+                ?: return@withNonCancellableContext Result.InvalidParent
+        }
+        val nextOrder = categories.maxOfOrNull { it.order }?.plus(1) ?: 0
+        val newCategory = Category(
+            id = 0,
+            name = name,
+            order = nextOrder,
+            flags = initialFlags(),
+            hidden = false,
+            parentId = validatedParentId,
+        )
+
+        try {
+            repository.insertCategory(newCategory)
+            Result.Success
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e)
+            Result.InternalError(e)
+        }
+    }
+
+    sealed interface Result {
+        data object Success : Result
+        data object InvalidParent : Result
+        data class InternalError(val error: Exception) : Result
+    }
+}
+
+internal class RenameCategory(
+    private val repository: CategoryRepositoryOps,
+) {
+    suspend fun await(categoryId: Long, name: String): Result = withNonCancellableContext {
+        try {
+            repository.updatePartialCategory(CategoryUpdate(id = categoryId, name = name))
+            Result.Success
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e)
+            Result.InternalError(e)
+        }
+    }
+
+    suspend fun await(category: Category, name: String): Result = await(category.id, name)
+
+    sealed interface Result {
+        data object Success : Result
+        data class InternalError(val error: Exception) : Result
+    }
+}
+
+internal class UpdateCategory(
+    private val repository: CategoryRepositoryOps,
+) {
+    suspend fun await(payload: CategoryUpdate): Result = withNonCancellableContext {
+        try {
+            repository.updatePartialCategory(payload)
+            Result.Success
+        } catch (e: Exception) {
+            Result.InternalError(e)
+        }
+    }
+
+    sealed interface Result {
+        data object Success : Result
+        data class InternalError(val error: Exception) : Result
+    }
+}
+
+internal class HideCategory(
+    private val repository: CategoryRepositoryOps,
+) {
+    suspend fun await(category: Category): Result = withNonCancellableContext {
+        val update = CategoryUpdate(
+            id = category.id,
+            hidden = !category.hidden,
+        )
+
+        try {
+            repository.updatePartialCategory(update)
+            Result.Success
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e)
+            Result.InternalError(e)
+        }
+    }
+
+    sealed class Result {
+        data object Success : Result()
+        data class InternalError(val error: Exception) : Result()
+    }
+}
+
+internal class ReorderCategory(
+    private val repository: CategoryRepositoryOps,
+) {
+    suspend fun await(category: Category, newIndex: Int): Result = withNonCancellableContext {
+        val categories = repository.getAllCategories()
+            .filterNot(Category::isSystemCategory)
+            .toMutableList()
+
+        val currentIndex = categories.indexOfFirst { it.id == category.id }
+        if (currentIndex == -1) {
+            return@withNonCancellableContext Result.Unchanged
+        }
+
+        try {
+            categories.add(newIndex, categories.removeAt(currentIndex))
+
+            val updates = categories.mapIndexed { index, movedCategory ->
+                CategoryUpdate(
+                    id = movedCategory.id,
+                    order = index.toLong(),
+                )
+            }
+
+            repository.updatePartialCategories(updates)
+            Result.Success
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e)
+            Result.InternalError(e)
+        }
+    }
+
+    sealed interface Result {
+        data object Success : Result
+        data object Unchanged : Result
+        data class InternalError(val error: Exception) : Result
+    }
+}
+
+internal class SetCategoryAlphabeticalSort(
+    private val repository: CategoryRepositoryOps,
+) {
+    suspend fun await(enabled: Boolean) {
+        val updates = repository.getAllCategories().map { category ->
+            val updatedFlags = if (enabled) {
+                category.flags or CategoryFlags.CATEGORY_FLAG_SORT_ALPHABETICAL
+            } else {
+                category.flags and CategoryFlags.CATEGORY_FLAG_SORT_ALPHABETICAL.inv()
+            }
+            CategoryUpdate(
+                id = category.id,
+                flags = updatedFlags,
+            )
+        }
+        repository.updatePartialCategories(updates)
+    }
+}
+
+internal class ResetCategoryFlags(
+    private val repository: CategoryRepositoryOps,
+) {
+    suspend fun await(sortFlags: Long) {
+        val updates = repository.getAllCategories().map {
+            CategoryUpdate(
+                id = it.id,
+                flags = (it.flags and SORT_MASK.inv()) + sortFlags,
+            )
+        }
+        repository.updatePartialCategories(updates)
+    }
+
+    private companion object {
+        const val SORT_MASK = 0b01111100L
+    }
+}
+
+internal suspend fun setSortModeForCategory(
+    repository: CategoryRepositoryOps,
+    categoryId: Long?,
+    type: Flag,
+    direction: Flag,
+    sortMask: Long,
+    categorizedDisplaySettings: Boolean,
+    isRandomSort: Boolean,
+    onRandomSortSelected: () -> Unit,
+    onGlobalSortSelected: () -> Unit,
+) {
+    val category = categoryId?.let { repository.getCategory(it) }
+    val flags = ((category?.flags ?: 0L) and sortMask.inv()) + type + direction
+    if (isRandomSort) {
+        onRandomSortSelected()
+    }
+    if (category != null && categorizedDisplaySettings) {
+        repository.updatePartialCategory(
+            CategoryUpdate(
+                id = category.id,
+                flags = flags,
+            ),
+        )
+    } else {
+        onGlobalSortSelected()
+        val updates = repository.getAllCategories().map {
+            CategoryUpdate(
+                id = it.id,
+                flags = (it.flags and sortMask.inv()) + type + direction,
+            )
+        }
+        repository.updatePartialCategories(updates)
+    }
+}
+
+internal class DeleteCategory(
+    private val repository: CategoryRepositoryOps,
+    private val defaultCategory: Preference<Int>,
+    private val categoryPreferences: List<Preference<Set<String>>>,
+) {
+    suspend fun await(categoryId: Long): Result = withNonCancellableContext {
+        try {
+            repository.deleteCategory(categoryId)
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e)
+            return@withNonCancellableContext Result.InternalError(e)
+        }
+
+        val categories = repository.getAllCategories()
+        val updates = categories.mapIndexed { index, category ->
+            CategoryUpdate(
+                id = category.id,
+                order = index.toLong(),
+                parentId = if (category.parentId == categoryId) null else category.parentId,
+                updateParentId = category.parentId == categoryId,
+            )
+        }
+
+        if (defaultCategory.get() == categoryId.toInt()) {
+            defaultCategory.delete()
+        }
+
+        val categoryIdString = categoryId.toString()
+        categoryPreferences.forEach { preference ->
+            val ids = preference.get()
+            if (categoryIdString !in ids) return@forEach
+            preference.set(ids.minus(categoryIdString))
+        }
+
+        try {
+            repository.updatePartialCategories(updates)
+            Result.Success
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e)
+            Result.InternalError(e)
+        }
+    }
+
+    sealed interface Result {
+        data object Success : Result
+        data class InternalError(val error: Exception) : Result
+    }
+}
+
+internal class SetEntryCategories(
+    private val setCategories: suspend (entryId: Long, categoryIds: List<Long>) -> Unit,
+) {
+    suspend fun await(entryId: Long, categoryIds: List<Long>) {
+        try {
+            setCategories(entryId, categoryIds)
+        } catch (e: Exception) {
+            logcat(LogPriority.ERROR, e)
+        }
+    }
+}
+
+internal class SetCategoryDisplayMode(
+    private val preferences: LibraryPreferences,
+) {
+    fun await(display: LibraryDisplayMode) {
+        preferences.displayMode().set(display)
+    }
+}

--- a/domain/src/main/java/tachiyomi/domain/category/interactor/CategoryRepositoryOps.kt
+++ b/domain/src/main/java/tachiyomi/domain/category/interactor/CategoryRepositoryOps.kt
@@ -1,0 +1,109 @@
+package tachiyomi.domain.category.interactor
+
+import kotlinx.coroutines.flow.Flow
+import tachiyomi.domain.category.anime.repository.AnimeCategoryRepository
+import tachiyomi.domain.category.manga.repository.MangaCategoryRepository
+import tachiyomi.domain.category.model.Category
+import tachiyomi.domain.category.model.CategoryUpdate
+
+internal interface CategoryRepositoryOps {
+    suspend fun getCategory(id: Long): Category?
+
+    suspend fun getAllCategories(): List<Category>
+
+    suspend fun getAllVisibleCategories(): List<Category>
+
+    fun getAllCategoriesAsFlow(): Flow<List<Category>>
+
+    fun getAllVisibleCategoriesAsFlow(): Flow<List<Category>>
+
+    suspend fun getCategoriesByEntryId(entryId: Long): List<Category>
+
+    suspend fun getVisibleCategoriesByEntryId(entryId: Long): List<Category>
+
+    fun getCategoriesByEntryIdAsFlow(entryId: Long): Flow<List<Category>>
+
+    fun getVisibleCategoriesByEntryIdAsFlow(entryId: Long): Flow<List<Category>>
+
+    suspend fun insertCategory(category: Category)
+
+    suspend fun updatePartialCategory(update: CategoryUpdate)
+
+    suspend fun updatePartialCategories(updates: List<CategoryUpdate>)
+
+    suspend fun updateAllCategoryFlags(flags: Long?)
+
+    suspend fun deleteCategory(categoryId: Long)
+}
+
+internal fun AnimeCategoryRepository.asCategoryRepositoryOps(): CategoryRepositoryOps =
+    object : CategoryRepositoryOps {
+        override suspend fun getCategory(id: Long): Category? = getAnimeCategory(id)
+
+        override suspend fun getAllCategories(): List<Category> = getAllAnimeCategories()
+
+        override suspend fun getAllVisibleCategories(): List<Category> = getAllVisibleAnimeCategories()
+
+        override fun getAllCategoriesAsFlow(): Flow<List<Category>> = getAllAnimeCategoriesAsFlow()
+
+        override fun getAllVisibleCategoriesAsFlow(): Flow<List<Category>> = getAllVisibleAnimeCategoriesAsFlow()
+
+        override suspend fun getCategoriesByEntryId(entryId: Long): List<Category> =
+            getCategoriesByAnimeId(entryId)
+
+        override suspend fun getVisibleCategoriesByEntryId(entryId: Long): List<Category> =
+            getVisibleCategoriesByAnimeId(entryId)
+
+        override fun getCategoriesByEntryIdAsFlow(entryId: Long): Flow<List<Category>> =
+            getCategoriesByAnimeIdAsFlow(entryId)
+
+        override fun getVisibleCategoriesByEntryIdAsFlow(entryId: Long): Flow<List<Category>> =
+            getVisibleCategoriesByAnimeIdAsFlow(entryId)
+
+        override suspend fun insertCategory(category: Category) = insertAnimeCategory(category)
+
+        override suspend fun updatePartialCategory(update: CategoryUpdate) = updatePartialAnimeCategory(update)
+
+        override suspend fun updatePartialCategories(updates: List<CategoryUpdate>) =
+            updatePartialAnimeCategories(updates)
+
+        override suspend fun updateAllCategoryFlags(flags: Long?) = updateAllAnimeCategoryFlags(flags)
+
+        override suspend fun deleteCategory(categoryId: Long) = deleteAnimeCategory(categoryId)
+    }
+
+internal fun MangaCategoryRepository.asCategoryRepositoryOps(): CategoryRepositoryOps =
+    object : CategoryRepositoryOps {
+        override suspend fun getCategory(id: Long): Category? = getMangaCategory(id)
+
+        override suspend fun getAllCategories(): List<Category> = getAllMangaCategories()
+
+        override suspend fun getAllVisibleCategories(): List<Category> = getAllVisibleMangaCategories()
+
+        override fun getAllCategoriesAsFlow(): Flow<List<Category>> = getAllMangaCategoriesAsFlow()
+
+        override fun getAllVisibleCategoriesAsFlow(): Flow<List<Category>> = getAllVisibleMangaCategoriesAsFlow()
+
+        override suspend fun getCategoriesByEntryId(entryId: Long): List<Category> =
+            getCategoriesByMangaId(entryId)
+
+        override suspend fun getVisibleCategoriesByEntryId(entryId: Long): List<Category> =
+            getVisibleCategoriesByMangaId(entryId)
+
+        override fun getCategoriesByEntryIdAsFlow(entryId: Long): Flow<List<Category>> =
+            getCategoriesByMangaIdAsFlow(entryId)
+
+        override fun getVisibleCategoriesByEntryIdAsFlow(entryId: Long): Flow<List<Category>> =
+            getVisibleCategoriesByMangaIdAsFlow(entryId)
+
+        override suspend fun insertCategory(category: Category) = insertMangaCategory(category)
+
+        override suspend fun updatePartialCategory(update: CategoryUpdate) = updatePartialMangaCategory(update)
+
+        override suspend fun updatePartialCategories(updates: List<CategoryUpdate>) =
+            updatePartialMangaCategories(updates)
+
+        override suspend fun updateAllCategoryFlags(flags: Long?) = updateAllMangaCategoryFlags(flags)
+
+        override suspend fun deleteCategory(categoryId: Long) = deleteMangaCategory(categoryId)
+    }

--- a/domain/src/main/java/tachiyomi/domain/category/manga/interactor/CreateMangaCategoryWithName.kt
+++ b/domain/src/main/java/tachiyomi/domain/category/manga/interactor/CreateMangaCategoryWithName.kt
@@ -1,10 +1,8 @@
 package tachiyomi.domain.category.manga.interactor
 
-import logcat.LogPriority
-import tachiyomi.core.common.util.lang.withNonCancellableContext
-import tachiyomi.core.common.util.system.logcat
+import tachiyomi.domain.category.interactor.CreateCategoryWithName
+import tachiyomi.domain.category.interactor.asCategoryRepositoryOps
 import tachiyomi.domain.category.manga.repository.MangaCategoryRepository
-import tachiyomi.domain.category.model.Category
 import tachiyomi.domain.library.service.LibraryPreferences
 
 class CreateMangaCategoryWithName(
@@ -12,34 +10,19 @@ class CreateMangaCategoryWithName(
     private val preferences: LibraryPreferences,
 ) {
 
-    private val initialFlags: Long
-        get() {
+    private val createCategory = CreateCategoryWithName(
+        repository = categoryRepository.asCategoryRepositoryOps(),
+        initialFlags = {
             val sort = preferences.mangaSortingMode().get()
-            return sort.type.flag or sort.direction.flag
-        }
+            sort.type.flag or sort.direction.flag
+        },
+    )
 
-    suspend fun await(name: String, parentId: Long? = null): Result = withNonCancellableContext {
-        val categories = categoryRepository.getAllMangaCategories()
-        val validatedParentId = parentId?.let { id ->
-            categories.find { it.id == id && it.parentId == null }?.id
-                ?: return@withNonCancellableContext Result.InvalidParent
-        }
-        val nextOrder = categories.maxOfOrNull { it.order }?.plus(1) ?: 0
-        val newCategory = Category(
-            id = 0,
-            name = name,
-            order = nextOrder,
-            flags = initialFlags,
-            hidden = false,
-            parentId = validatedParentId,
-        )
-
-        try {
-            categoryRepository.insertMangaCategory(newCategory)
-            Result.Success
-        } catch (e: Exception) {
-            logcat(LogPriority.ERROR, e)
-            Result.InternalError(e)
+    suspend fun await(name: String, parentId: Long? = null): Result {
+        return when (val result = createCategory.await(name, parentId)) {
+            CreateCategoryWithName.Result.Success -> Result.Success
+            CreateCategoryWithName.Result.InvalidParent -> Result.InvalidParent
+            is CreateCategoryWithName.Result.InternalError -> Result.InternalError(result.error)
         }
     }
 

--- a/domain/src/main/java/tachiyomi/domain/category/manga/interactor/DeleteMangaCategory.kt
+++ b/domain/src/main/java/tachiyomi/domain/category/manga/interactor/DeleteMangaCategory.kt
@@ -1,10 +1,8 @@
 package tachiyomi.domain.category.manga.interactor
 
-import logcat.LogPriority
-import tachiyomi.core.common.util.lang.withNonCancellableContext
-import tachiyomi.core.common.util.system.logcat
+import tachiyomi.domain.category.interactor.DeleteCategory
+import tachiyomi.domain.category.interactor.asCategoryRepositoryOps
 import tachiyomi.domain.category.manga.repository.MangaCategoryRepository
-import tachiyomi.domain.category.model.CategoryUpdate
 import tachiyomi.domain.download.service.DownloadPreferences
 import tachiyomi.domain.library.service.LibraryPreferences
 
@@ -14,49 +12,22 @@ class DeleteMangaCategory(
     private val downloadPreferences: DownloadPreferences,
 ) {
 
-    suspend fun await(categoryId: Long) = withNonCancellableContext {
-        try {
-            categoryRepository.deleteMangaCategory(categoryId)
-        } catch (e: Exception) {
-            logcat(LogPriority.ERROR, e)
-            return@withNonCancellableContext Result.InternalError(e)
-        }
-
-        val categories = categoryRepository.getAllMangaCategories()
-        val updates = categories.mapIndexed { index, category ->
-            CategoryUpdate(
-                id = category.id,
-                order = index.toLong(),
-                parentId = if (category.parentId == categoryId) null else category.parentId,
-                updateParentId = category.parentId == categoryId,
-            )
-        }
-
-        val defaultCategory = libraryPreferences.defaultMangaCategory().get()
-        if (defaultCategory == categoryId.toInt()) {
-            libraryPreferences.defaultMangaCategory().delete()
-        }
-
-        val categoryPreferences = listOf(
+    private val deleteCategory = DeleteCategory(
+        repository = categoryRepository.asCategoryRepositoryOps(),
+        defaultCategory = libraryPreferences.defaultMangaCategory(),
+        categoryPreferences = listOf(
             libraryPreferences.mangaUpdateCategories(),
             libraryPreferences.mangaUpdateCategories(),
             downloadPreferences.removeExcludeCategories(),
             downloadPreferences.downloadNewChapterCategories(),
             downloadPreferences.downloadNewChapterCategoriesExclude(),
-        )
-        val categoryIdString = categoryId.toString()
-        categoryPreferences.forEach { preference ->
-            val ids = preference.get()
-            if (categoryIdString !in ids) return@forEach
-            preference.set(ids.minus(categoryIdString))
-        }
+        ),
+    )
 
-        try {
-            categoryRepository.updatePartialMangaCategories(updates)
-            Result.Success
-        } catch (e: Exception) {
-            logcat(LogPriority.ERROR, e)
-            Result.InternalError(e)
+    suspend fun await(categoryId: Long): Result {
+        return when (val result = deleteCategory.await(categoryId)) {
+            DeleteCategory.Result.Success -> Result.Success
+            is DeleteCategory.Result.InternalError -> Result.InternalError(result.error)
         }
     }
 

--- a/domain/src/main/java/tachiyomi/domain/category/manga/interactor/GetMangaCategories.kt
+++ b/domain/src/main/java/tachiyomi/domain/category/manga/interactor/GetMangaCategories.kt
@@ -1,25 +1,20 @@
 package tachiyomi.domain.category.manga.interactor
 
-import kotlinx.coroutines.flow.Flow
+import tachiyomi.domain.category.interactor.GetCategories
+import tachiyomi.domain.category.interactor.asCategoryRepositoryOps
 import tachiyomi.domain.category.manga.repository.MangaCategoryRepository
 import tachiyomi.domain.category.model.Category
 
 class GetMangaCategories(
     private val categoryRepository: MangaCategoryRepository,
 ) {
-    fun subscribe(): Flow<List<Category>> {
-        return categoryRepository.getAllMangaCategoriesAsFlow()
-    }
+    private val getCategories = GetCategories(categoryRepository.asCategoryRepositoryOps())
 
-    fun subscribe(mangaId: Long): Flow<List<Category>> {
-        return categoryRepository.getCategoriesByMangaIdAsFlow(mangaId)
-    }
+    fun subscribe() = getCategories.subscribe()
 
-    suspend fun await(): List<Category> {
-        return categoryRepository.getAllMangaCategories()
-    }
+    fun subscribe(mangaId: Long) = getCategories.subscribe(mangaId)
 
-    suspend fun await(mangaId: Long): List<Category> {
-        return categoryRepository.getCategoriesByMangaId(mangaId)
-    }
+    suspend fun await(): List<Category> = getCategories.await()
+
+    suspend fun await(mangaId: Long): List<Category> = getCategories.await(mangaId)
 }

--- a/domain/src/main/java/tachiyomi/domain/category/manga/interactor/GetVisibleMangaCategories.kt
+++ b/domain/src/main/java/tachiyomi/domain/category/manga/interactor/GetVisibleMangaCategories.kt
@@ -1,25 +1,20 @@
 package tachiyomi.domain.category.manga.interactor
 
-import kotlinx.coroutines.flow.Flow
+import tachiyomi.domain.category.interactor.GetVisibleCategories
+import tachiyomi.domain.category.interactor.asCategoryRepositoryOps
 import tachiyomi.domain.category.manga.repository.MangaCategoryRepository
 import tachiyomi.domain.category.model.Category
 
 class GetVisibleMangaCategories(
     private val categoryRepository: MangaCategoryRepository,
 ) {
-    fun subscribe(): Flow<List<Category>> {
-        return categoryRepository.getAllVisibleMangaCategoriesAsFlow()
-    }
+    private val getVisibleCategories = GetVisibleCategories(categoryRepository.asCategoryRepositoryOps())
 
-    fun subscribe(mangaId: Long): Flow<List<Category>> {
-        return categoryRepository.getVisibleCategoriesByMangaIdAsFlow(mangaId)
-    }
+    fun subscribe() = getVisibleCategories.subscribe()
 
-    suspend fun await(): List<Category> {
-        return categoryRepository.getAllVisibleMangaCategories()
-    }
+    fun subscribe(mangaId: Long) = getVisibleCategories.subscribe(mangaId)
 
-    suspend fun await(mangaId: Long): List<Category> {
-        return categoryRepository.getVisibleCategoriesByMangaId(mangaId)
-    }
+    suspend fun await(): List<Category> = getVisibleCategories.await()
+
+    suspend fun await(mangaId: Long): List<Category> = getVisibleCategories.await(mangaId)
 }

--- a/domain/src/main/java/tachiyomi/domain/category/manga/interactor/HideMangaCategory.kt
+++ b/domain/src/main/java/tachiyomi/domain/category/manga/interactor/HideMangaCategory.kt
@@ -1,28 +1,20 @@
 package tachiyomi.domain.category.manga.interactor
 
-import logcat.LogPriority
-import tachiyomi.core.common.util.lang.withNonCancellableContext
-import tachiyomi.core.common.util.system.logcat
+import tachiyomi.domain.category.interactor.HideCategory
+import tachiyomi.domain.category.interactor.asCategoryRepositoryOps
 import tachiyomi.domain.category.manga.repository.MangaCategoryRepository
 import tachiyomi.domain.category.model.Category
-import tachiyomi.domain.category.model.CategoryUpdate
 
 class HideMangaCategory(
     private val categoryRepository: MangaCategoryRepository,
 ) {
 
-    suspend fun await(category: Category) = withNonCancellableContext {
-        val update = CategoryUpdate(
-            id = category.id,
-            hidden = !category.hidden,
-        )
+    private val hideCategory = HideCategory(categoryRepository.asCategoryRepositoryOps())
 
-        try {
-            categoryRepository.updatePartialMangaCategory(update)
-            Result.Success
-        } catch (e: Exception) {
-            logcat(LogPriority.ERROR, e)
-            Result.InternalError(e)
+    suspend fun await(category: Category): Result {
+        return when (val result = hideCategory.await(category)) {
+            HideCategory.Result.Success -> Result.Success
+            is HideCategory.Result.InternalError -> Result.InternalError(result.error)
         }
     }
 

--- a/domain/src/main/java/tachiyomi/domain/category/manga/interactor/RenameMangaCategory.kt
+++ b/domain/src/main/java/tachiyomi/domain/category/manga/interactor/RenameMangaCategory.kt
@@ -1,28 +1,20 @@
 package tachiyomi.domain.category.manga.interactor
 
-import logcat.LogPriority
-import tachiyomi.core.common.util.lang.withNonCancellableContext
-import tachiyomi.core.common.util.system.logcat
+import tachiyomi.domain.category.interactor.RenameCategory
+import tachiyomi.domain.category.interactor.asCategoryRepositoryOps
 import tachiyomi.domain.category.manga.repository.MangaCategoryRepository
 import tachiyomi.domain.category.model.Category
-import tachiyomi.domain.category.model.CategoryUpdate
 
 class RenameMangaCategory(
     private val categoryRepository: MangaCategoryRepository,
 ) {
 
-    suspend fun await(categoryId: Long, name: String) = withNonCancellableContext {
-        val update = CategoryUpdate(
-            id = categoryId,
-            name = name,
-        )
+    private val renameCategory = RenameCategory(categoryRepository.asCategoryRepositoryOps())
 
-        try {
-            categoryRepository.updatePartialMangaCategory(update)
-            Result.Success
-        } catch (e: Exception) {
-            logcat(LogPriority.ERROR, e)
-            Result.InternalError(e)
+    suspend fun await(categoryId: Long, name: String): Result {
+        return when (val result = renameCategory.await(categoryId, name)) {
+            RenameCategory.Result.Success -> Result.Success
+            is RenameCategory.Result.InternalError -> Result.InternalError(result.error)
         }
     }
 

--- a/domain/src/main/java/tachiyomi/domain/category/manga/interactor/ReorderMangaCategory.kt
+++ b/domain/src/main/java/tachiyomi/domain/category/manga/interactor/ReorderMangaCategory.kt
@@ -2,45 +2,25 @@ package tachiyomi.domain.category.manga.interactor
 
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import logcat.LogPriority
 import tachiyomi.core.common.util.lang.withNonCancellableContext
-import tachiyomi.core.common.util.system.logcat
+import tachiyomi.domain.category.interactor.ReorderCategory
+import tachiyomi.domain.category.interactor.asCategoryRepositoryOps
 import tachiyomi.domain.category.manga.repository.MangaCategoryRepository
 import tachiyomi.domain.category.model.Category
-import tachiyomi.domain.category.model.CategoryUpdate
 
 class ReorderMangaCategory(
     private val categoryRepository: MangaCategoryRepository,
 ) {
 
     private val mutex = Mutex()
+    private val reorderCategory = ReorderCategory(categoryRepository.asCategoryRepositoryOps())
 
     suspend fun await(category: Category, newIndex: Int) = withNonCancellableContext {
         mutex.withLock {
-            val categories = categoryRepository.getAllMangaCategories()
-                .filterNot(Category::isSystemCategory)
-                .toMutableList()
-
-            val currentIndex = categories.indexOfFirst { it.id == category.id }
-            if (currentIndex == -1) {
-                return@withNonCancellableContext Result.Unchanged
-            }
-
-            try {
-                categories.add(newIndex, categories.removeAt(currentIndex))
-
-                val updates = categories.mapIndexed { index, category ->
-                    CategoryUpdate(
-                        id = category.id,
-                        order = index.toLong(),
-                    )
-                }
-
-                categoryRepository.updatePartialMangaCategories(updates)
-                Result.Success
-            } catch (e: Exception) {
-                logcat(LogPriority.ERROR, e)
-                Result.InternalError(e)
+            when (val result = reorderCategory.await(category, newIndex)) {
+                ReorderCategory.Result.Success -> Result.Success
+                ReorderCategory.Result.Unchanged -> Result.Unchanged
+                is ReorderCategory.Result.InternalError -> Result.InternalError(result.error)
             }
         }
     }

--- a/domain/src/main/java/tachiyomi/domain/category/manga/interactor/ResetMangaCategoryFlags.kt
+++ b/domain/src/main/java/tachiyomi/domain/category/manga/interactor/ResetMangaCategoryFlags.kt
@@ -1,7 +1,8 @@
 package tachiyomi.domain.category.manga.interactor
 
+import tachiyomi.domain.category.interactor.ResetCategoryFlags
+import tachiyomi.domain.category.interactor.asCategoryRepositoryOps
 import tachiyomi.domain.category.manga.repository.MangaCategoryRepository
-import tachiyomi.domain.category.model.CategoryUpdate
 import tachiyomi.domain.library.model.plus
 import tachiyomi.domain.library.service.LibraryPreferences
 
@@ -10,17 +11,10 @@ class ResetMangaCategoryFlags(
     private val categoryRepository: MangaCategoryRepository,
 ) {
 
-    private val sortMask = 0b01111100L
+    private val resetCategoryFlags = ResetCategoryFlags(categoryRepository.asCategoryRepositoryOps())
 
     suspend fun await() {
         val sort = preferences.mangaSortingMode().get()
-        val updates = categoryRepository.getAllMangaCategories().map {
-            // Reset only sort mode bits; keep auxiliary flags such as alphabetical category sorting.
-            CategoryUpdate(
-                id = it.id,
-                flags = (it.flags and sortMask.inv()) + sort.type + sort.direction,
-            )
-        }
-        categoryRepository.updatePartialMangaCategories(updates)
+        resetCategoryFlags.await(sort.type + sort.direction)
     }
 }

--- a/domain/src/main/java/tachiyomi/domain/category/manga/interactor/SetMangaCategories.kt
+++ b/domain/src/main/java/tachiyomi/domain/category/manga/interactor/SetMangaCategories.kt
@@ -1,18 +1,15 @@
 package tachiyomi.domain.category.manga.interactor
 
-import logcat.LogPriority
-import tachiyomi.core.common.util.system.logcat
+import tachiyomi.domain.category.interactor.SetEntryCategories
 import tachiyomi.domain.entries.manga.repository.MangaRepository
 
 class SetMangaCategories(
     private val mangaRepository: MangaRepository,
 ) {
 
+    private val setEntryCategories = SetEntryCategories(mangaRepository::setMangaCategories)
+
     suspend fun await(mangaId: Long, categoryIds: List<Long>) {
-        try {
-            mangaRepository.setMangaCategories(mangaId, categoryIds)
-        } catch (e: Exception) {
-            logcat(LogPriority.ERROR, e)
-        }
+        setEntryCategories.await(mangaId, categoryIds)
     }
 }

--- a/domain/src/main/java/tachiyomi/domain/category/manga/interactor/SetMangaCategoryAlphabeticalSort.kt
+++ b/domain/src/main/java/tachiyomi/domain/category/manga/interactor/SetMangaCategoryAlphabeticalSort.kt
@@ -1,25 +1,17 @@
 package tachiyomi.domain.category.manga.interactor
 
+import tachiyomi.domain.category.interactor.SetCategoryAlphabeticalSort
+import tachiyomi.domain.category.interactor.asCategoryRepositoryOps
 import tachiyomi.domain.category.manga.repository.MangaCategoryRepository
-import tachiyomi.domain.category.model.CategoryFlags
-import tachiyomi.domain.category.model.CategoryUpdate
 
 class SetMangaCategoryAlphabeticalSort(
     private val categoryRepository: MangaCategoryRepository,
 ) {
 
+    private val setCategoryAlphabeticalSort =
+        SetCategoryAlphabeticalSort(categoryRepository.asCategoryRepositoryOps())
+
     suspend fun await(enabled: Boolean) {
-        val updates = categoryRepository.getAllMangaCategories().map { category ->
-            val updatedFlags = if (enabled) {
-                category.flags or CategoryFlags.CATEGORY_FLAG_SORT_ALPHABETICAL
-            } else {
-                category.flags and CategoryFlags.CATEGORY_FLAG_SORT_ALPHABETICAL.inv()
-            }
-            CategoryUpdate(
-                id = category.id,
-                flags = updatedFlags,
-            )
-        }
-        categoryRepository.updatePartialMangaCategories(updates)
+        setCategoryAlphabeticalSort.await(enabled)
     }
 }

--- a/domain/src/main/java/tachiyomi/domain/category/manga/interactor/SetMangaDisplayMode.kt
+++ b/domain/src/main/java/tachiyomi/domain/category/manga/interactor/SetMangaDisplayMode.kt
@@ -1,5 +1,6 @@
 package tachiyomi.domain.category.manga.interactor
 
+import tachiyomi.domain.category.interactor.SetCategoryDisplayMode
 import tachiyomi.domain.library.model.LibraryDisplayMode
 import tachiyomi.domain.library.service.LibraryPreferences
 
@@ -7,7 +8,9 @@ class SetMangaDisplayMode(
     private val preferences: LibraryPreferences,
 ) {
 
+    private val setCategoryDisplayMode = SetCategoryDisplayMode(preferences)
+
     fun await(display: LibraryDisplayMode) {
-        preferences.displayMode().set(display)
+        setCategoryDisplayMode.await(display)
     }
 }

--- a/domain/src/main/java/tachiyomi/domain/category/manga/interactor/SetSortModeForMangaCategory.kt
+++ b/domain/src/main/java/tachiyomi/domain/category/manga/interactor/SetSortModeForMangaCategory.kt
@@ -1,10 +1,10 @@
 package tachiyomi.domain.category.manga.interactor
 
+import tachiyomi.domain.category.interactor.asCategoryRepositoryOps
+import tachiyomi.domain.category.interactor.setSortModeForCategory
 import tachiyomi.domain.category.manga.repository.MangaCategoryRepository
 import tachiyomi.domain.category.model.Category
-import tachiyomi.domain.category.model.CategoryUpdate
 import tachiyomi.domain.library.manga.model.MangaLibrarySort
-import tachiyomi.domain.library.model.plus
 import tachiyomi.domain.library.service.LibraryPreferences
 import kotlin.random.Random
 
@@ -13,6 +13,7 @@ class SetSortModeForMangaCategory(
     private val categoryRepository: MangaCategoryRepository,
 ) {
 
+    private val categoryOps = categoryRepository.asCategoryRepositoryOps()
     private val sortMask: Long = MangaLibrarySort.Type.Alphabetical.mask or MangaLibrarySort.Direction.Ascending.mask
 
     suspend fun await(
@@ -20,28 +21,17 @@ class SetSortModeForMangaCategory(
         type: MangaLibrarySort.Type,
         direction: MangaLibrarySort.Direction,
     ) {
-        val category = categoryId?.let { categoryRepository.getMangaCategory(it) }
-        val flags = ((category?.flags ?: 0L) and sortMask.inv()) + type + direction
-        if (type == MangaLibrarySort.Type.Random) {
-            preferences.randomMangaSortSeed().set(Random.nextInt())
-        }
-        if (category != null && preferences.categorizedDisplaySettings().get()) {
-            categoryRepository.updatePartialMangaCategory(
-                CategoryUpdate(
-                    id = category.id,
-                    flags = flags,
-                ),
-            )
-        } else {
-            preferences.mangaSortingMode().set(MangaLibrarySort(type, direction))
-            val updates = categoryRepository.getAllMangaCategories().map {
-                CategoryUpdate(
-                    id = it.id,
-                    flags = (it.flags and sortMask.inv()) + type + direction,
-                )
-            }
-            categoryRepository.updatePartialMangaCategories(updates)
-        }
+        setSortModeForCategory(
+            repository = categoryOps,
+            categoryId = categoryId,
+            type = type,
+            direction = direction,
+            sortMask = sortMask,
+            categorizedDisplaySettings = preferences.categorizedDisplaySettings().get(),
+            isRandomSort = type == MangaLibrarySort.Type.Random,
+            onRandomSortSelected = { preferences.randomMangaSortSeed().set(Random.nextInt()) },
+            onGlobalSortSelected = { preferences.mangaSortingMode().set(MangaLibrarySort(type, direction)) },
+        )
     }
 
     suspend fun await(

--- a/domain/src/main/java/tachiyomi/domain/category/manga/interactor/UpdateMangaCategory.kt
+++ b/domain/src/main/java/tachiyomi/domain/category/manga/interactor/UpdateMangaCategory.kt
@@ -1,6 +1,7 @@
 package tachiyomi.domain.category.manga.interactor
 
-import tachiyomi.core.common.util.lang.withNonCancellableContext
+import tachiyomi.domain.category.interactor.UpdateCategory
+import tachiyomi.domain.category.interactor.asCategoryRepositoryOps
 import tachiyomi.domain.category.manga.repository.MangaCategoryRepository
 import tachiyomi.domain.category.model.CategoryUpdate
 
@@ -8,12 +9,12 @@ class UpdateMangaCategory(
     private val categoryRepository: MangaCategoryRepository,
 ) {
 
-    suspend fun await(payload: CategoryUpdate): Result = withNonCancellableContext {
-        try {
-            categoryRepository.updatePartialMangaCategory(payload)
-            Result.Success
-        } catch (e: Exception) {
-            Result.Error(e)
+    private val updateCategory = UpdateCategory(categoryRepository.asCategoryRepositoryOps())
+
+    suspend fun await(payload: CategoryUpdate): Result {
+        return when (val result = updateCategory.await(payload)) {
+            UpdateCategory.Result.Success -> Result.Success
+            is UpdateCategory.Result.InternalError -> Result.Error(result.error)
         }
     }
 

--- a/domain/src/test/java/tachiyomi/domain/category/interactor/CategoryInteractorOperationsTest.kt
+++ b/domain/src/test/java/tachiyomi/domain/category/interactor/CategoryInteractorOperationsTest.kt
@@ -1,0 +1,475 @@
+package tachiyomi.domain.category.interactor
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import tachiyomi.core.common.preference.Preference
+import tachiyomi.domain.category.anime.interactor.HideAnimeCategory
+import tachiyomi.domain.category.anime.repository.AnimeCategoryRepository
+import tachiyomi.domain.category.model.Category
+import tachiyomi.domain.category.model.CategoryFlags
+import tachiyomi.domain.category.model.CategoryUpdate
+import tachiyomi.domain.library.model.FlagWithMask
+import tachiyomi.domain.library.model.plus
+
+class CategoryInteractorOperationsTest {
+
+    @Test
+    fun `create validates parent and assigns next order with initial flags`() = runTest {
+        val parent = category(id = 1, name = "Parent", order = 0)
+        val child = category(id = 2, name = "Child", order = 1, parentId = 1)
+        val repository = FakeCategoryRepositoryOps(listOf(parent, child))
+        val createCategory = CreateCategoryWithName(repository) { INITIAL_FLAGS }
+
+        val result = createCategory.await(name = "New", parentId = parent.id)
+
+        assertEquals(CreateCategoryWithName.Result.Success, result)
+        assertEquals(
+            category(
+                id = 0,
+                name = "New",
+                order = 2,
+                flags = INITIAL_FLAGS,
+                parentId = parent.id,
+            ),
+            repository.insertedCategory,
+        )
+    }
+
+    @Test
+    fun `create rejects child category as parent`() = runTest {
+        val child = category(id = 2, name = "Child", order = 1, parentId = 1)
+        val repository = FakeCategoryRepositoryOps(listOf(child))
+        val createCategory = CreateCategoryWithName(repository) { INITIAL_FLAGS }
+
+        val result = createCategory.await(name = "New", parentId = child.id)
+
+        assertEquals(CreateCategoryWithName.Result.InvalidParent, result)
+        assertEquals(null, repository.insertedCategory)
+    }
+
+    @Test
+    fun `rename update and hide produce expected category updates`() = runTest {
+        val category = category(id = 1, name = "Old", order = 0, hidden = false)
+        val repository = FakeCategoryRepositoryOps(listOf(category))
+
+        assertEquals(RenameCategory.Result.Success, RenameCategory(repository).await(category, "New"))
+        assertEquals(CategoryUpdate(id = 1, name = "New"), repository.singleUpdate())
+
+        repository.clearUpdates()
+        assertEquals(
+            UpdateCategory.Result.Success,
+            UpdateCategory(repository).await(CategoryUpdate(id = 1, flags = 99L)),
+        )
+        assertEquals(CategoryUpdate(id = 1, flags = 99L), repository.singleUpdate())
+
+        repository.clearUpdates()
+        assertEquals(HideCategory.Result.Success, HideCategory(repository).await(category))
+        assertEquals(CategoryUpdate(id = 1, hidden = true), repository.singleUpdate())
+    }
+
+    @Test
+    fun `anime hide facade returns anime success result`() = runTest {
+        val category = category(id = 1, name = "Anime", order = 0, hidden = false)
+        val repository = FakeAnimeCategoryRepository(listOf(category))
+
+        val result = HideAnimeCategory(repository).await(category)
+
+        assertEquals(HideAnimeCategory.Result.Success, result)
+        assertEquals(CategoryUpdate(id = 1, hidden = true), repository.singleUpdate())
+    }
+
+    @Test
+    fun `reorder ignores system category and rewrites user category order`() = runTest {
+        val first = category(id = 1, name = "First", order = 0)
+        val second = category(id = 2, name = "Second", order = 1)
+        val repository = FakeCategoryRepositoryOps(
+            listOf(
+                category(id = Category.UNCATEGORIZED_ID, name = "System", order = -1),
+                first,
+                second,
+            ),
+        )
+
+        val result = ReorderCategory(repository).await(second, newIndex = 0)
+
+        assertEquals(ReorderCategory.Result.Success, result)
+        assertEquals(
+            listOf(
+                CategoryUpdate(id = 2, order = 0),
+                CategoryUpdate(id = 1, order = 1),
+            ),
+            repository.updates,
+        )
+    }
+
+    @Test
+    fun `reorder returns unchanged for missing category`() = runTest {
+        val repository = FakeCategoryRepositoryOps(listOf(category(id = 1, name = "Only", order = 0)))
+
+        val result = ReorderCategory(repository).await(category(id = 99, name = "Missing", order = 99), newIndex = 0)
+
+        assertEquals(ReorderCategory.Result.Unchanged, result)
+        assertTrue(repository.updates.isEmpty())
+    }
+
+    @Test
+    fun `alphabetical sort sets and clears only alphabetical sort flag`() = runTest {
+        val readingListFlag = CategoryFlags.CATEGORY_FLAG_IS_READING_LIST
+        val repository = FakeCategoryRepositoryOps(
+            listOf(
+                category(id = 1, name = "One", order = 0, flags = readingListFlag),
+                category(
+                    id = 2,
+                    name = "Two",
+                    order = 1,
+                    flags =
+                    readingListFlag or CategoryFlags.CATEGORY_FLAG_SORT_ALPHABETICAL,
+                ),
+            ),
+        )
+
+        SetCategoryAlphabeticalSort(repository).await(enabled = true)
+
+        assertEquals(
+            listOf(
+                CategoryUpdate(id = 1, flags = readingListFlag or CategoryFlags.CATEGORY_FLAG_SORT_ALPHABETICAL),
+                CategoryUpdate(id = 2, flags = readingListFlag or CategoryFlags.CATEGORY_FLAG_SORT_ALPHABETICAL),
+            ),
+            repository.updates,
+        )
+
+        repository.clearUpdates()
+        SetCategoryAlphabeticalSort(repository).await(enabled = false)
+
+        assertEquals(
+            listOf(
+                CategoryUpdate(id = 1, flags = readingListFlag),
+                CategoryUpdate(id = 2, flags = readingListFlag),
+            ),
+            repository.updates,
+        )
+    }
+
+    @Test
+    fun `reset flags preserves auxiliary flags while replacing sort bits`() = runTest {
+        val auxiliaryFlags =
+            CategoryFlags.CATEGORY_FLAG_IS_READING_LIST or CategoryFlags.CATEGORY_FLAG_SORT_ALPHABETICAL
+        val repository = FakeCategoryRepositoryOps(
+            listOf(
+                category(id = 1, name = "One", order = 0, flags = auxiliaryFlags or OLD_SORT_FLAG),
+            ),
+        )
+
+        ResetCategoryFlags(repository).await(sortFlags = NEW_SORT_FLAG)
+
+        assertEquals(
+            listOf(
+                CategoryUpdate(
+                    id = 1,
+                    flags = auxiliaryFlags or NEW_SORT_FLAG,
+                ),
+            ),
+            repository.updates,
+        )
+    }
+
+    @Test
+    fun `sort mode updates single category when categorized settings are enabled`() = runTest {
+        val category = category(id = 1, name = "One", order = 0, flags = CategoryFlags.CATEGORY_FLAG_IS_READING_LIST)
+        val repository = FakeCategoryRepositoryOps(listOf(category))
+        var globalSortUpdated = false
+        var randomSeedUpdated = false
+
+        setSortModeForCategory(
+            repository = repository,
+            categoryId = category.id,
+            type = SortTypeRandom,
+            direction = SortDirectionAscending,
+            sortMask = SORT_MASK,
+            categorizedDisplaySettings = true,
+            isRandomSort = true,
+            onRandomSortSelected = { randomSeedUpdated = true },
+            onGlobalSortSelected = { globalSortUpdated = true },
+        )
+
+        assertTrue(randomSeedUpdated)
+        assertFalse(globalSortUpdated)
+        assertEquals(
+            CategoryUpdate(
+                id = category.id,
+                flags = CategoryFlags.CATEGORY_FLAG_IS_READING_LIST + SortTypeRandom + SortDirectionAscending,
+            ),
+            repository.singleUpdate(),
+        )
+    }
+
+    @Test
+    fun `sort mode updates global sort and all categories when category settings are disabled`() = runTest {
+        val repository = FakeCategoryRepositoryOps(
+            listOf(
+                category(id = 1, name = "One", order = 0, flags = CategoryFlags.CATEGORY_FLAG_IS_READING_LIST),
+                category(id = 2, name = "Two", order = 1, flags = OLD_SORT_FLAG),
+            ),
+        )
+        var globalSortUpdated = false
+
+        setSortModeForCategory(
+            repository = repository,
+            categoryId = 1L,
+            type = SortTypeAlphabetical,
+            direction = SortDirectionAscending,
+            sortMask = SORT_MASK,
+            categorizedDisplaySettings = false,
+            isRandomSort = false,
+            onRandomSortSelected = {},
+            onGlobalSortSelected = { globalSortUpdated = true },
+        )
+
+        assertTrue(globalSortUpdated)
+        assertEquals(
+            listOf(
+                CategoryUpdate(
+                    id = 1,
+                    flags =
+                    CategoryFlags.CATEGORY_FLAG_IS_READING_LIST + SortTypeAlphabetical + SortDirectionAscending,
+                ),
+                CategoryUpdate(id = 2, flags = SortTypeAlphabetical + SortDirectionAscending),
+            ),
+            repository.updates,
+        )
+    }
+
+    @Test
+    fun `delete reparents children compacts order clears default and removes category preferences`() = runTest {
+        val categoryId = 2L
+        val defaultCategory = MutablePreference(defaultValue = -1, initialValue = categoryId.toInt())
+        val includePreference = MutablePreference(defaultValue = emptySet<String>(), initialValue = setOf("1", "2"))
+        val excludePreference = MutablePreference(defaultValue = emptySet<String>(), initialValue = setOf("2", "3"))
+        val untouchedPreference = MutablePreference(defaultValue = emptySet<String>(), initialValue = setOf("9"))
+        val repository = FakeCategoryRepositoryOps(
+            listOf(
+                category(id = 1, name = "Parent", order = 0),
+                category(id = categoryId, name = "Deleted", order = 1),
+                category(id = 3, name = "Child", order = 2, parentId = categoryId),
+                category(id = 4, name = "Later", order = 3),
+            ),
+        )
+        val deleteCategory = DeleteCategory(
+            repository = repository,
+            defaultCategory = defaultCategory,
+            categoryPreferences = listOf(includePreference, excludePreference, untouchedPreference),
+        )
+
+        val result = deleteCategory.await(categoryId)
+
+        assertEquals(DeleteCategory.Result.Success, result)
+        assertEquals(-1, defaultCategory.get())
+        assertEquals(setOf("1"), includePreference.get())
+        assertEquals(setOf("3"), excludePreference.get())
+        assertEquals(setOf("9"), untouchedPreference.get())
+        assertEquals(
+            listOf(
+                CategoryUpdate(id = 1, order = 0, parentId = null, updateParentId = false),
+                CategoryUpdate(id = 3, order = 1, parentId = null, updateParentId = true),
+                CategoryUpdate(id = 4, order = 2, parentId = null, updateParentId = false),
+            ),
+            repository.updates,
+        )
+    }
+
+    @Test
+    fun `delete reports internal error when repository delete fails`() = runTest {
+        val repository = FakeCategoryRepositoryOps(emptyList())
+        repository.deleteError = IllegalStateException("boom")
+        val deleteCategory = DeleteCategory(
+            repository = repository,
+            defaultCategory = MutablePreference(defaultValue = -1, initialValue = -1),
+            categoryPreferences = emptyList(),
+        )
+
+        val result = deleteCategory.await(1L)
+
+        assertInstanceOf(DeleteCategory.Result.InternalError::class.java, result)
+    }
+
+    private class FakeCategoryRepositoryOps(
+        initialCategories: List<Category>,
+    ) : CategoryRepositoryOps {
+
+        private val categories = initialCategories.toMutableList()
+        val updates = mutableListOf<CategoryUpdate>()
+        var insertedCategory: Category? = null
+            private set
+        var deleteError: Exception? = null
+
+        override suspend fun getCategory(id: Long): Category? = categories.find { it.id == id }
+
+        override suspend fun getAllCategories(): List<Category> = categories.toList()
+
+        override suspend fun getAllVisibleCategories(): List<Category> = categories.filterNot { it.hidden }
+
+        override fun getAllCategoriesAsFlow(): Flow<List<Category>> = MutableStateFlow(categories.toList())
+
+        override fun getAllVisibleCategoriesAsFlow(): Flow<List<Category>> =
+            MutableStateFlow(categories.filterNot { it.hidden })
+
+        override suspend fun getCategoriesByEntryId(entryId: Long): List<Category> = categories.toList()
+
+        override suspend fun getVisibleCategoriesByEntryId(entryId: Long): List<Category> =
+            categories.filterNot { it.hidden }
+
+        override fun getCategoriesByEntryIdAsFlow(entryId: Long): Flow<List<Category>> =
+            MutableStateFlow(categories.toList())
+
+        override fun getVisibleCategoriesByEntryIdAsFlow(entryId: Long): Flow<List<Category>> =
+            MutableStateFlow(categories.filterNot { it.hidden })
+
+        override suspend fun insertCategory(category: Category) {
+            insertedCategory = category
+        }
+
+        override suspend fun updatePartialCategory(update: CategoryUpdate) {
+            updates += update
+        }
+
+        override suspend fun updatePartialCategories(updates: List<CategoryUpdate>) {
+            this.updates += updates
+        }
+
+        override suspend fun updateAllCategoryFlags(flags: Long?) = Unit
+
+        override suspend fun deleteCategory(categoryId: Long) {
+            deleteError?.let { throw it }
+            categories.removeAll { it.id == categoryId }
+        }
+
+        fun singleUpdate(): CategoryUpdate = updates.single()
+
+        fun clearUpdates() = updates.clear()
+    }
+
+    private class FakeAnimeCategoryRepository(
+        initialCategories: List<Category>,
+    ) : AnimeCategoryRepository {
+
+        private val categories = initialCategories.toMutableList()
+        private val updates = mutableListOf<CategoryUpdate>()
+
+        override suspend fun getAnimeCategory(id: Long): Category? = categories.find { it.id == id }
+
+        override suspend fun getAllAnimeCategories(): List<Category> = categories.toList()
+
+        override suspend fun getAllVisibleAnimeCategories(): List<Category> =
+            categories.filterNot { it.hidden }
+
+        override fun getAllAnimeCategoriesAsFlow(): Flow<List<Category>> = MutableStateFlow(categories.toList())
+
+        override fun getAllVisibleAnimeCategoriesAsFlow(): Flow<List<Category>> =
+            MutableStateFlow(categories.filterNot { it.hidden })
+
+        override suspend fun getCategoriesByAnimeId(animeId: Long): List<Category> = categories.toList()
+
+        override suspend fun getVisibleCategoriesByAnimeId(animeId: Long): List<Category> =
+            categories.filterNot { it.hidden }
+
+        override fun getCategoriesByAnimeIdAsFlow(animeId: Long): Flow<List<Category>> =
+            MutableStateFlow(categories.toList())
+
+        override fun getVisibleCategoriesByAnimeIdAsFlow(animeId: Long): Flow<List<Category>> =
+            MutableStateFlow(categories.filterNot { it.hidden })
+
+        override suspend fun insertAnimeCategory(category: Category) {
+            throw UnsupportedOperationException("Not needed by this test")
+        }
+
+        override suspend fun updatePartialAnimeCategory(update: CategoryUpdate) {
+            updates += update
+        }
+
+        override suspend fun updatePartialAnimeCategories(updates: List<CategoryUpdate>) {
+            throw UnsupportedOperationException("Not needed by this test")
+        }
+
+        override suspend fun updateAllAnimeCategoryFlags(flags: Long?) {
+            throw UnsupportedOperationException("Not needed by this test")
+        }
+
+        override suspend fun deleteAnimeCategory(categoryId: Long) {
+            throw UnsupportedOperationException("Not needed by this test")
+        }
+
+        fun singleUpdate(): CategoryUpdate = updates.single()
+    }
+
+    private class MutablePreference<T>(
+        private val defaultValue: T,
+        initialValue: T,
+    ) : Preference<T> {
+
+        private val flow = MutableStateFlow(initialValue)
+
+        override fun key(): String = "test"
+
+        override fun get(): T = flow.value
+
+        override fun set(value: T) {
+            flow.value = value
+        }
+
+        override fun isSet(): Boolean = flow.value != defaultValue
+
+        override fun delete() {
+            flow.value = defaultValue
+        }
+
+        override fun defaultValue(): T = defaultValue
+
+        override fun changes(): Flow<T> = flow
+
+        override fun stateIn(scope: kotlinx.coroutines.CoroutineScope): kotlinx.coroutines.flow.StateFlow<T> = flow
+    }
+
+    private fun category(
+        id: Long,
+        name: String,
+        order: Long,
+        flags: Long = 0,
+        hidden: Boolean = false,
+        parentId: Long? = null,
+    ) = Category(
+        id = id,
+        name = name,
+        order = order,
+        flags = flags,
+        hidden = hidden,
+        parentId = parentId,
+    )
+
+    private data object SortTypeAlphabetical : FlagWithMask {
+        override val flag: Long = 0b00000000
+        override val mask: Long = 0b00111100
+    }
+
+    private data object SortTypeRandom : FlagWithMask {
+        override val flag: Long = 0b00111100
+        override val mask: Long = 0b00111100
+    }
+
+    private data object SortDirectionAscending : FlagWithMask {
+        override val flag: Long = 0b01000000
+        override val mask: Long = 0b01000000
+    }
+
+    private companion object {
+        const val INITIAL_FLAGS = 0b01000100L
+        const val OLD_SORT_FLAG = 0b00001000L
+        const val NEW_SORT_FLAG = 0b01000100L
+        const val SORT_MASK = 0b01111100L
+    }
+}


### PR DESCRIPTION
## Ticket
- ID: R661
- Priority: P2
- Risk Tier: T2
- GitHub Issue: Closes #720

## Objective
- Reduce duplicated anime/manga category interactor mechanics while preserving the existing public anime/manga interactor pattern and DI call sites.

## Scope
- Added an internal shared category interactor layer under `tachiyomi.domain.category.interactor`.
- Added `CategoryRepositoryOps` adapters over existing anime and manga category repositories.
- Converted public anime/manga category interactors into thin facades for create, rename, update, hide, reorder, alphabetical sort, reset flags, fetch, delete cleanup, entry-category assignment, display mode, and sort mode handling.
- Corrected `HideAnimeCategory` success mapping to return `HideAnimeCategory.Result.Success`.
- Preserved the existing `DeleteMangaCategory` duplicated `mangaUpdateCategories()` cleanup behavior for this ticket.
- Added focused shared-helper tests plus a facade-level `HideAnimeCategory` success-type test.
- Added an Unreleased > Other changelog entry without the ticket number.
- Created follow-up #728 / R664 for the deferred manga exclude-preference cleanup bug.

## Non-goals
- No merge of `AnimeCategoryRepository` and `MangaCategoryRepository`.
- No category UI, screen model, repository implementation, backup restore, light novel plugin, or `feature/novel` changes.
- No broad generic anime/manga core refactor.
- No fix for the suspected `DeleteMangaCategory` exclude-preference bug in this PR.

## Files Changed
- `domain/src/main/java/tachiyomi/domain/category/interactor/` shared internal helpers and repository adapters.
- Anime/manga category interactor facade files under `domain/src/main/java/tachiyomi/domain/category/{anime,manga}/interactor/`.
- `domain/src/test/java/tachiyomi/domain/category/interactor/CategoryInteractorOperationsTest.kt`.
- `CHANGELOG.md`.

## Verification
- Commands run:
  - `./gradlew :domain:testDebugUnitTest --tests "*Category*"`
  - `./gradlew spotlessCheck`
  - `./gradlew :app:compileDebugKotlin`
  - `./gradlew :app:compileStableDebugKotlin`
  - `git diff --check`
  - Source checks for public facade names, DI references, changed paths, and preserved duplicated manga preference cleanup.
  - Independent read-only review agent pass.
- Results:
  - `:domain:testDebugUnitTest --tests "*Category*"` passed, including the new `HideAnimeCategory` facade success test.
  - `spotlessCheck` passed.
  - `:app:compileDebugKotlin` failed only with the known ambiguous Gradle task name: candidates are `compileStableDebugAndroidTestKotlin`, `compileStableDebugKotlin`, and `compileStableDebugUnitTestKotlin`.
  - `:app:compileStableDebugKotlin` passed.
  - `git diff --check` passed.
  - Source checks confirmed no category UI, screen model, repository implementation, backup restore, light novel plugin, or `feature/novel` files changed.
  - Independent review returned no findings; residual risk noted that most tests use fake shared ops, now mitigated for the `HideAnimeCategory` success-type path with a facade-level test.
- Not tested:
  - No emulator or UI tests; this is domain interactor cleanup with no UI changes.

## Risk
- Medium risk from touching many category interactor facades. Mitigated by keeping concrete public class names and DI call sites intact, preserving repository interfaces, and adding focused domain tests for shared mechanics.
- Delete cleanup behavior is intentionally preserved, including the likely manga exclude-preference gap. Follow-up #728 tracks that behavioral fix separately.

## SLO Impact
- No runtime SLO impact expected. This is a domain cleanup with equivalent repository calls and no new I/O or coroutine scopes.

## Rollback
- Revert commit `22319be4a` to restore the prior duplicated anime/manga interactor implementations.

## Release Notes
- No user-facing behavior change expected; category interactors now share common domain mechanics while anime and manga entrypoints remain separate.

## Checklist
- [x] Naming conventions followed (use "Rayniyomi" in user-facing text, see [naming conventions](../docs/governance/naming-conventions.md))
- [x] Branch rebased on latest main and verification re-run (see [rebase policy](../docs/governance/agent-workflow.md#rebase-before-merge-policy-r45))
- [x] New coroutine scopes have documented owner and cancellation path
- [x] No new `runBlocking` on UI/main thread paths

## Definition of Done (DoD)
- [x] Acceptance criteria met and non-goals respected
- [x] Verification matrix completed (Risk Tier: T2)
- [x] Self-review completed
- [x] Rebased on latest `main` and revalidated (mandatory for merge)
- [x] Sprint board updated (branch, commit, checks, PR link)
- [x] Release notes drafted (if applicable)

## Fork Compliance Checklist (for new forks only)
Not applicable; this PR does not create a new fork.
