### PR TITLE
refactor: consolidate extension repo settings screens (R671)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 
 ### Other
 - Gradle resource source-set declarations now use the current directory-set API.
+- Anime and manga extension repository settings now share presentation content while keeping their typed entrypoints separate.
 - Removed the deprecated top-level UI coroutine launch helper after migrating its remaining callers.
 - Contributor docs now point PR authors at existing governance and guardrail files instead of removed policy paths.
 - Core maintenance dependencies refreshed: OkHttp 5.4.0, Cast framework 22.3.1, jsoup 1.22.2, AndroidX SQLite 2.6.2, Coil BOM 3.5.0, Material Components 1.14.0, JUnit 6.1.0, Kotest 6.2.1, and MockK 1.14.11.

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/browse/AnimeExtensionReposScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/browse/AnimeExtensionReposScreen.kt
@@ -1,29 +1,13 @@
 package eu.kanade.presentation.more.settings.screen.browse
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.ui.platform.LocalContext
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import cafe.adriel.voyager.core.model.rememberScreenModel
-import cafe.adriel.voyager.navigator.LocalNavigator
-import cafe.adriel.voyager.navigator.currentOrThrow
-import eu.kanade.presentation.more.settings.screen.browse.components.ExtensionRepoConfirmDialog
-import eu.kanade.presentation.more.settings.screen.browse.components.ExtensionRepoConflictDialog
-import eu.kanade.presentation.more.settings.screen.browse.components.ExtensionRepoCreateDialog
-import eu.kanade.presentation.more.settings.screen.browse.components.ExtensionRepoDeleteDialog
-import eu.kanade.presentation.more.settings.screen.browse.components.ExtensionReposScreen
 import eu.kanade.presentation.util.Screen
-import eu.kanade.tachiyomi.util.system.openInBrowser
-import eu.kanade.tachiyomi.util.system.toast
-import kotlinx.collections.immutable.toImmutableSet
-import kotlinx.coroutines.flow.collectLatest
 import mihon.domain.extensionrepo.anime.interactor.CreateAnimeExtensionRepo
 import mihon.domain.extensionrepo.anime.interactor.DeleteAnimeExtensionRepo
 import mihon.domain.extensionrepo.anime.interactor.GetAnimeExtensionRepo
 import mihon.domain.extensionrepo.anime.interactor.ReplaceAnimeExtensionRepo
 import mihon.domain.extensionrepo.anime.interactor.UpdateAnimeExtensionRepo
-import tachiyomi.presentation.core.screens.LoadingScreen
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 
@@ -33,9 +17,6 @@ class AnimeExtensionReposScreen(
 
     @Composable
     override fun Content() {
-        val context = LocalContext.current
-        val navigator = LocalNavigator.currentOrThrow
-
         val screenModel = rememberScreenModel {
             ExtensionReposScreenModel(
                 AnimeExtensionRepoDependencies(
@@ -47,67 +28,9 @@ class AnimeExtensionReposScreen(
                 ),
             )
         }
-        val state by screenModel.state.collectAsStateWithLifecycle()
-
-        LaunchedEffect(url) {
-            url?.let { screenModel.showDialog(RepoDialog.Confirm(it)) }
-        }
-
-        if (state is RepoScreenState.Loading) {
-            LoadingScreen()
-            return
-        }
-
-        val successState = state as RepoScreenState.Success
-
-        ExtensionReposScreen(
-            state = successState,
-            onClickCreate = { screenModel.showDialog(RepoDialog.Create) },
-            onOpenWebsite = { context.openInBrowser(it.website) },
-            onClickDelete = { screenModel.showDialog(RepoDialog.Delete(it)) },
-            onClickRefresh = { screenModel.refreshRepos() },
-            navigateUp = navigator::pop,
+        ExtensionReposScreenContent(
+            url = url,
+            screenModel = screenModel,
         )
-
-        when (val dialog = successState.dialog) {
-            null -> {}
-            is RepoDialog.Create -> {
-                ExtensionRepoCreateDialog(
-                    onDismissRequest = screenModel::dismissDialog,
-                    onCreate = { screenModel.createRepo(it) },
-                    repoUrls = successState.repos.map { it.baseUrl }.toImmutableSet(),
-                )
-            }
-            is RepoDialog.Delete -> {
-                ExtensionRepoDeleteDialog(
-                    onDismissRequest = screenModel::dismissDialog,
-                    onDelete = { screenModel.deleteRepo(dialog.repo) },
-                    repo = dialog.repo,
-                )
-            }
-            is RepoDialog.Conflict -> {
-                ExtensionRepoConflictDialog(
-                    onDismissRequest = screenModel::dismissDialog,
-                    onMigrate = { screenModel.replaceRepo(dialog.newRepo) },
-                    oldRepo = dialog.oldRepo,
-                    newRepo = dialog.newRepo,
-                )
-            }
-            is RepoDialog.Confirm -> {
-                ExtensionRepoConfirmDialog(
-                    onDismissRequest = screenModel::dismissDialog,
-                    onCreate = { screenModel.createRepo(dialog.url) },
-                    repo = dialog.url,
-                )
-            }
-        }
-
-        LaunchedEffect(Unit) {
-            screenModel.events.collectLatest { event ->
-                if (event is RepoEvent.LocalizedMessage) {
-                    context.toast(event.stringRes)
-                }
-            }
-        }
     }
 }

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/browse/ExtensionReposScreenContent.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/browse/ExtensionReposScreenContent.kt
@@ -1,0 +1,90 @@
+package eu.kanade.presentation.more.settings.screen.browse
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import cafe.adriel.voyager.navigator.LocalNavigator
+import cafe.adriel.voyager.navigator.currentOrThrow
+import eu.kanade.presentation.more.settings.screen.browse.components.ExtensionRepoConfirmDialog
+import eu.kanade.presentation.more.settings.screen.browse.components.ExtensionRepoConflictDialog
+import eu.kanade.presentation.more.settings.screen.browse.components.ExtensionRepoCreateDialog
+import eu.kanade.presentation.more.settings.screen.browse.components.ExtensionRepoDeleteDialog
+import eu.kanade.presentation.more.settings.screen.browse.components.ExtensionReposScreen
+import eu.kanade.tachiyomi.util.system.openInBrowser
+import eu.kanade.tachiyomi.util.system.toast
+import kotlinx.collections.immutable.toImmutableSet
+import kotlinx.coroutines.flow.collectLatest
+import tachiyomi.presentation.core.screens.LoadingScreen
+
+@Composable
+internal fun ExtensionReposScreenContent(
+    url: String?,
+    screenModel: ExtensionReposScreenModel,
+) {
+    val context = LocalContext.current
+    val navigator = LocalNavigator.currentOrThrow
+    val state by screenModel.state.collectAsStateWithLifecycle()
+
+    LaunchedEffect(url) {
+        url?.let { screenModel.showDialog(RepoDialog.Confirm(it)) }
+    }
+
+    if (state is RepoScreenState.Loading) {
+        LoadingScreen()
+        return
+    }
+
+    val successState = state as RepoScreenState.Success
+
+    ExtensionReposScreen(
+        state = successState,
+        onClickCreate = { screenModel.showDialog(RepoDialog.Create) },
+        onOpenWebsite = { context.openInBrowser(it.website) },
+        onClickDelete = { screenModel.showDialog(RepoDialog.Delete(it)) },
+        onClickRefresh = { screenModel.refreshRepos() },
+        navigateUp = navigator::pop,
+    )
+
+    when (val dialog = successState.dialog) {
+        null -> {}
+        is RepoDialog.Create -> {
+            ExtensionRepoCreateDialog(
+                onDismissRequest = screenModel::dismissDialog,
+                onCreate = { screenModel.createRepo(it) },
+                repoUrls = successState.repos.map { it.baseUrl }.toImmutableSet(),
+            )
+        }
+        is RepoDialog.Delete -> {
+            ExtensionRepoDeleteDialog(
+                onDismissRequest = screenModel::dismissDialog,
+                onDelete = { screenModel.deleteRepo(dialog.repo) },
+                repo = dialog.repo,
+            )
+        }
+        is RepoDialog.Conflict -> {
+            ExtensionRepoConflictDialog(
+                onDismissRequest = screenModel::dismissDialog,
+                onMigrate = { screenModel.replaceRepo(dialog.newRepo) },
+                oldRepo = dialog.oldRepo,
+                newRepo = dialog.newRepo,
+            )
+        }
+        is RepoDialog.Confirm -> {
+            ExtensionRepoConfirmDialog(
+                onDismissRequest = screenModel::dismissDialog,
+                onCreate = { screenModel.createRepo(dialog.url) },
+                repo = dialog.url,
+            )
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        screenModel.events.collectLatest { event ->
+            if (event is RepoEvent.LocalizedMessage) {
+                context.toast(event.stringRes)
+            }
+        }
+    }
+}

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/browse/MangaExtensionReposScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/browse/MangaExtensionReposScreen.kt
@@ -1,29 +1,13 @@
 package eu.kanade.presentation.more.settings.screen.browse
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.ui.platform.LocalContext
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import cafe.adriel.voyager.core.model.rememberScreenModel
-import cafe.adriel.voyager.navigator.LocalNavigator
-import cafe.adriel.voyager.navigator.currentOrThrow
-import eu.kanade.presentation.more.settings.screen.browse.components.ExtensionRepoConfirmDialog
-import eu.kanade.presentation.more.settings.screen.browse.components.ExtensionRepoConflictDialog
-import eu.kanade.presentation.more.settings.screen.browse.components.ExtensionRepoCreateDialog
-import eu.kanade.presentation.more.settings.screen.browse.components.ExtensionRepoDeleteDialog
-import eu.kanade.presentation.more.settings.screen.browse.components.ExtensionReposScreen
 import eu.kanade.presentation.util.Screen
-import eu.kanade.tachiyomi.util.system.openInBrowser
-import eu.kanade.tachiyomi.util.system.toast
-import kotlinx.collections.immutable.toImmutableSet
-import kotlinx.coroutines.flow.collectLatest
 import mihon.domain.extensionrepo.manga.interactor.CreateMangaExtensionRepo
 import mihon.domain.extensionrepo.manga.interactor.DeleteMangaExtensionRepo
 import mihon.domain.extensionrepo.manga.interactor.GetMangaExtensionRepo
 import mihon.domain.extensionrepo.manga.interactor.ReplaceMangaExtensionRepo
 import mihon.domain.extensionrepo.manga.interactor.UpdateMangaExtensionRepo
-import tachiyomi.presentation.core.screens.LoadingScreen
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 
@@ -33,9 +17,6 @@ class MangaExtensionReposScreen(
 
     @Composable
     override fun Content() {
-        val context = LocalContext.current
-        val navigator = LocalNavigator.currentOrThrow
-
         val screenModel = rememberScreenModel {
             ExtensionReposScreenModel(
                 MangaExtensionRepoDependencies(
@@ -47,67 +28,9 @@ class MangaExtensionReposScreen(
                 ),
             )
         }
-        val state by screenModel.state.collectAsStateWithLifecycle()
-
-        LaunchedEffect(url) {
-            url?.let { screenModel.showDialog(RepoDialog.Confirm(it)) }
-        }
-
-        if (state is RepoScreenState.Loading) {
-            LoadingScreen()
-            return
-        }
-
-        val successState = state as RepoScreenState.Success
-
-        ExtensionReposScreen(
-            state = successState,
-            onClickCreate = { screenModel.showDialog(RepoDialog.Create) },
-            onOpenWebsite = { context.openInBrowser(it.website) },
-            onClickDelete = { screenModel.showDialog(RepoDialog.Delete(it)) },
-            onClickRefresh = { screenModel.refreshRepos() },
-            navigateUp = navigator::pop,
+        ExtensionReposScreenContent(
+            url = url,
+            screenModel = screenModel,
         )
-
-        when (val dialog = successState.dialog) {
-            null -> {}
-            is RepoDialog.Create -> {
-                ExtensionRepoCreateDialog(
-                    onDismissRequest = screenModel::dismissDialog,
-                    onCreate = { screenModel.createRepo(it) },
-                    repoUrls = successState.repos.map { it.baseUrl }.toImmutableSet(),
-                )
-            }
-            is RepoDialog.Delete -> {
-                ExtensionRepoDeleteDialog(
-                    onDismissRequest = screenModel::dismissDialog,
-                    onDelete = { screenModel.deleteRepo(dialog.repo) },
-                    repo = dialog.repo,
-                )
-            }
-            is RepoDialog.Conflict -> {
-                ExtensionRepoConflictDialog(
-                    onDismissRequest = screenModel::dismissDialog,
-                    onMigrate = { screenModel.replaceRepo(dialog.newRepo) },
-                    oldRepo = dialog.oldRepo,
-                    newRepo = dialog.newRepo,
-                )
-            }
-            is RepoDialog.Confirm -> {
-                ExtensionRepoConfirmDialog(
-                    onDismissRequest = screenModel::dismissDialog,
-                    onCreate = { screenModel.createRepo(dialog.url) },
-                    repo = dialog.url,
-                )
-            }
-        }
-
-        LaunchedEffect(Unit) {
-            screenModel.events.collectLatest { event ->
-                if (event is RepoEvent.LocalizedMessage) {
-                    context.toast(event.stringRes)
-                }
-            }
-        }
     }
 }

--- a/app/src/test/java/eu/kanade/presentation/more/settings/screen/browse/ExtensionReposScreenContentOwnershipTest.kt
+++ b/app/src/test/java/eu/kanade/presentation/more/settings/screen/browse/ExtensionReposScreenContentOwnershipTest.kt
@@ -1,0 +1,54 @@
+package eu.kanade.presentation.more.settings.screen.browse
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import java.nio.file.Path
+
+class ExtensionReposScreenContentOwnershipTest {
+
+    @Test
+    fun `anime and manga repo screens remain typed entrypoints`() {
+        val animeScreen = source(
+            "app/src/main/java/eu/kanade/presentation/more/settings/screen/browse/AnimeExtensionReposScreen.kt",
+        )
+        val mangaScreen = source(
+            "app/src/main/java/eu/kanade/presentation/more/settings/screen/browse/MangaExtensionReposScreen.kt",
+        )
+
+        assertTrue(animeScreen.contains("class AnimeExtensionReposScreen("))
+        assertTrue(animeScreen.contains("AnimeExtensionRepoDependencies("))
+        assertTrue(mangaScreen.contains("class MangaExtensionReposScreen("))
+        assertTrue(mangaScreen.contains("MangaExtensionRepoDependencies("))
+    }
+
+    @Test
+    fun `shared repo screen content owns duplicated presentation orchestration`() {
+        val sharedContent = source(
+            "app/src/main/java/eu/kanade/presentation/more/settings/screen/browse/ExtensionReposScreenContent.kt",
+        )
+        val animeScreen = source(
+            "app/src/main/java/eu/kanade/presentation/more/settings/screen/browse/AnimeExtensionReposScreen.kt",
+        )
+        val mangaScreen = source(
+            "app/src/main/java/eu/kanade/presentation/more/settings/screen/browse/MangaExtensionReposScreen.kt",
+        )
+
+        assertTrue(sharedContent.contains("internal fun ExtensionReposScreenContent("))
+        assertTrue(sharedContent.contains("ExtensionRepoCreateDialog("))
+        assertTrue(sharedContent.contains("ExtensionRepoDeleteDialog("))
+        assertTrue(sharedContent.contains("ExtensionRepoConflictDialog("))
+        assertTrue(sharedContent.contains("ExtensionRepoConfirmDialog("))
+        assertTrue(animeScreen.contains("ExtensionReposScreenContent("))
+        assertTrue(mangaScreen.contains("ExtensionReposScreenContent("))
+        assertFalse(animeScreen.contains("ExtensionRepoCreateDialog("))
+        assertFalse(mangaScreen.contains("ExtensionRepoCreateDialog("))
+    }
+
+    private fun source(path: String): String {
+        val root = generateSequence(Path.of(System.getProperty("user.dir"))) { it.parent }
+            .first { Files.exists(it.resolve("settings.gradle.kts")) }
+        return Files.readString(root.resolve(path))
+    }
+}


### PR DESCRIPTION
## Ticket
- ID: R671
- Priority: P2
- Risk Tier: T1
- GitHub Issue: Closes #747

## Objective
- Reduce duplicated anime/manga extension repository settings presentation wiring while preserving typed entrypoints and dependency boundaries.

## Scope
- Added an internal `ExtensionReposScreenContent` composable for shared loading, dialog, event, navigation, and browser-open wiring.
- Kept `AnimeExtensionReposScreen` and `MangaExtensionReposScreen` as separate typed entrypoints that construct their existing dependency adapters.
- Added a focused source-ownership test for the conservative extraction boundary.
- Added an Unreleased changelog entry under Other without the ticket number.

## Non-goals
- No repository, interactor, service, or domain model consolidation.
- No source API, runBlocking bridge, light novel/plugin, or unrelated settings changes.
- No UI redesign or behavior changes.

## Files Changed
- `CHANGELOG.md`
- `app/src/main/java/eu/kanade/presentation/more/settings/screen/browse/`
- `app/src/test/java/eu/kanade/presentation/more/settings/screen/browse/`

## Verification
- Commands run:
  - `./gradlew :app:testStableDebugUnitTest --tests "eu.kanade.presentation.more.settings.screen.browse.ExtensionReposScreenContentOwnershipTest"` (red before implementation, green after implementation, rerun after formatting/build)
  - `rg -n "class AnimeExtensionReposScreen|class MangaExtensionReposScreen|ExtensionReposScreenContent|AnimeExtensionRepoDependencies|MangaExtensionRepoDependencies" app/src/main/java/eu/kanade/presentation/more/settings/screen/browse app/src/test/java/eu/kanade/presentation/more/settings/screen/browse`
  - `rg -n "ExtensionRepo(Create|Delete|Conflict|Confirm)Dialog\(|ExtensionReposScreenContent\(" app/src/main/java/eu/kanade/presentation/more/settings/screen/browse`
  - `git diff --name-only && git ls-files --others --exclude-standard`
  - `./gradlew spotlessCheck`
  - `./gradlew :app:compileStableDebugKotlin`
  - `git diff --check`
- Results:
  - Focused test passed.
  - Source checks confirm provider wrappers remain typed and dialog orchestration moved to the shared helper.
  - `spotlessCheck`, `:app:compileStableDebugKotlin`, and `git diff --check` passed.
  - Pre-push hook reran `spotlessCheck` and `:app:compileStableDebugKotlin`; both passed.
- Not tested:
  - No emulator/manual UI pass; this is a presentation-only extraction with unchanged callbacks and focused source coverage.

## Risk
- Low risk. The shared helper is a direct move of existing duplicate Compose wiring. Risk is callback miswiring, mitigated by keeping the moved code unchanged and adding source checks around ownership.

## SLO Impact
- None expected. No runtime data path, repository, service, or network behavior changed.

## Rollback
- Revert this PR to restore separate anime/manga screen orchestration.

## Release Notes
- Anime and manga extension repository settings now share presentation content while keeping their typed entrypoints separate.

## Checklist
- [x] Naming conventions followed (use "Rayniyomi" in user-facing text; see [branding guardrail](../docs/branding-guardrail.md))
- [x] Branch rebased on latest main and verification re-run
- [x] New coroutine scopes have documented owner and cancellation path
- [x] No new `runBlocking` on UI/main thread paths

## Definition of Done (DoD)
- [x] Acceptance criteria met and non-goals respected
- [x] Verification matrix completed (Risk Tier: T1)
- [x] Self-review completed
- [ ] Rebased on latest `main` and revalidated (mandatory for merge)
- [ ] Sprint board updated (branch, commit, checks, PR link)
- [x] Release notes drafted (if applicable)
