### PR TITLE
docs: clean stale governance doc references (R670)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -38,8 +38,8 @@
 - If no user-facing impact, explain why.
 
 ## Checklist
-- [ ] Naming conventions followed (use "Rayniyomi" in user-facing text, see [naming conventions](../docs/governance/naming-conventions.md))
-- [ ] Branch rebased on latest main and verification re-run (see [rebase policy](../docs/governance/agent-workflow.md#rebase-before-merge-policy-r45))
+- [ ] Naming conventions followed (use "Rayniyomi" in user-facing text; see [branding guardrail](../docs/branding-guardrail.md))
+- [ ] Branch rebased on latest main and verification re-run
 - [ ] New coroutine scopes have documented owner and cancellation path
 - [ ] No new `runBlocking` on UI/main thread paths
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Baseline profile CI job now dry-runs `:app:generateBaselineProfile` and verifies `baseline-prof.txt` is committed and non-empty on every PR touching app or macrobenchmark paths.
 
 ### Other
+- Contributor docs now point PR authors at existing governance and guardrail files instead of removed policy paths.
 - Core maintenance dependencies refreshed: OkHttp 5.4.0, Cast framework 22.3.1, jsoup 1.22.2, AndroidX SQLite 2.6.2, Coil BOM 3.5.0, Material Components 1.14.0, JUnit 6.1.0, Kotest 6.2.1, and MockK 1.14.11.
 - OkHttp and JUnit test dependencies now use BOM-managed versions so related artifacts stay aligned across app, core, and test modules.
 - Anime and manga tracking screens now share common presentation components while keeping their typed entrypoints separate.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,19 +16,16 @@ You do not need to ask for permission nor an assignment.
 
 ## Pull Request policy
 
-- Use ticket-based PR titles: `[R123] short imperative summary`
+- Use Conventional Commit PR titles with the ticket ID suffix: `fix: short summary (R123)`.
 - Fill out all required sections in the PR template.
 - Include verification evidence.
 - For user-facing changes, include a concrete Release Notes section.
 
-See governance docs:
-- [`docs/governance/agent-workflow.md`](docs/governance/agent-workflow.md)
-- [`docs/governance/branch-protection.md`](docs/governance/branch-protection.md)
-- [`docs/governance/dependency-policy.md`](docs/governance/dependency-policy.md)
-- [`docs/governance/labels-policy.md`](docs/governance/labels-policy.md)
-- [`docs/governance/release-notes-policy.md`](docs/governance/release-notes-policy.md)
-
-- ADRs: [`docs/adr/`](docs/adr/)
+See current governance docs:
+- PR validation: [`.github/workflows/pr_governance.yml`](.github/workflows/pr_governance.yml)
+- PR template: [`.github/pull_request_template.md`](.github/pull_request_template.md)
+- CI tiering: [`docs/ci-tiering.md`](docs/ci-tiering.md)
+- Branding guardrail: [`docs/branding-guardrail.md`](docs/branding-guardrail.md)
 
 ## Prerequisites
 


### PR DESCRIPTION
## Objective
Clean stale contributor/governance documentation references so PR authors are not pointed at removed policy files.

## Scope
- Align `CONTRIBUTING.md` PR title guidance with the enforced Conventional Commit title format.
- Replace removed governance doc links with existing PR governance, PR template, CI tiering, and branding guardrail files.
- Retarget PR template checklist links away from removed `docs/governance/*` files.
- Add an Unreleased changelog entry under Other.

## Non-goals
- No runtime, app, CI workflow, or policy behavior changes.
- No broad documentation rewrite.

## Files Changed
- `CONTRIBUTING.md`
- `.github/pull_request_template.md`
- `CHANGELOG.md`

## Verification
- `python3` local Markdown/YAML link check across repo Markdown files: passed, no missing local Markdown/YAML links found.
- `rg -n "docs/governance|docs/agent-templates|coroutine-scope-policy|GEMINI\.md|agent-workflow|naming-conventions|docs/adr" CONTRIBUTING.md .github/pull_request_template.md CHANGELOG.md docs README.md`: passed, no stale references found.
- `git diff --check`: passed.
- `./gradlew spotlessCheck`: passed.
- `./gradlew :app:compileStableDebugKotlin`: passed with pre-existing warnings.
- Pre-push hook reran `spotlessCheck` and `:app:compileStableDebugKotlin`: passed.

## Risk
Low. Docs-only cleanup limited to contributor guidance and changelog. Main risk is wording drift from current governance, mitigated by aligning title/body guidance to `.github/workflows/pr_governance.yml` and linking only existing files.

## Release Notes
- Contributor docs now point PR authors at existing governance and guardrail files instead of removed policy paths.

Closes #745
