### PR TITLE
refactor: migrate remaining top-level launchUI consumers (R674)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 
 ### Other
 - Gradle resource source-set declarations now use the current directory-set API.
+- Removed the deprecated top-level UI coroutine launch helper after migrating its remaining callers.
 - Contributor docs now point PR authors at existing governance and guardrail files instead of removed policy paths.
 - Core maintenance dependencies refreshed: OkHttp 5.4.0, Cast framework 22.3.1, jsoup 1.22.2, AndroidX SQLite 2.6.2, Coil BOM 3.5.0, Material Components 1.14.0, JUnit 6.1.0, Kotest 6.2.1, and MockK 1.14.11.
 - OkHttp and JUnit test dependencies now use BOM-managed versions so related artifacts stay aligned across app, core, and test modules.

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/anime/AnimeLibraryUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/anime/AnimeLibraryUpdateJob.kt
@@ -40,6 +40,7 @@ import eu.kanade.tachiyomi.util.system.isConnectedToWifi
 import eu.kanade.tachiyomi.util.system.isRunning
 import eu.kanade.tachiyomi.util.system.workManager
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -127,7 +128,7 @@ class AnimeLibraryUpdateJob(private val context: Context, workerParams: WorkerPa
 
         return withIOContext {
             try {
-                updateEpisodeList()
+                updateEpisodeList(this)
                 Result.success()
             } catch (e: Exception) {
                 if (e is CancellationException) {
@@ -267,7 +268,7 @@ class AnimeLibraryUpdateJob(private val context: Context, workerParams: WorkerPa
      *
      * @return an observable delivering the progress of each update.
      */
-    private suspend fun updateEpisodeList() {
+    private suspend fun updateEpisodeList(scope: CoroutineScope) {
         val semaphore = Semaphore(5)
         val progressCount = AtomicInteger(0)
         val currentlyUpdatingAnime = CopyOnWriteArrayList<Anime>()
@@ -337,7 +338,7 @@ class AnimeLibraryUpdateJob(private val context: Context, workerParams: WorkerPa
         notifier.cancelProgressNotification()
 
         if (newUpdates.isNotEmpty()) {
-            notifier.showUpdateNotifications(newUpdates)
+            notifier.showUpdateNotifications(newUpdates, scope)
             if (hasDownloads.get()) {
                 downloadManager.startDownloads()
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/anime/AnimeLibraryUpdateNotifier.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/anime/AnimeLibraryUpdateNotifier.kt
@@ -29,9 +29,11 @@ import eu.kanade.tachiyomi.util.system.cancelNotification
 import eu.kanade.tachiyomi.util.system.getBitmapOrNull
 import eu.kanade.tachiyomi.util.system.notificationBuilder
 import eu.kanade.tachiyomi.util.system.notify
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import logcat.LogPriority
 import tachiyomi.core.common.i18n.stringResource
-import tachiyomi.core.common.util.lang.launchUI
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.entries.anime.model.Anime
 import tachiyomi.domain.items.episode.model.Episode
@@ -183,7 +185,7 @@ class AnimeLibraryUpdateNotifier(
      *
      * @param updates a list of anime with new updates.
      */
-    fun showUpdateNotifications(updates: List<Pair<Anime, Array<Episode>>>) {
+    fun showUpdateNotifications(updates: List<Pair<Anime, Array<Episode>>>, scope: CoroutineScope) {
         // Parent group notification
         context.notify(
             Notifications.ID_NEW_EPISODES,
@@ -226,7 +228,7 @@ class AnimeLibraryUpdateNotifier(
 
         // Per-anime notification
         if (!securityPreferences.hideNotificationContent().get()) {
-            launchUI {
+            scope.launch(Dispatchers.Main) {
                 context.notify(
                     updates.mapNotNull { (anime, episodes) ->
                         createNewEpisodesNotification(anime, episodes)?.let {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/manga/MangaLibraryUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/manga/MangaLibraryUpdateJob.kt
@@ -38,6 +38,7 @@ import eu.kanade.tachiyomi.util.system.isConnectedToWifi
 import eu.kanade.tachiyomi.util.system.isRunning
 import eu.kanade.tachiyomi.util.system.workManager
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -121,7 +122,7 @@ class MangaLibraryUpdateJob(private val context: Context, workerParams: WorkerPa
 
         return withIOContext {
             try {
-                updateChapterList()
+                updateChapterList(this)
                 Result.success()
             } catch (e: Exception) {
                 if (e is CancellationException) {
@@ -241,7 +242,7 @@ class MangaLibraryUpdateJob(private val context: Context, workerParams: WorkerPa
      *
      * @return an observable delivering the progress of each update.
      */
-    private suspend fun updateChapterList() {
+    private suspend fun updateChapterList(scope: CoroutineScope) {
         val semaphore = Semaphore(5)
         val progressCount = AtomicInteger(0)
         val currentlyUpdatingManga = CopyOnWriteArrayList<Manga>()
@@ -309,7 +310,7 @@ class MangaLibraryUpdateJob(private val context: Context, workerParams: WorkerPa
         notifier.cancelProgressNotification()
 
         if (newUpdates.isNotEmpty()) {
-            notifier.showUpdateNotifications(newUpdates)
+            notifier.showUpdateNotifications(newUpdates, scope)
             if (hasDownloads.get()) {
                 downloadManager.startDownloads()
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/manga/MangaLibraryUpdateNotifier.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/manga/MangaLibraryUpdateNotifier.kt
@@ -29,8 +29,12 @@ import eu.kanade.tachiyomi.util.system.cancelNotification
 import eu.kanade.tachiyomi.util.system.getBitmapOrNull
 import eu.kanade.tachiyomi.util.system.notificationBuilder
 import eu.kanade.tachiyomi.util.system.notify
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import logcat.LogPriority
 import tachiyomi.core.common.i18n.stringResource
-import tachiyomi.core.common.util.lang.launchUI
+import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.entries.manga.model.Manga
 import tachiyomi.domain.items.chapter.model.Chapter
 import tachiyomi.domain.library.manga.LibraryManga
@@ -170,7 +174,7 @@ class MangaLibraryUpdateNotifier(
      *
      * @param updates a list of manga with new updates.
      */
-    fun showUpdateNotifications(updates: List<Pair<Manga, Array<Chapter>>>) {
+    fun showUpdateNotifications(updates: List<Pair<Manga, Array<Chapter>>>, scope: CoroutineScope) {
         // Parent group notification
         context.notify(
             Notifications.ID_NEW_CHAPTERS,
@@ -213,20 +217,28 @@ class MangaLibraryUpdateNotifier(
 
         // Per-manga notification
         if (!securityPreferences.hideNotificationContent().get()) {
-            launchUI {
+            scope.launch(Dispatchers.Main) {
                 context.notify(
-                    updates.map { (manga, chapters) ->
-                        NotificationManagerCompat.NotificationWithIdAndTag(
-                            manga.id.hashCode(),
-                            createNewChaptersNotification(manga, chapters),
-                        )
+                    updates.mapNotNull { (manga, chapters) ->
+                        createNewChaptersNotification(manga, chapters)?.let {
+                            NotificationManagerCompat.NotificationWithIdAndTag(manga.id.hashCode(), it)
+                        }
                     },
                 )
             }
         }
     }
 
-    private suspend fun createNewChaptersNotification(manga: Manga, chapters: Array<Chapter>): Notification {
+    private suspend fun createNewChaptersNotification(manga: Manga, chapters: Array<Chapter>): Notification? {
+        return try {
+            buildNewChaptersNotification(manga, chapters)
+        } catch (e: Throwable) {
+            logcat(LogPriority.WARN, e) { "Failed to create notification for manga: ${manga.title}" }
+            null
+        }
+    }
+
+    private suspend fun buildNewChaptersNotification(manga: Manga, chapters: Array<Chapter>): Notification {
         val icon = getMangaIcon(manga)
         return context.notificationBuilder(Notifications.CHANNEL_NEW_CHAPTERS_EPISODES) {
             setContentTitle(manga.title)

--- a/core/common/src/main/java/eu/kanade/tachiyomi/network/interceptor/WebViewInterceptor.kt
+++ b/core/common/src/main/java/eu/kanade/tachiyomi/network/interceptor/WebViewInterceptor.kt
@@ -5,16 +5,15 @@ import android.os.Build
 import android.webkit.WebSettings
 import android.webkit.WebView
 import android.widget.Toast
+import androidx.core.content.ContextCompat
 import eu.kanade.tachiyomi.util.system.DeviceUtil
 import eu.kanade.tachiyomi.util.system.WebViewUtil
 import eu.kanade.tachiyomi.util.system.setDefaultSettings
 import eu.kanade.tachiyomi.util.system.toast
-import kotlinx.coroutines.DelicateCoroutinesApi
 import okhttp3.Headers
 import okhttp3.Interceptor
 import okhttp3.Request
 import okhttp3.Response
-import tachiyomi.core.common.util.lang.launchUI
 import tachiyomi.i18n.MR
 import java.util.Locale
 import java.util.concurrent.CountDownLatch
@@ -49,7 +48,6 @@ abstract class WebViewInterceptor(
 
     abstract fun intercept(chain: Interceptor.Chain, request: Request, response: Response): Response
 
-    @OptIn(DelicateCoroutinesApi::class)
     override fun intercept(chain: Interceptor.Chain): Response {
         val request = chain.request()
         val response = chain.proceed(request)
@@ -58,14 +56,18 @@ abstract class WebViewInterceptor(
         }
 
         if (!WebViewUtil.supportsWebView(context)) {
-            launchUI {
-                context.toast(MR.strings.information_webview_required, Toast.LENGTH_LONG)
-            }
+            notifyWebViewRequired()
             return response
         }
         initWebView
 
         return intercept(chain, request, response)
+    }
+
+    private fun notifyWebViewRequired() {
+        ContextCompat.getMainExecutor(context).execute {
+            context.toast(MR.strings.information_webview_required, Toast.LENGTH_LONG)
+        }
     }
 
     fun parseHeaders(headers: Headers): Map<String, String> {

--- a/core/common/src/main/java/tachiyomi/core/common/util/lang/CoroutinesExtensions.kt
+++ b/core/common/src/main/java/tachiyomi/core/common/util/lang/CoroutinesExtensions.kt
@@ -17,22 +17,6 @@ import kotlinx.coroutines.withContext
  * - suspend function
  * - custom scope like view or presenter scope
  */
-@Deprecated(
-    message = "Use CoroutineScope.launchUI() with an appropriate scope instead of GlobalScope",
-    replaceWith = ReplaceWith("scope.launchUI(block)", "tachiyomi.core.common.util.lang.launchUI"),
-    level = DeprecationLevel.WARNING,
-)
-@DelicateCoroutinesApi
-fun launchUI(block: suspend CoroutineScope.() -> Unit): Job =
-    GlobalScope.launch(Dispatchers.Main, CoroutineStart.DEFAULT, block)
-
-/**
- * Think twice before using this. This is a delicate API. It is easy to accidentally create resource or memory leaks when GlobalScope is used.
- *
- * **Possible replacements**
- * - suspend function
- * - custom scope like view or presenter scope
- */
 @DelicateCoroutinesApi
 fun launchIO(block: suspend CoroutineScope.() -> Unit): Job =
     GlobalScope.launch(Dispatchers.IO, CoroutineStart.DEFAULT, block)


### PR DESCRIPTION
## Ticket
- ID: R674
- Priority: P2
- Risk Tier: T1/T2 boundary, treated as T2 due Android threading behavior review
- GitHub Issue: Closes #750

## Objective
- Remove the deprecated top-level `launchUI { ... }` helper after migrating its remaining in-repo top-level consumers without changing runtime behavior.

## Scope
- Replaced the missing-WebView toast dispatch with a private `notifyWebViewRequired()` helper that schedules the toast on the Android main executor, so the OkHttp interceptor still returns the original response immediately after scheduling UI-thread work.
- Kept anime and manga update notification result methods non-suspending while passing the worker coroutine scope explicitly, preserving the old fire-and-forget ordering before `downloadManager.startDownloads()`.
- Scheduled per-entry anime/manga child notifications on `Dispatchers.Main` from the worker scope instead of hidden `GlobalScope`/`ProcessLifecycleOwner` work.
- Added manga per-item notification failure containment to match anime, so a failed child notification is logged and skipped instead of cancelling the worker child scope.
- Removed only the deprecated top-level `launchUI(...)` helper and kept the scoped `CoroutineScope.launchUI(...)` extension available.
- Added an `Unreleased > Other` changelog entry.

## Non-goals
- No broad coroutine architecture cleanup.
- No changes to notification grouping/content, library update semantics, WebView interception behavior, source APIs, tracker/category code, repositories, UI screen models, or light novel/plugin paths.
- No changes to `launchIO`, `runBlocking`, SQLDelight transaction bridges, or extension compatibility surfaces.

## Files Changed
- `CHANGELOG.md`
- `app/src/main/java/eu/kanade/tachiyomi/data/library/anime/AnimeLibraryUpdateJob.kt`
- `app/src/main/java/eu/kanade/tachiyomi/data/library/anime/AnimeLibraryUpdateNotifier.kt`
- `app/src/main/java/eu/kanade/tachiyomi/data/library/manga/MangaLibraryUpdateJob.kt`
- `app/src/main/java/eu/kanade/tachiyomi/data/library/manga/MangaLibraryUpdateNotifier.kt`
- `core/common/src/main/java/eu/kanade/tachiyomi/network/interceptor/WebViewInterceptor.kt`
- `core/common/src/main/java/tachiyomi/core/common/util/lang/CoroutinesExtensions.kt`

## Verification
- Commands run:
  - `rg -n "^\\s*launchUI\\s*\\{" app core data domain source-api source-local presentation-core presentation-widget lightnovel-contract lightnovel-plugin || true`
  - `rg -n "\\b[a-zA-Z0-9_]+\\.launchUI\\s*\\{" app core data domain source-api source-local presentation-core presentation-widget lightnovel-contract lightnovel-plugin`
  - `rg -n "tachiyomi\\.core\\.common\\.util\\.lang\\.launchUI|fun launchUI|GlobalScope\\.launch\\(Dispatchers\\.Main" app core data domain source-api source-local presentation-core presentation-widget lightnovel-contract lightnovel-plugin`
  - `rg -n "showUpdateNotifications\\(" app core data domain source-api source-local presentation-core presentation-widget lightnovel-contract lightnovel-plugin -g '*.kt'`
  - `git diff --check`
  - `./gradlew spotlessCheck`
  - `./gradlew :app:compileStableDebugKotlin`
- Results:
  - No top-level `launchUI { ... }` call sites remain.
  - Scoped `scope.launchUI { ... }` callers remain and still compile.
  - Remaining `GlobalScope.launch(Dispatchers.Main...)` match is the pre-existing `launchNow` helper, not the removed top-level `launchUI` API.
  - `showUpdateNotifications(...)` has only the two intended worker call sites.
  - `git diff --check` passed.
  - `spotlessCheck` passed.
  - `:app:compileStableDebugKotlin` passed.
  - Independent agent review found one valid manga child-notification failure-containment issue; fixed.
  - Final focused independent review completed with no findings on commit `a42ca70ca`.
- Not tested:
  - No emulator/manual notification flow test. This is a narrow dispatch replacement with compile/source verification and static threading review.

## Risk
- Main risk is threading, cancellation, or ordering drift around notification and toast dispatch.
- Mitigations: kept WebView toast as asynchronous main-thread dispatch, kept notification visibility checks and payloads unchanged, preserved fire-and-forget ordering before downloads start, passed worker scope explicitly instead of hidden process/global scope, and contained manga per-item notification failures to match anime.
- Residual edge case: if WorkManager cancels the worker before the scheduled child notification job runs, child notifications can be skipped. That follows structured cancellation semantics and avoids detached work outliving the worker.

## SLO Impact
- No expected runtime SLO impact. This removes a deprecated helper and preserves async UI dispatch behavior.

## Rollback
- Revert this PR to restore the deprecated top-level helper and previous call sites.

## Release Notes
- Removed the deprecated top-level UI coroutine launch helper after migrating its remaining callers.

## Checklist
- [x] Naming conventions followed (use "Rayniyomi" in user-facing text; see [branding guardrail](../docs/branding-guardrail.md))
- [x] Branch rebased on latest main and verification re-run
- [x] New coroutine scopes have documented owner and cancellation path
- [x] No new `runBlocking` on UI/main thread paths

## Definition of Done (DoD)
- [x] Acceptance criteria met and non-goals respected
- [x] Verification matrix completed (Risk Tier: T1/T2)
- [x] Self-review completed
- [x] Rebased on latest `main` and revalidated (mandatory for merge)
- [ ] Sprint board updated (branch, commit, checks, PR link)
- [x] Release notes drafted (if applicable)

## Fork Compliance Checklist (for new forks only)
If you are creating a new fork of this project, ensure the following:
- [ ] **App Identity**: Changed app name from "Aniyomi" to your fork name
- [ ] **App Icon**: Replaced launcher icon assets with fork-specific icons
- [ ] **Application ID**: Changed `applicationId` in `app/build.gradle.kts` from `xyz.rayniyomi` to your unique ID
- [ ] **Update Checker**: Configured `AppUpdateChecker.kt` to point to your fork's repository
- [ ] **Analytics**: Either disabled Firebase Analytics or configured with your own `google-services.json`
- [ ] **Crash Reporting**: Either disabled ACRA crash reporting or configured with your own endpoint credentials

See [CONTRIBUTING.md](../CONTRIBUTING.md) Forks section for details.
