### PR TITLE
fix: preserve manual backup on create failure (R675)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Discover and entry-enrichment Compose screen state now uses explicit stability annotations, and discover feed items are stored as immutable collections at the UI-state boundary to reduce avoidable recompositions.
 
 ### Fixed
+- Manual backup creation now stages and validates new backup data before replacing the selected file, preserving existing backups when generation, validation, or final writes fail.
 - Missing-extension sources now preserve readable stub source names from runtime and backup metadata (fallback to raw source ID only when metadata is unavailable), for both manga and anime source flows.
 - Reader initialization now guards chapter loading with a descriptive `checkNotNull` for `ChapterLoader`, replacing an unsafe null assertion crash path in `ReaderViewModel`.
 - Manga category deletion now clears deleted categories from both library update include and exclude preferences.

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/create/BackupCreator.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/create/BackupCreator.kt
@@ -31,9 +31,6 @@ import eu.kanade.tachiyomi.data.backup.models.BackupSource
 import eu.kanade.tachiyomi.data.backup.models.BackupSourcePreferences
 import kotlinx.serialization.protobuf.ProtoBuf
 import logcat.LogPriority
-import okio.buffer
-import okio.gzip
-import okio.sink
 import tachiyomi.core.common.i18n.stringResource
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.domain.backup.service.BackupPreferences
@@ -46,7 +43,7 @@ import tachiyomi.domain.entries.manga.repository.MangaRepository
 import tachiyomi.i18n.MR
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
-import java.io.FileOutputStream
+import java.io.File
 import java.text.SimpleDateFormat
 import java.time.Instant
 import java.util.Date
@@ -75,10 +72,16 @@ class BackupCreator(
     private val mangaSourcesBackupCreator: MangaSourcesBackupCreator = MangaSourcesBackupCreator(),
     private val extensionsBackupCreator: ExtensionsBackupCreator = ExtensionsBackupCreator(context),
     private val lightNovelBackupCreator: LightNovelBackupCreator = LightNovelBackupCreator(context),
+    private val backupFileWriter: BackupFileWriter = BackupFileWriter { BackupFileValidator(context).validate(it) },
+    private val manualBackupTempFileFactory: () -> File = {
+        File.createTempFile("rayniyomi-manual-backup-", ".tachibk", context.cacheDir)
+    },
 ) {
 
     suspend fun backup(uri: Uri, options: BackupOptions): String {
         var file: UniFile? = null
+        var stagedFile: UniFile? = null
+        var stagedLightNovelBackupFile: UniFile? = null
         try {
             file = if (isAutoBackup) {
                 // Get dir of file and create
@@ -139,21 +142,41 @@ class BackupCreator(
                 throw IllegalStateException(context.stringResource(MR.strings.empty_backup_error))
             }
 
-            file.openOutputStream().use { outputStream ->
-                // Force overwrite old file
-                (outputStream as? FileOutputStream)?.channel?.truncate(0)
-                outputStream.sink().gzip().buffer().use {
-                    it.write(byteArray)
+            val stagedLightNovelBackup = if (!isAutoBackup && options.lightNovels) {
+                prepareLightNovelBackup(file)
+            } else {
+                null
+            }
+            stagedLightNovelBackupFile = stagedLightNovelBackup?.stagedFile
+
+            val fileUri = if (isAutoBackup) {
+                backupFileWriter.writeAutoBackup(file, byteArray)
+            } else {
+                val previousManualBackupBytes = backupFileWriter.readBytesOrNull(file)
+                try {
+                    val manualStagedFile = UniFile.fromFile(manualBackupTempFileFactory())
+                        ?: throw IllegalStateException(context.stringResource(MR.strings.create_backup_file_error))
+                    stagedFile = manualStagedFile
+                    val manualFileUri = backupFileWriter.writeManualBackup(
+                        stagedFile = manualStagedFile,
+                        targetFile = file,
+                        backupBytes = byteArray,
+                    )
+                    stagedLightNovelBackup?.let(::commitLightNovelBackup)
+                    manualFileUri
+                } catch (e: Exception) {
+                    if (previousManualBackupBytes != null) {
+                        backupFileWriter.restoreRawFile(file, previousManualBackupBytes)
+                    }
+                    throw e
                 }
             }
-            val fileUri = file.uri
-
-            // Make sure it's a valid backup file
-            BackupFileValidator(context).validate(fileUri)
 
             if (options.lightNovels) {
                 // Create separate light novel backup file
-                createLightNovelBackup(file)
+                if (isAutoBackup) {
+                    createLightNovelBackup(file)
+                }
             }
 
             if (isAutoBackup) {
@@ -163,8 +186,13 @@ class BackupCreator(
             return fileUri.toString()
         } catch (e: Exception) {
             logcat(LogPriority.ERROR, e)
-            file?.delete()
+            if (isAutoBackup) {
+                file?.delete()
+            }
             throw e
+        } finally {
+            stagedFile?.delete()
+            stagedLightNovelBackupFile?.delete()
         }
     }
 
@@ -234,6 +262,33 @@ class BackupCreator(
         return extensionsBackupCreator()
     }
 
+    private suspend fun prepareLightNovelBackup(parentBackupFile: UniFile): StagedLightNovelBackup? {
+        val lightNovelBackupBytes = lightNovelBackupCreator() ?: return null
+        val parentDir = parentBackupFile.parentFile
+        if (parentDir == null) {
+            logcat(LogPriority.WARN) { "Cannot create Light Novel backup: backup file has no parent directory" }
+            return null
+        }
+
+        val sidecarFileName = LightNovelBackupContract.sidecarNameFor(parentBackupFile.name.orEmpty())
+        val stagedSidecarFileName = "$sidecarFileName.tmp-${System.currentTimeMillis()}"
+        val stagedSidecarFile = parentDir.createFile(stagedSidecarFileName)
+            ?: throw IllegalStateException("Unable to create staged Light Novel backup file")
+        backupFileWriter.writeRawStagedFile(stagedSidecarFile, lightNovelBackupBytes)
+        return StagedLightNovelBackup(
+            parentDir = parentDir,
+            sidecarFileName = sidecarFileName,
+            stagedFile = stagedSidecarFile,
+        )
+    }
+
+    private fun commitLightNovelBackup(stagedBackup: StagedLightNovelBackup) {
+        val sidecarFile = stagedBackup.parentDir.findFile(stagedBackup.sidecarFileName)
+            ?: stagedBackup.parentDir.createFile(stagedBackup.sidecarFileName)
+            ?: throw IllegalStateException("Unable to create Light Novel backup file")
+        backupFileWriter.commitRawStagedFile(stagedBackup.stagedFile, sidecarFile)
+    }
+
     private suspend fun createLightNovelBackup(parentBackupFile: UniFile?) {
         try {
             val lightNovelBackupBytes = lightNovelBackupCreator()
@@ -256,6 +311,12 @@ class BackupCreator(
             logcat(LogPriority.WARN, e) { "Failed to create Light Novel backup: ${e.message}" }
         }
     }
+
+    private data class StagedLightNovelBackup(
+        val parentDir: UniFile,
+        val sidecarFileName: String,
+        val stagedFile: UniFile,
+    )
 
     companion object {
         private const val MAX_AUTO_BACKUPS: Int = 4

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/create/BackupFileWriter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/create/BackupFileWriter.kt
@@ -1,0 +1,96 @@
+package eu.kanade.tachiyomi.data.backup.create
+
+import android.net.Uri
+import com.hippo.unifile.UniFile
+import okio.buffer
+import okio.gzip
+import okio.sink
+import okio.source
+import java.io.FileOutputStream
+
+class BackupFileWriter(
+    private val validator: (Uri) -> Unit = {},
+) {
+
+    fun writeAutoBackup(file: UniFile, backupBytes: ByteArray): Uri {
+        writeCompressedBackup(file, backupBytes)
+        val fileUri = file.uri
+        validator(fileUri)
+        return fileUri
+    }
+
+    fun writeManualBackup(
+        stagedFile: UniFile,
+        targetFile: UniFile,
+        backupBytes: ByteArray,
+    ): Uri {
+        writeCompressedBackup(stagedFile, backupBytes)
+        validator(stagedFile.uri)
+        commitStagedBackup(stagedFile, targetFile)
+        return targetFile.uri
+    }
+
+    fun writeRawStagedFile(file: UniFile, bytes: ByteArray) {
+        file.openOutputStream().use { outputStream ->
+            (outputStream as? FileOutputStream)?.channel?.truncate(0)
+            outputStream.write(bytes)
+        }
+    }
+
+    fun commitRawStagedFile(stagedFile: UniFile, targetFile: UniFile): Uri {
+        commitStagedBackup(stagedFile, targetFile)
+        return targetFile.uri
+    }
+
+    fun readBytesOrNull(file: UniFile): ByteArray? {
+        return readBytes(file)
+    }
+
+    fun restoreRawFile(file: UniFile, bytes: ByteArray) {
+        restoreTarget(file, bytes)
+    }
+
+    private fun writeCompressedBackup(file: UniFile, backupBytes: ByteArray) {
+        file.openOutputStream().use { outputStream ->
+            (outputStream as? FileOutputStream)?.channel?.truncate(0)
+            outputStream.sink().gzip().buffer().use {
+                it.write(backupBytes)
+            }
+        }
+    }
+
+    private fun commitStagedBackup(stagedFile: UniFile, targetFile: UniFile) {
+        val previousBytes = readBytes(targetFile)
+
+        try {
+            targetFile.openOutputStream().use { outputStream ->
+                (outputStream as? FileOutputStream)?.channel?.truncate(0)
+                stagedFile.openInputStream().source().buffer().use { source ->
+                    outputStream.sink().buffer().use { sink ->
+                        sink.writeAll(source)
+                    }
+                }
+            }
+        } catch (e: Exception) {
+            if (previousBytes != null) {
+                restoreTarget(targetFile, previousBytes)
+            }
+            throw e
+        }
+    }
+
+    private fun readBytes(file: UniFile): ByteArray? {
+        return runCatching {
+            file.openInputStream().use { it.readBytes() }
+        }.getOrNull()
+    }
+
+    private fun restoreTarget(targetFile: UniFile, previousBytes: ByteArray) {
+        runCatching {
+            targetFile.openOutputStream().use { outputStream ->
+                (outputStream as? FileOutputStream)?.channel?.truncate(0)
+                outputStream.write(previousBytes)
+            }
+        }
+    }
+}

--- a/app/src/test/java/eu/kanade/tachiyomi/data/backup/create/BackupFileWriterTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/data/backup/create/BackupFileWriterTest.kt
@@ -1,0 +1,140 @@
+package eu.kanade.tachiyomi.data.backup.create
+
+import android.net.Uri
+import com.hippo.unifile.UniFile
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayOutputStream
+
+class BackupFileWriterTest {
+
+    @Test
+    fun `manual backup validation failure does not open final target`() {
+        val target = fakeUniFile("manual.tachibk", "previous backup".encodeToByteArray())
+        val staged = fakeUniFile("staged.tachibk")
+        val writer = BackupFileWriter(
+            validator = { throw IllegalStateException("invalid backup") },
+        )
+
+        assertThrows(IllegalStateException::class.java) {
+            writer.writeManualBackup(
+                stagedFile = staged,
+                targetFile = target,
+                backupBytes = "new backup".encodeToByteArray(),
+            )
+        }
+
+        assertArrayEquals("previous backup".encodeToByteArray(), target.bytes)
+        verify(exactly = 0) { target.file.openOutputStream() }
+    }
+
+    @Test
+    fun `manual backup write failure restores existing target bytes`() {
+        val target = fakeUniFile(
+            name = "manual.tachibk",
+            initialBytes = "previous backup".encodeToByteArray(),
+            failNextOutputAfterBytes = 1,
+        )
+        val staged = fakeUniFile("staged.tachibk")
+        val writer = BackupFileWriter()
+
+        assertThrows(RuntimeException::class.java) {
+            writer.writeManualBackup(
+                stagedFile = staged,
+                targetFile = target,
+                backupBytes = "new backup".encodeToByteArray(),
+            )
+        }
+
+        assertArrayEquals("previous backup".encodeToByteArray(), target.bytes)
+        verify(exactly = 2) { target.file.openOutputStream() }
+    }
+
+    @Test
+    fun `raw staged file commit failure restores existing target bytes`() {
+        val target = fakeUniFile(
+            name = "manual.lightnovel.tachibk",
+            initialBytes = "previous light novel backup".encodeToByteArray(),
+            failNextOutputAfterBytes = 1,
+        )
+        val staged = fakeUniFile("manual.lightnovel.tachibk.tmp", "new light novel backup".encodeToByteArray())
+        val writer = BackupFileWriter()
+
+        assertThrows(RuntimeException::class.java) {
+            writer.commitRawStagedFile(staged.file, target.file)
+        }
+
+        assertArrayEquals("previous light novel backup".encodeToByteArray(), target.bytes)
+        verify(exactly = 2) { target.file.openOutputStream() }
+    }
+
+    @Test
+    fun `restore raw file rewrites previous target bytes`() {
+        val target = fakeUniFile("manual.tachibk", "new backup".encodeToByteArray())
+        val writer = BackupFileWriter()
+
+        writer.restoreRawFile(target.file, "previous backup".encodeToByteArray())
+
+        assertArrayEquals("previous backup".encodeToByteArray(), target.bytes)
+    }
+
+    private fun fakeUniFile(
+        name: String,
+        initialBytes: ByteArray = ByteArray(0),
+        failNextOutputAfterBytes: Int? = null,
+    ): FakeUniFile {
+        val file = mockk<UniFile>(relaxed = true)
+        val fake = FakeUniFile(file, initialBytes)
+        var failNextOutputAfterBytes = failNextOutputAfterBytes
+
+        every { file.uri } returns mockk<Uri>(relaxed = true)
+        every { file.name } returns name
+        every { file.isFile } returns true
+        every { file.length() } answers { fake.bytes.size.toLong() }
+        every { file.openInputStream() } answers { fake.bytes.inputStream() }
+        every { file.openOutputStream() } answers {
+            fake.bytes = ByteArray(0)
+            val failAfterBytes = failNextOutputAfterBytes
+            failNextOutputAfterBytes = null
+            object : ByteArrayOutputStream() {
+                override fun write(b: Int) {
+                    super.write(b)
+                    fake.bytes = toByteArray()
+                    if (failAfterBytes != null && size() >= failAfterBytes) {
+                        throw RuntimeException("write failed")
+                    }
+                }
+
+                override fun write(b: ByteArray, off: Int, len: Int) {
+                    for (index in off until off + len) {
+                        write(b[index].toInt())
+                    }
+                }
+
+                override fun close() {
+                    fake.bytes = toByteArray()
+                    super.close()
+                }
+            }
+        }
+
+        return fake
+    }
+
+    private class FakeUniFile(
+        val file: UniFile,
+        var bytes: ByteArray,
+    )
+
+    private fun BackupFileWriter.writeManualBackup(
+        stagedFile: FakeUniFile,
+        targetFile: FakeUniFile,
+        backupBytes: ByteArray,
+    ): Uri {
+        return writeManualBackup(stagedFile.file, targetFile.file, backupBytes)
+    }
+}


### PR DESCRIPTION
## Ticket
- ID: R675
- Priority: P1
- Risk Tier: T2
- GitHub Issue: Closes #756

## Objective
Prevent manual backup creation failures from replacing or deleting an existing user-selected backup document.

## Scope
- Stage generated manual backup data in a temporary file before replacing the selected target.
- Validate staged backup data before committing to the selected target.
- Restore the selected target bytes if final main-file or light-novel sidecar commit fails after the target is opened.
- Stage light-novel sidecar bytes before committing the main manual backup, and use the same restore-capable commit path for existing sidecars.
- Keep auto-backup create/prune behavior on the existing path.
- Add focused JVM tests for staged manual backup write/validation failures and raw sidecar restore behavior.
- Add an Unreleased Fixed changelog entry.

## Non-goals
- No backup format changes.
- No restore-flow changes.
- No changes to auto-backup pruning policy.
- No UI changes.

## Files Changed
- `BackupCreator.kt`: manual backup staging, sidecar staging, selected-target rollback on failure.
- `BackupFileWriter.kt`: shared staged compressed/raw write and best-effort restore helpers.
- `BackupFileWriterTest.kt`: focused regression coverage for validation/write/sidecar restore failure paths.
- `CHANGELOG.md`: user-facing data-safety fix note.

## Verification
- Commands run:
  - `./gradlew :app:testStableDebugUnitTest --tests 'eu.kanade.tachiyomi.data.backup.create.BackupFileWriterTest'`\n  - `./gradlew :app:testStableDebugUnitTest --tests 'eu.kanade.tachiyomi.data.backup.create.BackupFileWriterTest' && ./gradlew :app:compileStableDebugKotlin`\n  - `./gradlew spotlessCheck`\n  - `./gradlew :app:compileStableDebugKotlin`\n  - `git diff --check`\n- Results:\n  - Focused backup writer tests passed.\n  - Spotless passed.\n  - Stable debug Kotlin compile passed.\n  - Diff whitespace check passed.\n  - Pre-push hook reran `spotlessCheck` and `:app:compileStableDebugKotlin`; both passed.\n- Independent review:\n  - Initial review found manual light-novel sidecar failures were not fully protected.\n  - Follow-up review found selected main backup needed rollback if final sidecar commit failed.\n  - Final blockers-only re-review was clean.\n- Not tested:\n  - Manual SAF smoke test with a real provider and injected runtime failure was not run; failure modes are covered with focused JVM tests around the staged writer/restore path.\n\n## Risk\nLow-medium. The highest risk is provider-specific SAF behavior: if a provider truncates on open and then rejects restore writes, restore remains best-effort. The implementation mitigates common file/provider behavior by snapshotting previous bytes before opening the target and restoring them on failure. Auto-backup behavior remains on the existing final-file path.\n\n## SLO Impact\nNo runtime SLO impact expected. Manual backup creation may perform extra local temp writes and reads for safety.\n\n## Rollback\nRevert this PR to restore the previous direct-write manual backup behavior.\n\n## Release Notes\nManual backup creation now stages and validates data before replacing the selected file, preserving existing backups when generation, validation, sidecar creation, or final writes fail.\n\n## Checklist\n- [x] Naming conventions followed\n- [x] Branch rebased on latest main and verification re-run\n- [x] New coroutine scopes have documented owner and cancellation path\n- [x] No new `runBlocking` on UI/main thread paths\n\n## Definition of Done (DoD)\n- [x] Acceptance criteria met and non-goals respected\n- [x] Verification matrix completed (Risk Tier: T2)\n- [x] Self-review completed\n- [x] Rebased on latest `main` and revalidated\n- [ ] Sprint board updated after merge\n- [x] Release notes drafted\n