### PR TITLE
ci: convert reader parity smoke to plain instrumentation (R730)

### DIFF
--- a/.github/workflows/reader_parity_gate.yml
+++ b/.github/workflows/reader_parity_gate.yml
@@ -3,7 +3,8 @@ name: Reader parity gate
 on:
   pull_request:
     paths:
-      - 'macrobenchmark/**'
+      - 'reader-parity/**'
+      - 'macrobenchmark/parity/**'
       - 'scripts/reader_parity_*.py'
       - 'scripts/reader_parity_extract_benchmark.py'
       - 'scripts/tests/test_reader_parity_*.py'
@@ -36,7 +37,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs:
       - reader_a11y_android_test
-      - reader_benchmark_smoke
+      - reader_smoke
 
     steps:
       - name: Clone repo
@@ -60,7 +61,7 @@ jobs:
           path: .artifacts/a11y
 
       - name: Run parity script unit tests
-        run: python3 -m unittest scripts/tests/test_reader_parity_gate.py scripts/tests/test_reader_parity_collect.py scripts/tests/test_reader_parity_extract_benchmark.py
+        run: python3 -m unittest scripts/tests/test_reader_parity_gate.py scripts/tests/test_reader_parity_collect.py scripts/tests/test_reader_parity_extract_benchmark.py scripts/tests/test_reader_parity_workflow.py
 
       - name: Collect candidate report
         run: |
@@ -71,6 +72,8 @@ jobs:
             --output macrobenchmark/parity/reader_parity_candidate.json
 
       - name: Evaluate parity gate
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           set -euo pipefail
 
@@ -80,10 +83,7 @@ jobs:
 
           if [ "$allow_bypass" = "true" ]; then
             bypass_reason="maintainer-approved emergency bypass"
-            body="$(cat <<'PR_BODY'
-${{ github.event.pull_request.body }}
-PR_BODY
-)"
+            body="${PR_BODY:-}"
             followup_issue=$(printf '%s' "$body" | sed -n 's/.*reader-parity-followup:[[:space:]]*\([^[:space:]]*\).*/\1/p' | head -n1)
           fi
 
@@ -181,32 +181,26 @@ PR_BODY
           arch: x86_64
           target: google_apis
           profile: pixel_7
-          script: |
-            set +e
-            ./gradlew :app:connectedDebugAndroidTest \
-              -Pandroid.testInstrumentationRunnerArguments.class=eu.kanade.tachiyomi.ui.reader.viewer.ReaderErrorSurfaceAndroidTest \
-              --build-cache
-            status=$?
-            if [ "$status" -eq 0 ]; then
-              manual_talkback_validated="${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'reader-parity-talkback-validated') }}"
-              if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ github.event.inputs.manual_talkback_validated || 'false' }}" = "true" ]; then
-                manual_talkback_validated="true"
-              fi
-              mkdir -p macrobenchmark/parity
-              cat > macrobenchmark/parity/reader_parity_a11y_observed.json <<'JSON'
-              {
-                "a11y": {
-                  "automatedFocusOrderPassed": true,
-                  "automatedRetryDiscoverabilityPassed": true,
-                  "manualTalkBackChecklist": "macrobenchmark/parity/manual_talkback_checklist.md",
-                  "manualTalkBackValidated": __MANUAL_TALKBACK_VALIDATED__
-                }
-              }
-JSON
-              sed -i "s/__MANUAL_TALKBACK_VALIDATED__/${manual_talkback_validated}/" macrobenchmark/parity/reader_parity_a11y_observed.json
-            fi
-            adb logcat -d > app/build/reports/androidTests/reader-a11y-logcat.txt || true
-            exit $status
+          script: >-
+            bash -c 'set +e; ./gradlew :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=eu.kanade.tachiyomi.ui.reader.viewer.ReaderErrorSurfaceAndroidTest --build-cache; status=$?; adb logcat -d > app/build/reports/androidTests/reader-a11y-logcat.txt || true; exit "$status"'
+
+      - name: Write reader a11y observed report
+        run: |
+          manual_talkback_validated="${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'reader-parity-talkback-validated') }}"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ github.event.inputs.manual_talkback_validated || 'false' }}" = "true" ]; then
+            manual_talkback_validated="true"
+          fi
+          mkdir -p macrobenchmark/parity
+          {
+            printf '{\n'
+            printf '  "a11y": {\n'
+            printf '    "automatedFocusOrderPassed": true,\n'
+            printf '    "automatedRetryDiscoverabilityPassed": true,\n'
+            printf '    "manualTalkBackChecklist": "macrobenchmark/parity/manual_talkback_checklist.md",\n'
+            printf '    "manualTalkBackValidated": %s\n' "$manual_talkback_validated"
+            printf '  }\n'
+            printf '}\n'
+          } > macrobenchmark/parity/reader_parity_a11y_observed.json
 
       - name: Upload reader a11y reports
         if: always()
@@ -220,8 +214,8 @@ JSON
             macrobenchmark/parity/reader_parity_a11y_observed.json
           if-no-files-found: warn
 
-  reader_benchmark_smoke:
-    name: Reader benchmark smoke
+  reader_smoke:
+    name: Reader parity smoke
     runs-on: ubuntu-24.04
     needs: prepare_sqldelight
 
@@ -246,26 +240,15 @@ JSON
           name: sqldelight-m2-${{ env.SQLDELIGHT_AGP9_FIX_SHA }}
           path: ~/.m2/repository/app/cash
 
-      - name: Run reader parity benchmark smoke
+      - name: Run reader parity smoke
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: 35
           arch: x86_64
           target: google_apis
           profile: pixel_7
-          script: |
-            set +e
-            ./gradlew :macrobenchmark:connectedBenchmarkAndroidTest \
-              -Pandroid.testInstrumentationRunnerArguments.class=tachiyomi.macrobenchmark.ReaderParitySmokeBenchmark \
-              --build-cache 2>&1 | tee macrobenchmark/build/reports/reader-benchmark-stdout.txt
-            status=${PIPESTATUS[0]}
-            if [ "$status" -eq 0 ]; then
-              python3 scripts/reader_parity_extract_benchmark.py \
-                --log macrobenchmark/build/reports/reader-benchmark-stdout.txt \
-                --output macrobenchmark/parity/reader_parity_benchmark_observed.json
-            fi
-            adb logcat -d > macrobenchmark/build/reports/reader-benchmark-logcat.txt || true
-            exit $status
+          script: >-
+            bash -o pipefail -c 'set +e; mkdir -p reader-parity/build/reports; ./gradlew :reader-parity:connectedBenchmarkAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=tachiyomi.readerparity.ReaderParitySmokeTest --build-cache 2>&1 | tee reader-parity/build/reports/reader-benchmark-stdout.txt; status=$?; if [ "$status" -eq 0 ]; then python3 scripts/reader_parity_extract_benchmark.py --log reader-parity/build/reports/reader-benchmark-stdout.txt --output macrobenchmark/parity/reader_parity_benchmark_observed.json; fi; adb logcat -d > reader-parity/build/reports/reader-benchmark-logcat.txt || true; exit "$status"'
 
       - name: Upload reader benchmark artifacts
         if: always()
@@ -273,9 +256,8 @@ JSON
         with:
           name: reader-parity-benchmark-observed-${{ github.sha }}
           path: |
-            macrobenchmark/build/reports
-            macrobenchmark/build/outputs/connected_android_test_additional_output
-            macrobenchmark/build/outputs/androidTest-results
-            macrobenchmark/build/reports/reader-benchmark-logcat.txt
+            reader-parity/build/reports
+            reader-parity/build/outputs/androidTest-results
+            reader-parity/build/reports/reader-benchmark-logcat.txt
             macrobenchmark/parity/reader_parity_benchmark_observed.json
           if-no-files-found: warn

--- a/reader-parity/build.gradle.kts
+++ b/reader-parity/build.gradle.kts
@@ -1,0 +1,46 @@
+import mihon.buildlogic.AndroidConfig
+
+plugins {
+    id("com.android.test")
+
+    id("mihon.code.lint")
+}
+
+android {
+    namespace = "tachiyomi.readerparity"
+    compileSdk = AndroidConfig.COMPILE_SDK
+    buildToolsVersion = AndroidConfig.BUILD_TOOLS
+    ndkVersion = AndroidConfig.NDK
+
+    defaultConfig {
+        minSdk = AndroidConfig.MIN_SDK
+    }
+
+    compileOptions {
+        sourceCompatibility = AndroidConfig.JavaVersion
+        targetCompatibility = AndroidConfig.JavaVersion
+    }
+
+    buildTypes {
+        create("benchmark") {
+            isDebuggable = true
+            signingConfig = getByName("debug").signingConfig
+            matchingFallbacks.add("release")
+        }
+    }
+
+    targetProjectPath = ":app"
+    experimentalProperties["android.experimental.self-instrumenting"] = true
+}
+
+androidComponents {
+    beforeVariants(selector().all()) {
+        it.enable = it.buildType == "benchmark"
+    }
+}
+
+dependencies {
+    implementation(androidx.test.ext)
+    implementation(androidx.test.espresso.core)
+    implementation(androidx.test.uiautomator)
+}

--- a/reader-parity/src/main/java/tachiyomi/readerparity/ReaderParitySmokeTest.kt
+++ b/reader-parity/src/main/java/tachiyomi/readerparity/ReaderParitySmokeTest.kt
@@ -1,14 +1,10 @@
-package tachiyomi.macrobenchmark
+package tachiyomi.readerparity
 
 import androidx.annotation.VisibleForTesting
-import androidx.benchmark.macro.CompilationMode
-import androidx.benchmark.macro.FrameTimingMetric
-import androidx.benchmark.macro.junit4.MacrobenchmarkRule
-import androidx.test.internal.runner.junit4.AndroidJUnit4ClassRunner
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import org.json.JSONArray
 import org.json.JSONObject
-import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.io.FileInputStream
@@ -17,45 +13,29 @@ import kotlin.math.pow
 import kotlin.math.sqrt
 
 /**
- * Governance smoke benchmark for reader parity gate.
+ * Governance smoke test for reader parity gate.
  *
- * This benchmark intentionally keeps interactions lightweight and deterministic so CI can
- * continuously validate benchmark execution plumbing before deeper reader-fixture expansion.
+ * This test intentionally keeps interactions lightweight and deterministic so CI can
+ * validate reader parity plumbing before deeper reader-fixture expansion.
  */
-@RunWith(AndroidJUnit4ClassRunner::class)
-class ReaderParitySmokeBenchmark {
+@RunWith(AndroidJUnit4::class)
+class ReaderParitySmokeTest {
 
     private val instrumentation
         get() = InstrumentationRegistry.getInstrumentation()
 
-    @get:Rule
-    val benchmarkRule = MacrobenchmarkRule()
-
     @Test
     fun emit_reader_parity_observed_metrics() {
-        benchmarkRule.measureRepeated(
-            packageName = BENCHMARK_TARGET_PACKAGE,
-            metrics = listOf(FrameTimingMetric()),
-            compilationMode = CompilationMode.None(),
-            iterations = 1,
-            setupBlock = {
-                pressHome()
-            },
-        ) {
-            startActivityAndWait()
-            device.waitForIdle()
-        }
-
         val launchIntent = instrumentation.targetContext.packageManager
-            .getLaunchIntentForPackage(BENCHMARK_TARGET_PACKAGE)
-            ?: throw IllegalStateException("Unable to resolve launch intent for benchmark target")
+            .getLaunchIntentForPackage(TARGET_PACKAGE)
+            ?: throw IllegalStateException("Unable to resolve launch intent for reader parity target")
         val launchComponent = launchIntent.component
-            ?: throw IllegalStateException("Missing launch component for benchmark target")
+            ?: throw IllegalStateException("Missing launch component for reader parity target")
         val componentName = "${launchComponent.packageName}/${launchComponent.className}"
 
         val coldStartupRuns = mutableListOf<Double>()
         repeat(5) {
-            shell("am force-stop $BENCHMARK_TARGET_PACKAGE")
+            shell("am force-stop $TARGET_PACKAGE")
             startTotalTimeMs(componentName)?.let { value -> coldStartupRuns.add(value) }
         }
 
@@ -67,7 +47,7 @@ class ReaderParitySmokeBenchmark {
         val recoveryAttempts = 10
         var recoverySuccesses = 0
         repeat(recoveryAttempts) {
-            shell("am force-stop $BENCHMARK_TARGET_PACKAGE")
+            shell("am force-stop $TARGET_PACKAGE")
             if (startTotalTimeMs(componentName) != null) {
                 recoverySuccesses++
             }
@@ -79,8 +59,8 @@ class ReaderParitySmokeBenchmark {
             percentile = 0.95,
         ) ?: 50_000.0
 
-        val observedJankPercent = parseJankPercent(shell("dumpsys gfxinfo $BENCHMARK_TARGET_PACKAGE")) ?: 100.0
-        val observedMemoryMb = parseTotalPssMb(shell("dumpsys meminfo $BENCHMARK_TARGET_PACKAGE")) ?: 4096.0
+        val observedJankPercent = parseJankPercent(shell("dumpsys gfxinfo $TARGET_PACKAGE")) ?: 100.0
+        val observedMemoryMb = parseTotalPssMb(shell("dumpsys meminfo $TARGET_PACKAGE")) ?: 4096.0
 
         val recoveryPassRatePercent = (recoverySuccesses.toDouble() / recoveryAttempts.toDouble()) * 100.0
         val variancePercent = coefficientOfVariationPercent(coldStartupRuns) ?: 0.0
@@ -169,6 +149,7 @@ class ReaderParitySmokeBenchmark {
     }
 
     private companion object {
+        private const val TARGET_PACKAGE = "xyz.rayniyomi.benchmark"
         private val TOTAL_TIME_REGEX = Regex("TotalTime:\\s*(\\d+)")
         private val JANK_PERCENT_REGEX = Regex("Janky frames:\\s+\\d+\\s+\\((\\d+(?:\\.\\d+)?)%\\)")
         private val TOTAL_PSS_REGEX = Regex("TOTAL\\s+PSS:\\s*(\\d+)")

--- a/scripts/tests/test_reader_parity_workflow.py
+++ b/scripts/tests/test_reader_parity_workflow.py
@@ -1,0 +1,39 @@
+import unittest
+from pathlib import Path
+
+
+class ReaderParityWorkflowTest(unittest.TestCase):
+    def test_reader_smoke_runs_as_plain_junit_instrumentation(self):
+        workflow = Path(".github/workflows/reader_parity_gate.yml").read_text()
+
+        self.assertIn(":reader-parity:connectedBenchmarkAndroidTest", workflow)
+        self.assertIn(
+            "-Pandroid.testInstrumentationRunnerArguments.class=tachiyomi.readerparity.ReaderParitySmokeTest",
+            workflow,
+        )
+        self.assertNotIn(":macrobenchmark:connectedBenchmarkAndroidTest", workflow)
+        self.assertNotIn("ReaderParitySmokeBenchmark", workflow)
+        self.assertNotIn("connected_android_test_additional_output", workflow)
+
+    def test_reader_smoke_does_not_initialize_androidx_benchmark(self):
+        smoke_source = Path(
+            "reader-parity/src/main/java/tachiyomi/readerparity/ReaderParitySmokeTest.kt",
+        ).read_text()
+
+        self.assertNotIn("MacrobenchmarkRule", smoke_source)
+        self.assertNotIn("FrameTimingMetric", smoke_source)
+        self.assertNotIn("CompilationMode", smoke_source)
+        self.assertNotIn("measureRepeated", smoke_source)
+
+    def test_reader_parity_module_has_no_benchmark_dependency(self):
+        build_file = Path("reader-parity/build.gradle.kts").read_text()
+
+        self.assertIn('id("com.android.test")', build_file)
+        self.assertIn('targetProjectPath = ":app"', build_file)
+        self.assertIn('it.buildType == "benchmark"', build_file)
+        self.assertNotIn('id("mihon.benchmark")', build_file)
+        self.assertNotIn("androidx.benchmark", build_file)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -82,6 +82,7 @@ include(":i18n-aniyomi")
 include(":macrobenchmark")
 include(":presentation-core")
 include(":presentation-widget")
+include(":reader-parity")
 include(":source-api")
 include(":source-local")
 


### PR DESCRIPTION
## Ticket
- ID: R730
- Priority: P2
- Risk Tier: T2
- GitHub Issue: Closes #730

## Objective
- Remove the AndroidX Benchmark initialization path from the reader parity smoke gate so CI no longer fails on benchmark output-directory setup before emitting observed parity JSON.

## Scope
- Move reader parity smoke into a dedicated plain `com.android.test` module: `:reader-parity`.
- Keep the app target on the existing `benchmark` build type for baseline comparability, but remove all `androidx.benchmark` usage from this gate.
- Preserve the existing `RPARITY_OBSERVED_JSON` stdout contract.
- Update `reader_parity_gate.yml` to run `:reader-parity:connectedBenchmarkAndroidTest` instead of `:macrobenchmark:connectedBenchmarkAndroidTest`.
- Narrow reader parity workflow triggers to `reader-parity/**` plus parity artifacts/scripts.
- Add workflow-contract tests proving reader parity no longer depends on the macrobenchmark module or AndroidX Benchmark.

## Non-goals
- No removal of the real `:macrobenchmark` module; baseline profile and startup benchmark surfaces remain.
- No Firebase Test Lab or physical-device performance gating.
- No SqlDelight dependency changes in this ticket.

## Files Changed
- `.github/workflows/reader_parity_gate.yml`
- `reader-parity/build.gradle.kts`
- `reader-parity/src/main/java/tachiyomi/readerparity/ReaderParitySmokeTest.kt`
- `scripts/tests/test_reader_parity_workflow.py`
- `settings.gradle.kts`

## Verification
- Commands run:
  - `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/reader_parity_gate.yml"); puts "ok"'`
  - `python3 -m unittest scripts/tests/test_reader_parity_gate.py scripts/tests/test_reader_parity_collect.py scripts/tests/test_reader_parity_extract_benchmark.py scripts/tests/test_reader_parity_workflow.py`
  - `./gradlew :reader-parity:compileBenchmarkKotlin --build-cache`
  - `./gradlew :reader-parity:connectedBenchmarkAndroidTest --dry-run`
  - `./gradlew :macrobenchmark:compileBenchmarkKotlin --build-cache`
  - `./gradlew spotlessCheck`
  - `./gradlew :app:compileStableDebugKotlin --build-cache`
- Results:
  - All commands completed with exit 0.
- Not tested:
  - Full emulator execution locally; PR CI is expected to validate the API 35 reader parity workflow.
  - Literal `:app:compileDebugKotlin` is ambiguous in this flavored app; concrete `:app:compileStableDebugKotlin` passed.

## Risk
- T2 because this changes CI instrumentation behavior and workflow plumbing.
- Risk is limited by preserving the separate test APK, the benchmark app build target, and the existing stdout JSON marker contract.

## SLO Impact
- No runtime app SLO impact. CI reliability should improve for reader parity checks.

## Rollback
- Revert this PR to restore the previous macrobenchmark-module reader parity smoke path and workflow command.

## Release Notes
- No user-facing impact; CI-only reader parity smoke gate cleanup.

## Checklist
- [x] Naming conventions followed (use Rayniyomi in user-facing text, see [naming conventions](../docs/governance/naming-conventions.md))
- [x] Branch rebased on latest main and verification re-run (see [rebase policy](../docs/governance/agent-workflow.md#rebase-before-merge-policy-r45))
- [x] New coroutine scopes have documented owner and cancellation path
- [x] No new runBlocking on UI/main thread paths

## Definition of Done (DoD)
- [x] Acceptance criteria met and non-goals respected
- [x] Verification matrix completed (Risk Tier: T2)
- [x] Self-review completed
- [x] Rebased on latest main and revalidated (mandatory for merge)
- [ ] Sprint board updated (branch, commit, checks, PR link)
- [x] Release notes drafted (if applicable)

## Fork Compliance Checklist (for new forks only)
- [ ] App Identity: N/A
- [ ] App Icon: N/A
- [ ] Application ID: N/A
- [ ] Update Checker: N/A
- [ ] Analytics: N/A
- [ ] Crash Reporting: N/A
