### PR TITLE
chore: migrate Shikimori OAuth credentials (R707)

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/shikimori/ShikimoriApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/shikimori/ShikimoriApi.kt
@@ -1,6 +1,7 @@
 package eu.kanade.tachiyomi.data.track.shikimori
 
 import android.net.Uri
+import androidx.annotation.VisibleForTesting
 import androidx.core.net.toUri
 import eu.kanade.tachiyomi.data.database.models.anime.AnimeTrack
 import eu.kanade.tachiyomi.data.database.models.manga.MangaTrack
@@ -27,6 +28,7 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonObject
 import okhttp3.FormBody
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.RequestBody.Companion.toRequestBody
 import tachiyomi.core.common.util.lang.withIOContext
@@ -231,17 +233,6 @@ class ShikimoriApi(
         }
     }
 
-    private fun accessTokenRequest(code: String) = POST(
-        OAUTH_URL,
-        body = FormBody.Builder()
-            .add("grant_type", "authorization_code")
-            .add("client_id", CLIENT_ID)
-            .add("client_secret", CLIENT_SECRET)
-            .add("code", code)
-            .add("redirect_uri", REDIRECT_URL)
-            .build(),
-    )
-
     private fun graphQLRequest(payload: String) = POST(
         GRAPHQL_URL,
         body = payload.toRequestBody(jsonMime),
@@ -254,16 +245,32 @@ class ShikimoriApi(
         private const val OAUTH_URL = "$BASE_URL/oauth/token"
         private const val LOGIN_URL = "$BASE_URL/oauth/authorize"
 
-        private const val REDIRECT_URL = "aniyomi://shikimori-auth"
+        private const val REDIRECT_URL = "rayniyomi://shikimori-auth"
 
-        private const val CLIENT_ID = "aOAYRqOLwxpA8skpcQIXetNy4cw2rn2fRzScawlcQ5U"
-        private const val CLIENT_SECRET = "jqjmORn6bh2046ulkm4lHEwJ3OA1RmO3FD2sR9f6Clw"
+        private const val CLIENT_ID = "SmkA50jJviGntLvJLsEwEVetogb0RnS35OgvFCQttpM"
+        private const val CLIENT_SECRET = "lOFK6rLfV8Eu7cO0V9pMLIoC8X2f3BL11HVn-MRitvQ"
 
-        fun authUrl(): Uri = LOGIN_URL.toUri().buildUpon()
-            .appendQueryParameter("client_id", CLIENT_ID)
-            .appendQueryParameter("redirect_uri", REDIRECT_URL)
-            .appendQueryParameter("response_type", "code")
+        fun authUrl(): Uri = authUrlString().toUri()
+
+        @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+        internal fun authUrlString(): String = LOGIN_URL.toHttpUrl().newBuilder()
+            .addQueryParameter("client_id", CLIENT_ID)
+            .addQueryParameter("redirect_uri", REDIRECT_URL)
+            .addQueryParameter("response_type", "code")
             .build()
+            .toString()
+
+        @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+        internal fun accessTokenRequest(code: String) = POST(
+            OAUTH_URL,
+            body = FormBody.Builder()
+                .add("grant_type", "authorization_code")
+                .add("client_id", CLIENT_ID)
+                .add("client_secret", CLIENT_SECRET)
+                .add("code", code)
+                .add("redirect_uri", REDIRECT_URL)
+                .build(),
+        )
 
         fun refreshTokenRequest(token: String) = POST(
             OAUTH_URL,

--- a/app/src/test/java/eu/kanade/tachiyomi/data/track/shikimori/ShikimoriApiTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/data/track/shikimori/ShikimoriApiTest.kt
@@ -18,6 +18,9 @@ import io.kotest.matchers.string.shouldNotContain
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import okhttp3.FormBody
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.Request
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -26,6 +29,72 @@ import org.junit.jupiter.api.Test
 class ShikimoriApiTest {
 
     private val json = Json { ignoreUnknownKeys = true }
+
+    @Nested
+    @DisplayName("OAuth")
+    inner class OAuth {
+
+        @Test
+        @DisplayName("authUrl uses Rayniyomi redirect and fork-owned client")
+        fun authUrlUsesRayniyomiRedirectAndClient() {
+            val authUrl = ShikimoriApi.authUrlString().toHttpUrl()
+
+            authUrl.scheme shouldBe "https"
+            authUrl.host shouldBe "shikimori.one"
+            authUrl.encodedPath shouldBe "/oauth/authorize"
+            authUrl.queryParameter("redirect_uri") shouldBe RAYNIYOMI_REDIRECT_URI
+            authUrl.toString() shouldNotContain "aniyomi://shikimori-auth"
+            authUrl.queryParameter("client_id").shouldBeConfiguredCredential("client_id", ANIYOMI_CLIENT_ID)
+            authUrl.queryParameter("response_type") shouldBe "code"
+        }
+
+        @Test
+        @DisplayName("access token request uses Rayniyomi redirect and fork-owned credentials")
+        fun accessTokenRequestUsesRayniyomiRedirectAndClient() {
+            val request = ShikimoriApi.accessTokenRequest("auth-code")
+            val form = request.formBody()
+            val authRedirect = ShikimoriApi.authUrlString()
+                .toHttpUrl()
+                .queryParameter("redirect_uri")
+
+            request.url.scheme shouldBe "https"
+            request.url.host shouldBe "shikimori.one"
+            request.url.encodedPath shouldBe "/oauth/token"
+            form.value("grant_type") shouldBe "authorization_code"
+            form.value("code") shouldBe "auth-code"
+            form.value("redirect_uri") shouldBe RAYNIYOMI_REDIRECT_URI
+            form.value("redirect_uri") shouldBe authRedirect
+            form.value("client_id").shouldBeConfiguredCredential("client_id", ANIYOMI_CLIENT_ID)
+            form.value("client_secret").shouldBeConfiguredCredential("client_secret", ANIYOMI_CLIENT_SECRET)
+        }
+
+        private fun Request.formBody(): FormBody = body as FormBody
+
+        private fun String?.shouldBeConfiguredCredential(name: String, aniyomiValue: String) {
+            val credential = this
+            if (credential.isNullOrBlank()) {
+                throw AssertionError("$name must be configured")
+            }
+            if (credential == aniyomiValue) {
+                throw AssertionError("$name must not use the old Aniyomi credential")
+            }
+            if (
+                credential.contains("<") ||
+                credential.contains("placeholder", ignoreCase = true) ||
+                credential.contains("redacted", ignoreCase = true) ||
+                credential.contains("todo", ignoreCase = true)
+            ) {
+                throw AssertionError("$name must not use a placeholder")
+            }
+        }
+
+        private fun FormBody.value(name: String): String {
+            for (i in 0 until size) {
+                if (name(i) == name) return value(i)
+            }
+            throw AssertionError("Missing form field: $name")
+        }
+    }
 
     @Nested
     @DisplayName("Feature 1: GraphQL payload builders")
@@ -253,5 +322,11 @@ class ShikimoriApiTest {
                 // Expected
             }
         }
+    }
+
+    private companion object {
+        private const val RAYNIYOMI_REDIRECT_URI = "rayniyomi://shikimori-auth"
+        private const val ANIYOMI_CLIENT_ID = "aOAYRqOLwxpA8skpcQIXetNy4cw2rn2fRzScawlcQ5U"
+        private const val ANIYOMI_CLIENT_SECRET = "jqjmORn6bh2046ulkm4lHEwJ3OA1RmO3FD2sR9f6Clw"
     }
 }


### PR DESCRIPTION
## Ticket
- ID: R707
- Priority: P1
- Risk Tier: T2
- GitHub Issue: Closes #707

## Objective
- Move Shikimori OAuth off the inherited Aniyomi client registration and onto Rayniyomi-owned OAuth registration values.

## Scope
- Update Shikimori OAuth authorize/token redirect URI to `rayniyomi://shikimori-auth`.
- Replace the inherited Shikimori OAuth client values with fork-owned values sourced from the ignored local secret file during implementation.
- Add focused unit coverage for OAuth authorize/token endpoint shape, redirect consistency, and non-placeholder fork credential configuration without printing secret values.
- Mark request-builder test hooks as `@VisibleForTesting`.

## Non-goals
- No changes to unrelated tracker OAuth registrations.
- No OAuth UX rewrite.
- No committed local secret/config file.

## Files Changed
- `app/src/main/java/eu/kanade/tachiyomi/data/track/shikimori/ShikimoriApi.kt`
- `app/src/test/java/eu/kanade/tachiyomi/data/track/shikimori/ShikimoriApiTest.kt`

## Verification
- Commands run:
  - `git diff --check`
  - `./gradlew :app:testStableDebugUnitTest --tests 'eu.kanade.tachiyomi.data.track.shikimori.ShikimoriApiTest'`
  - `./gradlew spotlessCheck`
  - `./gradlew :app:compileStableDebugKotlin --build-cache`
  - pre-push `spotlessCheck`
  - pre-push `:app:compileStableDebugKotlin`
  - `./gradlew :app:assembleStableDebug`
  - Installed `app-stable-arm64-v8a-debug.apk` on `R645_API36_PlayStore` (`emulator-5554`)
  - `adb shell cmd package resolve-activity --brief -a android.intent.action.VIEW -d rayniyomi://shikimori-auth?... xyz.rayniyomi.dev`
  - `adb shell am start -W -a android.intent.action.VIEW -d rayniyomi://shikimori-auth?... xyz.rayniyomi.dev`
- Results:
  - All commands passed.
  - Independent agent review completed after remediation; no remaining blockers from redacted evidence.
  - Existing manifest routing already accepts `rayniyomi://shikimori-auth` and dispatches Shikimori callback by host.
  - Emulator resolver confirmed `rayniyomi://shikimori-auth` opens `TrackLoginActivity`; fake-code callback started the activity without AndroidRuntime/FATAL crash logs.
- Not tested:
  - Full authenticated Shikimori browser login on a device/emulator; emulator callback routing was validated, but completing OAuth requires a real Shikimori user login.
  - Shikimori admin-side scope selection cannot be verified from repository code; maintainer should confirm only `user_rates` is enabled in the OAuth app registration.

## Risk
- OAuth login can fail if the Shikimori app registration does not exactly match `rayniyomi://shikimori-auth`.
- Mitigation: unit tests pin authorize/token redirect consistency and existing Android callback routing already supports the Rayniyomi scheme.

## SLO Impact
- No expected runtime SLO impact. This only changes Shikimori OAuth login credentials and redirect plumbing.

## Rollback
- Revert this PR to restore the previous Shikimori OAuth client and redirect behavior.

## Release Notes
- Shikimori login now uses Rayniyomi-owned OAuth registration instead of the inherited Aniyomi registration.

## Checklist
- [x] Naming conventions followed (use "Rayniyomi" in user-facing text, see [naming conventions](../docs/governance/naming-conventions.md))
- [x] Branch rebased on latest main and verification re-run (see [rebase policy](../docs/governance/agent-workflow.md#rebase-before-merge-policy-r45))
- [x] New coroutine scopes have documented owner and cancellation path
- [x] No new `runBlocking` on UI/main thread paths

## Definition of Done (DoD)
- [ ] Acceptance criteria met and non-goals respected
- [x] Verification matrix completed (Risk Tier: T2)
- [x] Self-review completed
- [x] Rebased on latest `main` and revalidated (mandatory for merge)
- [ ] Sprint board updated (branch, commit, checks, PR link)
- [x] Release notes drafted (if applicable)

## Fork Compliance Checklist (for new forks only)
Not applicable; this is a fork credential cleanup, not creation of a new fork.

## Remaining Manual Validation
- Confirm in Shikimori OAuth application settings that only `user_rates` is enabled.
- Validate an actual Shikimori login on emulator/device before closing #707 as fully complete.


