### PR TITLE
refactor: clean notification coroutine ownership (R674)

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/anime/AnimeLibraryUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/anime/AnimeLibraryUpdateJob.kt
@@ -41,10 +41,12 @@ import eu.kanade.tachiyomi.util.system.isRunning
 import eu.kanade.tachiyomi.util.system.workManager
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
 import logcat.LogPriority
@@ -128,7 +130,7 @@ class AnimeLibraryUpdateJob(private val context: Context, workerParams: WorkerPa
 
         return withIOContext {
             try {
-                updateEpisodeList(this)
+                updateEpisodeList()
                 Result.success()
             } catch (e: Exception) {
                 if (e is CancellationException) {
@@ -268,7 +270,7 @@ class AnimeLibraryUpdateJob(private val context: Context, workerParams: WorkerPa
      *
      * @return an observable delivering the progress of each update.
      */
-    private suspend fun updateEpisodeList(scope: CoroutineScope) {
+    private suspend fun CoroutineScope.updateEpisodeList() {
         val semaphore = Semaphore(5)
         val progressCount = AtomicInteger(0)
         val currentlyUpdatingAnime = CopyOnWriteArrayList<Anime>()
@@ -338,7 +340,12 @@ class AnimeLibraryUpdateJob(private val context: Context, workerParams: WorkerPa
         notifier.cancelProgressNotification()
 
         if (newUpdates.isNotEmpty()) {
-            notifier.showUpdateNotifications(newUpdates, scope)
+            notifier.showUpdateSummaryNotification(newUpdates)
+            if (notifier.shouldShowUpdateDetailNotifications()) {
+                launch(Dispatchers.Main) {
+                    notifier.showUpdateDetailNotifications(newUpdates)
+                }
+            }
             if (hasDownloads.get()) {
                 downloadManager.startDownloads()
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/anime/AnimeLibraryUpdateNotifier.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/anime/AnimeLibraryUpdateNotifier.kt
@@ -29,9 +29,6 @@ import eu.kanade.tachiyomi.util.system.cancelNotification
 import eu.kanade.tachiyomi.util.system.getBitmapOrNull
 import eu.kanade.tachiyomi.util.system.notificationBuilder
 import eu.kanade.tachiyomi.util.system.notify
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 import logcat.LogPriority
 import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.core.common.util.system.logcat
@@ -181,11 +178,11 @@ class AnimeLibraryUpdateNotifier(
     }
 
     /**
-     * Shows the notification containing the result of the update done by the service.
+     * Shows the parent group notification containing the result of the update done by the service.
      *
      * @param updates a list of anime with new updates.
      */
-    fun showUpdateNotifications(updates: List<Pair<Anime, Array<Episode>>>, scope: CoroutineScope) {
+    fun showUpdateSummaryNotification(updates: List<Pair<Anime, Array<Episode>>>) {
         // Parent group notification
         context.notify(
             Notifications.ID_NEW_EPISODES,
@@ -225,19 +222,21 @@ class AnimeLibraryUpdateNotifier(
             setContentIntent(getNotificationIntent())
             setAutoCancel(true)
         }
+    }
 
-        // Per-anime notification
-        if (!securityPreferences.hideNotificationContent().get()) {
-            scope.launch(Dispatchers.Main) {
-                context.notify(
-                    updates.mapNotNull { (anime, episodes) ->
-                        createNewEpisodesNotification(anime, episodes)?.let {
-                            NotificationManagerCompat.NotificationWithIdAndTag(anime.id.hashCode(), it)
-                        }
-                    },
-                )
-            }
-        }
+    fun shouldShowUpdateDetailNotifications(): Boolean {
+        return !securityPreferences.hideNotificationContent().get()
+    }
+
+    internal suspend fun showUpdateDetailNotifications(updates: List<Pair<Anime, Array<Episode>>>) {
+        // Per-anime notifications
+        context.notify(
+            updates.mapNotNull { (anime, episodes) ->
+                createNewEpisodesNotification(anime, episodes)?.let {
+                    NotificationManagerCompat.NotificationWithIdAndTag(anime.id.hashCode(), it)
+                }
+            },
+        )
     }
 
     private suspend fun createNewEpisodesNotification(anime: Anime, episodes: Array<Episode>): Notification? {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/manga/MangaLibraryUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/manga/MangaLibraryUpdateJob.kt
@@ -39,10 +39,12 @@ import eu.kanade.tachiyomi.util.system.isRunning
 import eu.kanade.tachiyomi.util.system.workManager
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
 import logcat.LogPriority
@@ -122,7 +124,7 @@ class MangaLibraryUpdateJob(private val context: Context, workerParams: WorkerPa
 
         return withIOContext {
             try {
-                updateChapterList(this)
+                updateChapterList()
                 Result.success()
             } catch (e: Exception) {
                 if (e is CancellationException) {
@@ -242,7 +244,7 @@ class MangaLibraryUpdateJob(private val context: Context, workerParams: WorkerPa
      *
      * @return an observable delivering the progress of each update.
      */
-    private suspend fun updateChapterList(scope: CoroutineScope) {
+    private suspend fun CoroutineScope.updateChapterList() {
         val semaphore = Semaphore(5)
         val progressCount = AtomicInteger(0)
         val currentlyUpdatingManga = CopyOnWriteArrayList<Manga>()
@@ -310,7 +312,12 @@ class MangaLibraryUpdateJob(private val context: Context, workerParams: WorkerPa
         notifier.cancelProgressNotification()
 
         if (newUpdates.isNotEmpty()) {
-            notifier.showUpdateNotifications(newUpdates, scope)
+            notifier.showUpdateSummaryNotification(newUpdates)
+            if (notifier.shouldShowUpdateDetailNotifications()) {
+                launch(Dispatchers.Main) {
+                    notifier.showUpdateDetailNotifications(newUpdates)
+                }
+            }
             if (hasDownloads.get()) {
                 downloadManager.startDownloads()
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/manga/MangaLibraryUpdateNotifier.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/manga/MangaLibraryUpdateNotifier.kt
@@ -29,9 +29,6 @@ import eu.kanade.tachiyomi.util.system.cancelNotification
 import eu.kanade.tachiyomi.util.system.getBitmapOrNull
 import eu.kanade.tachiyomi.util.system.notificationBuilder
 import eu.kanade.tachiyomi.util.system.notify
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 import logcat.LogPriority
 import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.core.common.util.system.logcat
@@ -170,11 +167,11 @@ class MangaLibraryUpdateNotifier(
     }
 
     /**
-     * Shows the notification containing the result of the update done by the service.
+     * Shows the parent group notification containing the result of the update done by the service.
      *
      * @param updates a list of manga with new updates.
      */
-    fun showUpdateNotifications(updates: List<Pair<Manga, Array<Chapter>>>, scope: CoroutineScope) {
+    fun showUpdateSummaryNotification(updates: List<Pair<Manga, Array<Chapter>>>) {
         // Parent group notification
         context.notify(
             Notifications.ID_NEW_CHAPTERS,
@@ -214,19 +211,21 @@ class MangaLibraryUpdateNotifier(
             setContentIntent(getNotificationIntent())
             setAutoCancel(true)
         }
+    }
 
-        // Per-manga notification
-        if (!securityPreferences.hideNotificationContent().get()) {
-            scope.launch(Dispatchers.Main) {
-                context.notify(
-                    updates.mapNotNull { (manga, chapters) ->
-                        createNewChaptersNotification(manga, chapters)?.let {
-                            NotificationManagerCompat.NotificationWithIdAndTag(manga.id.hashCode(), it)
-                        }
-                    },
-                )
-            }
-        }
+    fun shouldShowUpdateDetailNotifications(): Boolean {
+        return !securityPreferences.hideNotificationContent().get()
+    }
+
+    internal suspend fun showUpdateDetailNotifications(updates: List<Pair<Manga, Array<Chapter>>>) {
+        // Per-manga notifications
+        context.notify(
+            updates.mapNotNull { (manga, chapters) ->
+                createNewChaptersNotification(manga, chapters)?.let {
+                    NotificationManagerCompat.NotificationWithIdAndTag(manga.id.hashCode(), it)
+                }
+            },
+        )
     }
 
     private suspend fun createNewChaptersNotification(manga: Manga, chapters: Array<Chapter>): Notification? {

--- a/app/src/test/java/eu/kanade/tachiyomi/data/library/LibraryUpdateNotificationOwnershipTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/data/library/LibraryUpdateNotificationOwnershipTest.kt
@@ -1,0 +1,60 @@
+package eu.kanade.tachiyomi.data.library
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import java.nio.file.Path
+
+class LibraryUpdateNotificationOwnershipTest {
+
+    @Test
+    fun `library update notifiers do not accept caller coroutine scopes`() {
+        val animeNotifier = source(
+            "app/src/main/java/eu/kanade/tachiyomi/data/library/anime/AnimeLibraryUpdateNotifier.kt",
+        )
+        val mangaNotifier = source(
+            "app/src/main/java/eu/kanade/tachiyomi/data/library/manga/MangaLibraryUpdateNotifier.kt",
+        )
+
+        assertFalse(
+            animeNotifier.contains("CoroutineScope"),
+            "Anime notifier should not expose coroutine ownership",
+        )
+        assertFalse(
+            mangaNotifier.contains("CoroutineScope"),
+            "Manga notifier should not expose coroutine ownership",
+        )
+    }
+
+    @Test
+    fun `library update jobs own async detail notification dispatch`() {
+        val animeJob = source(
+            "app/src/main/java/eu/kanade/tachiyomi/data/library/anime/AnimeLibraryUpdateJob.kt",
+        )
+        val mangaJob = source(
+            "app/src/main/java/eu/kanade/tachiyomi/data/library/manga/MangaLibraryUpdateJob.kt",
+        )
+
+        assertDetailDispatchOwnedByJob(animeJob, "Anime")
+        assertDetailDispatchOwnedByJob(mangaJob, "Manga")
+    }
+
+    private fun assertDetailDispatchOwnedByJob(source: String, label: String) {
+        val guardIndex = source.indexOf("if (notifier.shouldShowUpdateDetailNotifications())")
+        val launchIndex = source.indexOf("launch(Dispatchers.Main)", startIndex = guardIndex)
+        val detailIndex = source.indexOf("notifier.showUpdateDetailNotifications", startIndex = launchIndex)
+        val downloadsIndex = source.indexOf("downloadManager.startDownloads()", startIndex = detailIndex)
+
+        assertTrue(guardIndex >= 0, "$label job should guard detail notification dispatch")
+        assertTrue(launchIndex > guardIndex, "$label job should launch detail notifications from the job")
+        assertTrue(detailIndex > launchIndex, "$label job should call detail notifications inside the launch")
+        assertTrue(downloadsIndex > detailIndex, "$label job should preserve fire-and-forget ordering before downloads")
+    }
+
+    private fun source(path: String): String {
+        val root = generateSequence(Path.of(System.getProperty("user.dir"))) { it.parent }
+            .first { Files.exists(it.resolve("settings.gradle.kts")) }
+        return Files.readString(root.resolve(path))
+    }
+}


### PR DESCRIPTION
## Ticket
- ID: R674
- Priority: P2
- Risk Tier: T2
- GitHub Issue: Closes #750

## Objective
- Follow up on R674 by removing coroutine-scope plumbing from library notifier APIs while preserving the structured-concurrency replacement for deprecated top-level `launchUI`.

## Scope
- Split anime/manga update notifications into explicit summary and detail methods.
- Keep worker-owned `launch(Dispatchers.Main)` for detail notifications.
- Preserve hidden-content behavior by checking before launching detail work.
- Add a focused regression test for notifier API ownership and scheduling order.

## Non-goals
- No notification UI/content changes.
- No WebView interceptor changes.
- No source API, repository, screen model, light novel, or plugin changes.
- No new changelog entry; this is a same-ticket cleanup of R674 internals with no user-facing release-note delta.

## Files Changed
- Library update jobs for anime and manga.
- Library update notifiers for anime and manga.
- Focused source-level regression test for notification coroutine ownership.

## Verification
- Commands run:
  - `./gradlew :app:testStableDebugUnitTest --tests "eu.kanade.tachiyomi.data.library.LibraryUpdateNotificationOwnershipTest"`
  - `./gradlew spotlessCheck`
  - `./gradlew :app:compileStableDebugKotlin`
  - `git diff --check`
  - `rg -n "showUpdateNotifications\\(|showUpdateSummaryNotification\\(|showUpdateDetailNotifications\\(|CoroutineScope|Dispatchers\\.Main|GlobalScope\\.launch\\(Dispatchers\\.Main" app/src/main/java/eu/kanade/tachiyomi/data/library core/common/src/main/java/tachiyomi/core/common/util/lang/CoroutinesExtensions.kt -g '*.kt'`
- Results:
  - Focused regression test passed after first failing against the pre-cleanup API shape.
  - `spotlessCheck` passed.
  - `:app:compileStableDebugKotlin` passed.
  - `git diff --check` passed.
  - Source check confirmed notifier APIs no longer accept `CoroutineScope`; worker methods own the detail notification launch.
  - Independent review found one valid hidden-content launch drift; fixed and re-reviewed clean.
- Not tested:
  - No emulator/manual notification flow test.

## Risk
- Main risk is notification ordering or cancellation drift from moving launch ownership.
- Mitigation: summary notification remains synchronous, detail notification remains asynchronously scheduled before downloads start, hidden-content users no longer dispatch detail work, and failure containment from R674 remains in the detail builders.

## SLO Impact
- No expected runtime SLO impact. This is an internal API cleanup around existing library-update notification dispatch.

## Rollback
- Revert this PR to restore the R674 merged notifier API shape.

## Release Notes
- No new release note. This is same-ticket internal cleanup for R674 and does not change user-facing behavior.

## Checklist
- [x] Naming conventions followed (use "Rayniyomi" in user-facing text; see [branding guardrail](../docs/branding-guardrail.md))
- [x] Branch rebased on latest main and verification re-run
- [x] New coroutine scopes have documented owner and cancellation path
- [x] No new `runBlocking` on UI/main thread paths

## Definition of Done (DoD)
- [x] Acceptance criteria met and non-goals respected
- [x] Verification matrix completed (Risk Tier: T2)
- [x] Self-review completed
- [x] Rebased on latest `main` and revalidated (mandatory for merge)
- [ ] Sprint board updated (branch, commit, checks, PR link)
- [x] Release notes drafted (if applicable)

## Fork Compliance Checklist (for new forks only)
If you are creating a new fork of this project, ensure the following:
- [ ] **App Identity**: Changed app name from "Aniyomi" to your fork name
- [ ] **App Icon**: Replaced launcher icon assets with fork-specific icons
- [ ] **Application ID**: Changed `applicationId` in `app/build.gradle.kts` from `xyz.rayniyomi` to your unique ID
- [ ] **Update Checker**: Configured `AppUpdateChecker.kt` to point to your fork's repository
- [ ] **Analytics**: Either disabled Firebase Analytics or configured with your own `google-services.json`
- [ ] **Crash Reporting**: Either disabled ACRA crash reporting or configured with your own endpoint credentials

See [CONTRIBUTING.md](../CONTRIBUTING.md) Forks section for details.