### PR TITLE
build: refresh low-risk dependencies (R668)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Baseline profile CI job now dry-runs `:app:generateBaselineProfile` and verifies `baseline-prof.txt` is committed and non-empty on every PR touching app or macrobenchmark paths.
 
 ### Other
+- Core maintenance dependencies refreshed: OkHttp 5.4.0, Cast framework 22.3.1, jsoup 1.22.2, AndroidX SQLite 2.6.2, Coil BOM 3.5.0, Material Components 1.14.0, JUnit 6.1.0, Kotest 6.2.1, and MockK 1.14.11.
+- OkHttp and JUnit test dependencies now use BOM-managed versions so related artifacts stay aligned across app, core, and test modules.
 - Anime and manga tracking screens now share common presentation components while keeping their typed entrypoints separate.
 - Category interactors now share common domain mechanics while keeping anime and manga entrypoints separate.
 - Track previews now share sample fixture builders between anime and manga preview providers.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -311,6 +311,7 @@ dependencies {
     implementation(libs.rxjava)
 
     // Networking
+    implementation(platform(libs.okhttp.bom))
     implementation(libs.bundles.okhttp)
     implementation(libs.okio)
     implementation(libs.conscrypt.android) // TLS 1.3 support for Android < 10
@@ -370,6 +371,7 @@ dependencies {
     implementation(libs.bundles.shizuku)
 
     // Tests
+    testImplementation(platform(libs.junit.bom))
     testImplementation(libs.bundles.test)
     testImplementation("androidx.lifecycle:lifecycle-runtime-testing:2.8.7")
     androidTestImplementation(platform(compose.bom))

--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
 
     api(libs.rxjava)
 
+    api(platform(libs.okhttp.bom))
     api(libs.okhttp.core)
     api(libs.okhttp.logging)
     api(libs.okhttp.brotli)
@@ -52,5 +53,6 @@ dependencies {
     implementation(aniyomilibs.ffmpeg.kit)
 
     // Tests
+    testImplementation(platform(libs.junit.bom))
     testImplementation(libs.bundles.test)
 }

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -42,5 +42,6 @@ dependencies {
 
     api(libs.bundles.sqldelight)
 
+    testImplementation(platform(libs.junit.bom))
     testImplementation(libs.bundles.test)
 }

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
 
     compileOnly(libs.compose.stablemarker)
 
+    testImplementation(platform(libs.junit.bom))
     testImplementation(libs.bundles.test)
     testImplementation(kotlinx.coroutines.test)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,16 +1,16 @@
 [versions]
 aboutlib_version = "11.6.3"
-cast = "22.0.0"
+cast = "22.3.1"
 google_services = "4.4.4"
 firebase_crashlytics_gradle = "3.0.6"
 leakcanary = "2.14"
 mediarouter = "1.8.1"
 moko = "0.26.0"
-okhttp_version = "5.3.2"
+okhttp = "5.4.0"
 richtext = "0.20.0"
 shizuku_version = "13.1.0"
 sqldelight = "2.3.2"
-sqlite = "2.4.0"
+sqlite = "2.6.2"
 voyager = "1.1.0-beta03"
 spotless = "8.2.1"
 ktlint-core = "1.7.1"
@@ -20,10 +20,11 @@ desugar = "com.android.tools:desugar_jdk_libs:2.1.5"
 
 rxjava = "io.reactivex:rxjava:1.3.8"
 
-okhttp-core = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp_version" }
-okhttp-logging = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp_version" }
-okhttp-brotli = { module = "com.squareup.okhttp3:okhttp-brotli", version.ref = "okhttp_version" }
-okhttp-dnsoverhttps = { module = "com.squareup.okhttp3:okhttp-dnsoverhttps", version.ref = "okhttp_version" }
+okhttp-bom = { module = "com.squareup.okhttp3:okhttp-bom", version.ref = "okhttp" }
+okhttp-core = { module = "com.squareup.okhttp3:okhttp" }
+okhttp-logging = { module = "com.squareup.okhttp3:logging-interceptor" }
+okhttp-brotli = { module = "com.squareup.okhttp3:okhttp-brotli" }
+okhttp-dnsoverhttps = { module = "com.squareup.okhttp3:okhttp-dnsoverhttps" }
 okio = "com.squareup.okio:okio:3.17.0"
 
 androidx-mediarouter = { module = "androidx.mediarouter:mediarouter", version.ref = "mediarouter" }
@@ -33,7 +34,7 @@ conscrypt-android = "org.conscrypt:conscrypt-android:2.5.3"
 
 quickjs-android = "com.github.zhanghai.quickjs-java:quickjs-android:547f5b1597"
 
-jsoup = "org.jsoup:jsoup:1.22.1"
+jsoup = "org.jsoup:jsoup:1.22.2"
 
 disklrucache = "com.jakewharton:disklrucache:2.0.2"
 unifile = "com.github.tachiyomiorg:unifile:a9de196cc7"
@@ -47,7 +48,7 @@ preferencektx = "androidx.preference:preference-ktx:1.2.1"
 
 injekt = "com.github.mihonapp:injekt:91edab2317"
 
-coil-bom = { module = "io.coil-kt.coil3:coil-bom", version = "3.4.0" }
+coil-bom = { module = "io.coil-kt.coil3:coil-bom", version = "3.5.0" }
 coil-core = { module = "io.coil-kt.coil3:coil" }
 coil-gif = { module = "io.coil-kt.coil3:coil-gif" }
 coil-compose = { module = "io.coil-kt.coil3:coil-compose" }
@@ -61,7 +62,7 @@ natural-comparator = "com.github.gpanther:java-nat-sort:natural-comparator-1.1"
 richtext-commonmark = { module = "com.halilibo.compose-richtext:richtext-commonmark", version.ref = "richtext" }
 richtext-m3 = { module = "com.halilibo.compose-richtext:richtext-ui-material3", version.ref = "richtext" }
 
-material = "com.google.android.material:material:1.13.0"
+material = "com.google.android.material:material:1.14.0"
 photoview = "com.github.chrisbanes:PhotoView:2.3.0"
 directionalviewpager = "com.github.tachiyomiorg:DirectionalViewPager:1.0.0"
 insetter = "dev.chrisbanes.insetter:insetter:0.6.1"
@@ -89,10 +90,11 @@ sqldelight-android-driver = { module = "app.cash.sqldelight:android-driver", ver
 sqldelight-coroutines = { module = "app.cash.sqldelight:coroutines-extensions-jvm", version.ref = "sqldelight" }
 sqldelight-dialects-sql = { module = "app.cash.sqldelight:sqlite-3-38-dialect", version.ref = "sqldelight" }
 
-junit = "org.junit.jupiter:junit-jupiter:6.0.3"
-junit-platform-launcher = "org.junit.platform:junit-platform-launcher:6.0.3"
-kotest-assertions = "io.kotest:kotest-assertions-core:6.1.7"
-mockk = "io.mockk:mockk:1.14.9"
+junit-bom = { module = "org.junit:junit-bom", version = "6.1.0" }
+junit = { module = "org.junit.jupiter:junit-jupiter" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
+kotest-assertions = "io.kotest:kotest-assertions-core:6.2.1"
+mockk = "io.mockk:mockk:1.14.11"
 
 voyager-navigator = { module = "cafe.adriel.voyager:voyager-navigator", version.ref = "voyager" }
 voyager-screenmodel = { module = "cafe.adriel.voyager:voyager-screenmodel", version.ref = "voyager" }

--- a/lightnovel-contract/build.gradle.kts
+++ b/lightnovel-contract/build.gradle.kts
@@ -7,5 +7,6 @@ android {
 }
 
 dependencies {
+    testImplementation(platform(libs.junit.bom))
     testImplementation(libs.bundles.test)
 }

--- a/lightnovel-plugin/build.gradle.kts
+++ b/lightnovel-plugin/build.gradle.kts
@@ -57,5 +57,6 @@ dependencies {
     implementation(kotlinx.serialization.json)
     implementation(kotlinx.coroutines.android)
 
+    testImplementation(platform(libs.junit.bom))
     testImplementation(libs.bundles.test)
 }


### PR DESCRIPTION
## Ticket
- ID: R668
- Priority: P2
- Risk Tier: T1
- GitHub Issue: Closes #740

## Objective
Refresh the low-risk dependency set identified in R668 and move OkHttp/JUnit version control to BOMs so related artifacts stay aligned.

## Scope
- Bumped OkHttp, Google Cast framework, jsoup, AndroidX SQLite, Coil BOM, Material Components, JUnit, Kotest, and MockK to the R668 target versions.
- Added OkHttp BOM usage for app/core networking dependencies and removed explicit OkHttp module versions.
- Added JUnit BOM usage for every shared `libs.bundles.test` consumer and removed explicit JUnit/JUnit Platform versions.

## Non-goals
- Voyager 2.x migration.
- JitPack commit-pinned dependency changes.
- Broader dependency modernization outside R668.

## Files Changed
- `CHANGELOG.md`
- `gradle/libs.versions.toml`
- Gradle dependency declarations in app, core/common, domain, data, lightnovel-contract, and lightnovel-plugin.

## Verification
- Commands run:
  - `git diff --check`
  - `./gradlew :app:dependencies --configuration stableDebugRuntimeClasspath`
  - `./gradlew :app:dependencyInsight --configuration stableDebugRuntimeClasspath --dependency com.squareup.okhttp3:okhttp`
  - `./gradlew :app:dependencyInsight --configuration stableDebugUnitTestRuntimeClasspath --dependency org.junit.jupiter:junit-jupiter`
  - `./gradlew :app:spotlessCheck :app:compileStableDebugKotlin :app:testDebugUnitTest --build-cache`
  - `./gradlew spotlessCheck :app:assembleStableDebug --build-cache`
  - Pre-push hook: `./gradlew spotlessCheck`
  - Pre-push hook: `./gradlew :app:compileStableDebugKotlin`
- Results:
  - All commands passed.
  - OkHttp dependency insight resolved OkHttp artifacts through `okhttp-bom:5.4.0`.
  - JUnit dependency insight resolved JUnit/JUnit Platform artifacts through `junit-bom:6.1.0`.
  - Stable debug APK assembled successfully.
- Not tested:
  - Manual app launch and hands-on Coil/OkHttp/Cast runtime smoke tests were not run locally.

## Risk
Low. Changes are constrained to version catalog bumps and BOM wiring. Main runtime risk is library behavior drift in networking/image loading/cast surfaces; mitigated by dependency resolution checks, stable debug compile, full app unit tests, and stable debug APK assembly.

## SLO Impact
No expected runtime SLO impact. Dependency alignment should reduce future skew risk for OkHttp and JUnit artifacts.

## Rollback
Revert this PR to restore the prior explicit dependency versions and remove the newly added BOM platform declarations.

## Release Notes
No direct user-facing change; dependency maintenance only.

## Checklist
- [x] Naming conventions followed (use "Rayniyomi" in user-facing text, see [naming conventions](../docs/governance/naming-conventions.md))
- [x] Branch rebased on latest main and verification re-run (see [rebase policy](../docs/governance/agent-workflow.md#rebase-before-merge-policy-r45))
- [x] New coroutine scopes have documented owner and cancellation path
- [x] No new `runBlocking` on UI/main thread paths

## Definition of Done (DoD)
- [x] Acceptance criteria met and non-goals respected
- [x] Verification matrix completed (Risk Tier: T1)
- [x] Self-review completed
- [x] Rebased on latest `main` and revalidated (mandatory for merge)
- [ ] Sprint board updated (branch, commit, checks, PR link)
- [x] Release notes drafted (if applicable)
