### PR TITLE
build: replace deprecated Gradle resource srcDir APIs (R673)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Baseline profile CI job now dry-runs `:app:generateBaselineProfile` and verifies `baseline-prof.txt` is committed and non-empty on every PR touching app or macrobenchmark paths.
 
 ### Other
+- Gradle resource source-set declarations now use the current directory-set API.
 - Contributor docs now point PR authors at existing governance and guardrail files instead of removed policy paths.
 - Core maintenance dependencies refreshed: OkHttp 5.4.0, Cast framework 22.3.1, jsoup 1.22.2, AndroidX SQLite 2.6.2, Coil BOM 3.5.0, Material Components 1.14.0, JUnit 6.1.0, Kotest 6.2.1, and MockK 1.14.11.
 - OkHttp and JUnit test dependencies now use BOM-managed versions so related artifacts stay aligned across app, core, and test modules.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -127,8 +127,8 @@ android {
     }
 
     sourceSets {
-        getByName("preview") { res.srcDir("src/debug/res") }
-        getByName("benchmark") { res.srcDir("src/debug/res") }
+        getByName("preview") { res.directories.add("src/debug/res") }
+        getByName("benchmark") { res.directories.add("src/debug/res") }
     }
 
     testOptions {
@@ -217,7 +217,7 @@ afterEvaluate {
         "stableRelease" to "injectCrashlyticsMappingFileIdStableRelease",
     ).forEach { (sourceSetName, generatedDir) ->
         android.sourceSets.findByName(sourceSetName)
-            ?.res?.srcDir("build/generated/res/$generatedDir")
+            ?.res?.directories?.add("build/generated/res/$generatedDir")
     }
 }
 


### PR DESCRIPTION
## Ticket
- ID: R673
- Priority: P2
- Risk Tier: T1
- GitHub Issue: Closes #749

## Objective
- Replace deprecated Android Gradle resource source-set `srcDir(...)` declarations with the current directory-set API so app Gradle configuration no longer emits the targeted R673 deprecation warnings.

## Scope
- Updated the preview and benchmark resource source-set declarations in `app/build.gradle.kts`.
- Updated the generated Crashlytics mapping resource directory wiring in `app/build.gradle.kts`.
- Added an Unreleased changelog entry under Other.

## Non-goals
- No runtime, UI, repository, source API, extension compatibility, light novel, or plugin changes.
- No cleanup of unrelated Gradle, Kotlin, AGP, or Compose deprecation warnings.

## Files Changed
- `app/build.gradle.kts`
- `CHANGELOG.md`

## Verification
- Commands run:
  - `./gradlew :app:compileStableDebugKotlin --warning-mode all`
  - `rg -n 'res\\.srcDir|srcDir\\("src/debug/res"|srcDir\\("build/generated/res' app/build.gradle.kts`
  - `./gradlew spotlessCheck`
  - `./gradlew :app:compileStableDebugKotlin`
  - `git diff --check`
- Results:
  - Compile succeeded; the targeted `app/build.gradle.kts` resource `srcDir(...)` deprecation warnings are gone.
  - Source search found no remaining deprecated resource `srcDir` call sites in `app/build.gradle.kts`.
  - Spotless, compile, and whitespace checks passed.
  - Pre-push hook reran `spotlessCheck` and `:app:compileStableDebugKotlin` successfully.
- Not tested:
  - No device or emulator testing; this is a Gradle build-script-only cleanup.

## Risk
- Low risk. The change preserves the same resource directories and only swaps the deprecated mutator API for `res.directories.add(...)`.

## SLO Impact
- No runtime SLO impact expected.

## Rollback
- Revert this PR to restore the previous `res.srcDir(...)` declarations if AGP behavior unexpectedly differs.

## Release Notes
- Gradle resource source-set declarations now use the current directory-set API.

## Checklist
- [x] Naming conventions followed (use "Rayniyomi" in user-facing text; see [branding guardrail](../docs/branding-guardrail.md))
- [x] Branch rebased on latest main and verification re-run
- [x] New coroutine scopes have documented owner and cancellation path
- [x] No new `runBlocking` on UI/main thread paths

## Definition of Done (DoD)
- [x] Acceptance criteria met and non-goals respected
- [x] Verification matrix completed (Risk Tier: T1)
- [x] Self-review completed
- [x] Rebased on latest `main` and revalidated (mandatory for merge)
- [ ] Sprint board updated (branch, commit, checks, PR link)
- [x] Release notes drafted (if applicable)

## Fork Compliance Checklist (for new forks only)
If you are creating a new fork of this project, ensure the following:
- [ ] **App Identity**: Changed app name from "Aniyomi" to your fork name
- [ ] **App Icon**: Replaced launcher icon assets with fork-specific icons
- [ ] **Application ID**: Changed `applicationId` in `app/build.gradle.kts` from `xyz.rayniyomi` to your unique ID
- [ ] **Update Checker**: Configured `AppUpdateChecker.kt` to point to your fork's repository
- [ ] **Analytics**: Either disabled Firebase Analytics or configured with your own `google-services.json`
- [ ] **Crash Reporting**: Either disabled ACRA crash reporting or configured with your own endpoint credentials

See [CONTRIBUTING.md](../CONTRIBUTING.md) Forks section for details.
