### PR TITLE
ci: harden gitleaks PR checkout range (R666)

### DIFF
--- a/.github/workflows/secret_scan.yml
+++ b/.github/workflows/secret_scan.yml
@@ -18,6 +18,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
+          # gitleaks computes pull_request scan ranges from the PR head history.
+          # Checking out the head SHA avoids missing-range failures when queued
+          # PR jobs run after merge or branch cleanup.
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
 
       - name: Run gitleaks

--- a/docs/ci-tiering.md
+++ b/docs/ci-tiering.md
@@ -20,6 +20,10 @@ These checks are expected on normal pull requests:
 | `Branding guardrail` | `.github/workflows/build_pull_request.yml` | Prevents user-facing fork-brand regressions. |
 | `Plugin Compatibility` | `.github/workflows/plugin_compatibility.yml` | Targeted PR gate for light novel plugin host and manifest changes. |
 
+The gitleaks workflow checks out the pull request head SHA with full history so
+its commit-range scan can resolve PR head commits even if queued jobs finish
+after merge or branch cleanup. Push and manual runs fall back to `github.sha`.
+
 ## Removed Emulator Gate
 
 These hosted-emulator workflows were removed because they were slow, noisy, and

--- a/scripts/tests/test_ci_workflow_tiering.py
+++ b/scripts/tests/test_ci_workflow_tiering.py
@@ -29,6 +29,12 @@ class CiWorkflowTieringTest(unittest.TestCase):
 
         self.assertIn("'.github/workflows/plugin_compatibility.yml'", workflow)
 
+    def test_gitleaks_scans_pull_request_head_history(self) -> None:
+        workflow = read_workflow("secret_scan.yml")
+
+        self.assertIn("ref: ${{ github.event.pull_request.head.sha || github.sha }}", workflow)
+        self.assertIn("fetch-depth: 0", workflow)
+
     def test_pr_build_skips_gradle_for_non_android_changes(self) -> None:
         workflow = read_workflow("build_pull_request.yml")
 
@@ -45,6 +51,7 @@ class CiWorkflowTieringTest(unittest.TestCase):
         self.assertIn("Required PR Gate", text)
         self.assertIn("Removed Emulator Gate", text)
         self.assertIn("Release Gate", text)
+        self.assertIn("pull request head SHA", text)
         self.assertIn("SqlDelight bootstrap", text)
 
 


### PR DESCRIPTION
## Objective
Prevent gitleaks pull_request runs from failing when queued PR jobs execute after merge or branch cleanup and the action cannot resolve the PR commit range.

Closes #736

## Scope
- Check out the pull request head SHA for gitleaks PR runs, falling back to `github.sha` for push/manual runs.
- Keep `fetch-depth: 0` so gitleaks can scan commit history rather than a shallow checkout.
- Document the scan-range behavior in `docs/ci-tiering.md`.
- Add regression coverage in `scripts/tests/test_ci_workflow_tiering.py`.

## Verification
- `python3 -m unittest scripts/tests/test_ci_workflow_tiering.py` (red before implementation, green after)
- `python3 -m unittest discover scripts/tests`
- Ruby YAML parse over `.github/workflows/*.yml`
- `git diff --check`
- `./gradlew spotlessCheck`
- `./gradlew :app:compileStableDebugKotlin --build-cache`
- Global pre-push hook reran `./gradlew spotlessCheck` and `./gradlew :app:compileStableDebugKotlin`

## Risk
T1. Secret scanning remains active on pull_request, main push, and manual runs. The checkout ref changes only the local git history presented to gitleaks so its PR range can resolve reliably.

## Rollback
Revert this PR to restore the previous default checkout behavior in the gitleaks workflow.