### PR TITLE
build: make custom lint guardrails configuration-cache safe (R672)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Orphaned Compose reader migration benchmark gate scripts, artifacts, tests, and documentation were removed after the invoking CI workflow was deleted.
 
 ### CI
+- Custom lint guardrails now run cleanly with Gradle configuration cache enabled.
 - PR CI now skips Gradle-heavy jobs for docs, workflow, and CI-test-only changes while keeping app-relevant build, format, unit-test, and baseline-profile coverage.
 - Gitleaks PR scans now check out the pull request head with enough history to resolve commit ranges after queue delays, merges, or branch cleanup.
 - SqlDelight now uses released artifacts instead of snapshot/local Maven bootstrap wiring, with CI guardrails preventing snapshot dependency regression.

--- a/buildSrc/src/main/kotlin/mihon.code.lint.gradle.kts
+++ b/buildSrc/src/main/kotlin/mihon.code.lint.gradle.kts
@@ -1,4 +1,7 @@
 import org.gradle.accessors.dm.LibrariesForLibs
+import mihon.buildlogic.tasks.CheckBlockingCallsTask
+import mihon.buildlogic.tasks.CheckDeadXmlLayoutsTask
+import mihon.buildlogic.tasks.CheckNoXmlForMigratedScreensTask
 
 plugins {
     id("com.diffplug.spotless")
@@ -34,164 +37,50 @@ spotless {
     }
 }
 
-tasks.register("checkBlockingCalls") {
+tasks.register<CheckBlockingCallsTask>("checkBlockingCalls") {
     group = "verification"
     description = "Check for runBlocking usage in UI-layer code"
-
-    doLast {
-        val violations = mutableListOf<String>()
-        val uiPaths = listOf(
+    sourceDir.set(layout.projectDirectory.dir("src/main/java"))
+    uiPaths.set(
+        listOf(
             "eu/kanade/tachiyomi/ui",
             "eu/kanade/presentation",
-        )
-
-        // Pre-existing violations baselined before guardrail was added.
-        // Remove entries as they are fixed in dedicated tickets.
-        val baseline = setOf(
-            "ReaderChapterListManager.kt",
-        )
-
-        val sourceDir = projectDir.resolve("src/main/java")
-        if (!sourceDir.exists()) return@doLast
-
-        sourceDir.walkTopDown()
-            .filter { it.extension == "kt" }
-            .filter { file -> uiPaths.any { file.path.contains(it) } }
-            .filter { file -> !file.path.contains("/test/") && !file.path.contains("/androidTest/") }
-            .filter { file -> file.name !in baseline }
-            .forEach { file ->
-                file.readLines().forEachIndexed { index, line ->
-                    val trimmed = line.trim()
-                    if (trimmed.contains("runBlocking") &&
-                        !trimmed.startsWith("import ") &&
-                        !trimmed.startsWith("//") &&
-                        !trimmed.startsWith("*") &&
-                        !trimmed.startsWith("/*")) {
-                        violations.add("${file.relativeTo(projectDir)}:${index + 1}: $trimmed")
-                    }
-                }
-            }
-
-        if (violations.isNotEmpty()) {
-            violations.forEach { logger.error("BLOCKING_CALL: $it") }
-            throw GradleException(
-                "Found ${violations.size} runBlocking usage(s) in UI-layer code. " +
-                "Use coroutine scopes instead (viewModelScope.launchIO, lifecycleScope)."
-            )
-        } else {
-            logger.lifecycle("checkBlockingCalls: No blocking calls found in UI-layer code ✓")
-        }
-    }
+        ),
+    )
+    // Pre-existing violations baselined before guardrail was added.
+    // Remove entries as they are fixed in dedicated tickets.
+    baseline.set(listOf("ReaderChapterListManager.kt"))
 }
 
-tasks.register("checkDeadXmlLayouts") {
+tasks.register<CheckDeadXmlLayoutsTask>("checkDeadXmlLayouts") {
     group = "verification"
     description = "Check for unreferenced XML layout files not tracked for migration"
-    notCompatibleWithConfigurationCache("Scans file system at execution time")
-
-    doLast {
-        // Layouts known to be dead but pending deletion — add names here to suppress false positives
-        // during the deletion migration window. Remove entries after the file is deleted.
-        val migratedLayouts = emptySet<String>()
-
-        val layoutDir = projectDir.resolve("src/main/res/layout")
-        if (!layoutDir.exists()) return@doLast
-
-        val sourceRoots = listOf(
-            projectDir.resolve("src/main/java"),
-            projectDir.resolve("src/main/kotlin"),
-            projectDir.resolve("src/main/res"),
-        )
-
-        fun toPascalCaseBinding(layoutName: String): String {
-            return layoutName.split("_").joinToString("") { part ->
-                part.replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }
-            } + "Binding"
-        }
-
-        fun buildSearchPatterns(layoutName: String): List<String> = listOf(
-            "R.layout.$layoutName",
-            "@layout/$layoutName",
-            "${toPascalCaseBinding(layoutName)}.inflate",
-            "${toPascalCaseBinding(layoutName)}.bind",
-        )
-
-        fun isLayoutReferenced(layoutName: String): Boolean {
-            val patterns = buildSearchPatterns(layoutName)
-            for (sourceRoot in sourceRoots) {
-                if (!sourceRoot.exists()) continue
-                sourceRoot.walkTopDown()
-                    .filter { it.isFile && (it.extension == "kt" || it.extension == "java" || it.extension == "xml") }
-                    .forEach { file ->
-                        val content = file.readText()
-                        if (patterns.any { content.contains(it) }) return true
-                    }
-            }
-            return false
-        }
-
-        val violations = mutableListOf<String>()
-
-        layoutDir.listFiles()
-            ?.filter { it.extension == "xml" }
-            ?.forEach { xmlFile ->
-                val layoutName = xmlFile.nameWithoutExtension
-                if (layoutName in migratedLayouts) return@forEach
-                if (!isLayoutReferenced(layoutName)) {
-                    violations.add(layoutName)
-                }
-            }
-
-        if (violations.isNotEmpty()) {
-            violations.forEach { name ->
-                logger.error("DEAD_LAYOUT: $name — not referenced in any source file")
-            }
-            throw GradleException(
-                "Found ${violations.size} unreferenced XML layout(s). " +
-                "Either reference the layout, delete it, or add it to the migratedLayouts " +
-                "baseline in buildSrc/src/main/kotlin/mihon.code.lint.gradle.kts."
-            )
-        } else {
-            logger.lifecycle("checkDeadXmlLayouts: No unexpected dead layouts found ✓")
-        }
-    }
+    layoutDir.set(layout.projectDirectory.dir("src/main/res/layout"))
+    sourceRoots.from(
+        layout.projectDirectory.dir("src/main/java"),
+        layout.projectDirectory.dir("src/main/kotlin"),
+        layout.projectDirectory.dir("src/main/res"),
+    )
+    // Layouts known to be dead but pending deletion during the deletion migration window.
+    migratedLayouts.set(emptyList())
 }
 
-tasks.register("checkNoXmlForMigratedScreens") {
+tasks.register<CheckNoXmlForMigratedScreensTask>("checkNoXmlForMigratedScreens") {
     group = "verification"
     description = "Guard against re-introduction of XML layouts for screens migrated to Compose"
-    notCompatibleWithConfigurationCache("Scans file system at execution time")
 
-    doLast {
-        // Screens that have been migrated to Compose — their XML layouts must never come back.
-        // Add entries here whenever a screen completes its Compose migration.
-        val migratedScreens = setOf(
+    layoutDir.set(layout.projectDirectory.dir("src/main/res/layout"))
+    // Screens that have been migrated to Compose — their XML layouts must never come back.
+    // Add entries here whenever a screen completes its Compose migration.
+    migratedScreens.set(
+        listOf(
             "download_header",
             "download_item",
             "download_list",
             "player_layout",
             "reader_error",
-        )
-
-        val layoutDir = projectDir.resolve("src/main/res/layout")
-        if (!layoutDir.exists()) return@doLast
-
-        val reintroduced = layoutDir.listFiles()
-            ?.filter { it.extension == "xml" && it.nameWithoutExtension in migratedScreens }
-            ?: emptyList()
-
-        if (reintroduced.isNotEmpty()) {
-            reintroduced.forEach { file ->
-                logger.error("COMPOSE_REGRESSION: ${file.name} — this screen has been migrated to Compose; delete the XML layout")
-            }
-            throw GradleException(
-                "Found ${reintroduced.size} XML layout(s) for Compose-migrated screen(s). " +
-                "Remove the XML file(s) — these screens must not revert to XML."
-            )
-        } else {
-            logger.lifecycle("checkNoXmlForMigratedScreens: No Compose migration regressions found ✓")
-        }
-    }
+        ),
+    )
 }
 
 tasks.named("check") {

--- a/buildSrc/src/main/kotlin/mihon/buildlogic/tasks/CodeLintTasks.kt
+++ b/buildSrc/src/main/kotlin/mihon/buildlogic/tasks/CodeLintTasks.kt
@@ -1,0 +1,175 @@
+package mihon.buildlogic.tasks
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+
+abstract class CheckBlockingCallsTask : DefaultTask() {
+
+    @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val sourceDir: DirectoryProperty
+
+    @get:Input
+    abstract val uiPaths: ListProperty<String>
+
+    @get:Input
+    abstract val baseline: ListProperty<String>
+
+    @TaskAction
+    fun check() {
+        val violations = mutableListOf<String>()
+        val sourceDirFile = sourceDir.get().asFile
+        if (!sourceDirFile.exists()) return
+
+        val uiPathValues = uiPaths.get()
+        val baselineValues = baseline.get().toSet()
+        val projectDir = sourceDirFile.parentFile.parentFile.parentFile
+
+        sourceDirFile.walkTopDown()
+            .filter { it.extension == "kt" }
+            .filter { file -> uiPathValues.any { file.path.contains(it) } }
+            .filter { file -> !file.path.contains("/test/") && !file.path.contains("/androidTest/") }
+            .filter { file -> file.name !in baselineValues }
+            .forEach { file ->
+                file.readLines().forEachIndexed { index, line ->
+                    val trimmed = line.trim()
+                    if (trimmed.contains("runBlocking") &&
+                        !trimmed.startsWith("import ") &&
+                        !trimmed.startsWith("//") &&
+                        !trimmed.startsWith("*") &&
+                        !trimmed.startsWith("/*")
+                    ) {
+                        violations.add("${file.relativeTo(projectDir)}:${index + 1}: $trimmed")
+                    }
+                }
+            }
+
+        if (violations.isNotEmpty()) {
+            violations.forEach { logger.error("BLOCKING_CALL: $it") }
+            throw GradleException(
+                "Found ${violations.size} runBlocking usage(s) in UI-layer code. " +
+                    "Use coroutine scopes instead (viewModelScope.launchIO, lifecycleScope).",
+            )
+        } else {
+            logger.lifecycle("checkBlockingCalls: No blocking calls found in UI-layer code ✓")
+        }
+    }
+}
+
+abstract class CheckDeadXmlLayoutsTask : DefaultTask() {
+
+    @get:InputDirectory
+    @get:Optional
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val layoutDir: DirectoryProperty
+
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val sourceRoots: ConfigurableFileCollection
+
+    @get:Input
+    abstract val migratedLayouts: ListProperty<String>
+
+    @TaskAction
+    fun check() {
+        val layoutDirFile = layoutDir.get().asFile
+        if (!layoutDirFile.exists()) return
+
+        val migratedLayoutValues = migratedLayouts.get().toSet()
+        val violations = mutableListOf<String>()
+
+        layoutDirFile.listFiles()
+            ?.filter { it.extension == "xml" }
+            ?.forEach { xmlFile ->
+                val layoutName = xmlFile.nameWithoutExtension
+                if (layoutName in migratedLayoutValues) return@forEach
+                if (!isLayoutReferenced(layoutName)) {
+                    violations.add(layoutName)
+                }
+            }
+
+        if (violations.isNotEmpty()) {
+            violations.forEach { name ->
+                logger.error("DEAD_LAYOUT: $name — not referenced in any source file")
+            }
+            throw GradleException(
+                "Found ${violations.size} unreferenced XML layout(s). " +
+                    "Either reference the layout, delete it, or add it to the migratedLayouts " +
+                    "baseline in buildSrc/src/main/kotlin/mihon.code.lint.gradle.kts.",
+            )
+        } else {
+            logger.lifecycle("checkDeadXmlLayouts: No unexpected dead layouts found ✓")
+        }
+    }
+
+    private fun isLayoutReferenced(layoutName: String): Boolean {
+        val patterns = buildSearchPatterns(layoutName)
+        for (sourceRoot in sourceRoots.files) {
+            if (!sourceRoot.exists()) continue
+            sourceRoot.walkTopDown()
+                .filter { it.isFile && (it.extension == "kt" || it.extension == "java" || it.extension == "xml") }
+                .forEach { file ->
+                    val content = file.readText()
+                    if (patterns.any { content.contains(it) }) return true
+                }
+        }
+        return false
+    }
+
+    private fun buildSearchPatterns(layoutName: String): List<String> = listOf(
+        "R.layout.$layoutName",
+        "@layout/$layoutName",
+        "${toPascalCaseBinding(layoutName)}.inflate",
+        "${toPascalCaseBinding(layoutName)}.bind",
+    )
+
+    private fun toPascalCaseBinding(layoutName: String): String {
+        return layoutName.split("_").joinToString("") { part ->
+            part.replaceFirstChar { if (it.isLowerCase()) it.titlecase() else it.toString() }
+        } + "Binding"
+    }
+}
+
+abstract class CheckNoXmlForMigratedScreensTask : DefaultTask() {
+
+    @get:InputDirectory
+    @get:Optional
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val layoutDir: DirectoryProperty
+
+    @get:Input
+    abstract val migratedScreens: ListProperty<String>
+
+    @TaskAction
+    fun check() {
+        val layoutDirFile = layoutDir.get().asFile
+        if (!layoutDirFile.exists()) return
+
+        val migratedScreenValues = migratedScreens.get().toSet()
+        val reintroduced = layoutDirFile.listFiles()
+            ?.filter { it.extension == "xml" && it.nameWithoutExtension in migratedScreenValues }
+            ?: emptyList()
+
+        if (reintroduced.isNotEmpty()) {
+            reintroduced.forEach { file ->
+                logger.error("COMPOSE_REGRESSION: ${file.name} — this screen has been migrated to Compose; delete the XML layout")
+            }
+            throw GradleException(
+                "Found ${reintroduced.size} XML layout(s) for Compose-migrated screen(s). " +
+                    "Remove the XML file(s) — these screens must not revert to XML.",
+            )
+        } else {
+            logger.lifecycle("checkNoXmlForMigratedScreens: No Compose migration regressions found ✓")
+        }
+    }
+}


### PR DESCRIPTION
## Ticket
- ID: R672
- Priority: P2
- Risk Tier: T1
- GitHub Issue: Closes #748

## Objective
Make the custom lint guardrails pass cleanly with the repository's enabled Gradle configuration cache so successful guardrail checks do not still fail during cache storage.

## Scope
- Move custom lint guardrail actions into typed buildSrc task classes with explicit Gradle inputs.
- Preserve the existing UI `runBlocking`, dead XML layout, and Compose migration XML guardrail behavior.
- Keep all three guardrails wired into `check`.
- Add an Unreleased CI changelog entry.

## Non-goals
- No runtime `runBlocking` changes.
- No source API, Rx extension compatibility, repository, UI, light novel, or plugin changes.
- No R673 Gradle `srcDir(...)` deprecation cleanup.

## Files Changed
- `buildSrc` custom lint task registration and task implementations.
- `CHANGELOG.md` Unreleased CI entry.

## Verification
- Commands run:
  - `./gradlew :app:checkBlockingCalls` before implementation reproduced the baseline config-cache serialization failure after the guardrail logic passed.
  - `./gradlew :app:checkBlockingCalls` after implementation: passed, configuration cache entry stored.
  - `./gradlew :app:checkBlockingCalls` second run: passed, configuration cache entry reused.
  - `./gradlew :app:checkDeadXmlLayouts :app:checkNoXmlForMigratedScreens`: passed, configuration cache entry stored.
  - same XML guardrail command second run: passed, configuration cache entry reused.
  - temporary `runBlocking` probe under `app/src/main/java/eu/kanade/presentation/`: failed with `BLOCKING_CALL`.
  - temporary `reader_error.xml` probe: failed with `COMPOSE_REGRESSION`.
  - temporary unreferenced XML layout probe: failed with `DEAD_LAYOUT`.
  - post-probe `rg -n "runBlocking|reader_error|temporary_probe|dead_layout_probe" app/src/main/java/eu/kanade/presentation app/src/main/res/layout`: no matches.
  - `./gradlew spotlessCheck`: passed.
  - `./gradlew :app:compileStableDebugKotlin`: passed.
  - `git diff --check`: passed.
- Results:
  - Custom guardrails now store and reuse configuration cache.
  - Negative probes confirm guardrail failures still trigger as expected.
- Not tested:
  - Full `./gradlew :app:check` is currently blocked outside R672 by `:core-metadata:debugUnitTestRuntimeClasspath` failing to resolve `org.junit.platform:junit-platform-launcher:.`, plus an AGP lint model configuration-cache serialization issue. Targeted custom guardrail tasks were used for R672 acceptance.

## Risk
Low. This is buildSrc tooling only. Main regression risk is accidentally weakening guardrail detection; mitigated with negative probes for all three guardrails and unchanged scan semantics.

## SLO Impact
No runtime SLO impact. This affects developer/CI verification behavior only.

## Rollback
Revert this PR to restore the previous closure-based guardrail task registrations.

## Release Notes
Custom lint guardrails now run cleanly with Gradle configuration cache enabled.

## Checklist
- [x] Naming conventions followed (use "Rayniyomi" in user-facing text; see [branding guardrail](../docs/branding-guardrail.md))
- [x] Branch rebased on latest main and verification re-run
- [x] New coroutine scopes have documented owner and cancellation path
- [x] No new `runBlocking` on UI/main thread paths

## Definition of Done (DoD)
- [x] Acceptance criteria met and non-goals respected
- [x] Verification matrix completed (Risk Tier: T1)
- [x] Self-review completed
- [x] Rebased on latest `main` and revalidated (mandatory for merge)
- [x] Sprint board updated (branch, commit, checks, PR link)
- [x] Release notes drafted (if applicable)

## Fork Compliance Checklist (for new forks only)
Not applicable.
