### PR TITLE
fix: guard search intent type parsing (R678)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Discover and entry-enrichment Compose screen state now uses explicit stability annotations, and discover feed items are stored as immutable collections at the UI-state boundary to reduce avoidable recompositions.
 
 ### Fixed
+- Exported search intents now ignore malformed search type extras instead of crashing, and anime custom search no longer routes through the manga deep-link activity.
 - Manual backup creation now stages and validates new backup data before replacing the selected file, preserving existing backups when generation, validation, or final writes fail.
 - Missing-extension sources now preserve readable stub source names from runtime and backup metadata (fallback to raw source ID only when metadata is unavailable), for both manga and anime source flows.
 - Reader initialization now guards chapter loading with a descriptive `checkNotNull` for `ChapterLoader`, replacing an unsafe null assertion crash path in `ReaderViewModel`.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -179,10 +179,6 @@
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
             <intent-filter>
-                <action android:name="eu.kanade.tachiyomi.ANIMESEARCH" />
-                <category android:name="android.intent.category.DEFAULT" />
-            </intent-filter>
-            <intent-filter>
                 <action android:name="android.intent.action.SEND" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="text/plain" />

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/deeplink/DeepLinkScreenType.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/deeplink/DeepLinkScreenType.kt
@@ -3,4 +3,14 @@ package eu.kanade.tachiyomi.ui.deeplink
 enum class DeepLinkScreenType {
     ANIME,
     MANGA,
+    ;
+
+    companion object {
+        fun fromIntentExtra(value: String?): DeepLinkScreenType {
+            return value
+                ?.takeUnless { it.isBlank() }
+                ?.let { runCatching { valueOf(it) }.getOrNull() }
+                ?: ANIME
+        }
+    }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/main/MainActivity.kt
@@ -542,9 +542,9 @@ class MainActivity : BaseActivity() {
                 if (!query.isNullOrEmpty()) {
                     navigator.popUntilRoot()
 
-                    val screenType = intent.getStringExtra(INTENT_SEARCH_TYPE).orEmpty()
-                        .ifBlank { "ANIME" }
-                        .let(DeepLinkScreenType::valueOf)
+                    val screenType = DeepLinkScreenType.fromIntentExtra(
+                        intent.getStringExtra(INTENT_SEARCH_TYPE),
+                    )
 
                     when (screenType) {
                         DeepLinkScreenType.MANGA -> {

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/deeplink/DeepLinkScreenTypeTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/deeplink/DeepLinkScreenTypeTest.kt
@@ -1,0 +1,25 @@
+package eu.kanade.tachiyomi.ui.deeplink
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class DeepLinkScreenTypeTest {
+
+    @Test
+    fun `fromIntentExtra keeps missing and blank values on anime default`() {
+        assertEquals(DeepLinkScreenType.ANIME, DeepLinkScreenType.fromIntentExtra(null))
+        assertEquals(DeepLinkScreenType.ANIME, DeepLinkScreenType.fromIntentExtra(""))
+        assertEquals(DeepLinkScreenType.ANIME, DeepLinkScreenType.fromIntentExtra("   "))
+    }
+
+    @Test
+    fun `fromIntentExtra routes valid values unchanged`() {
+        assertEquals(DeepLinkScreenType.ANIME, DeepLinkScreenType.fromIntentExtra("ANIME"))
+        assertEquals(DeepLinkScreenType.MANGA, DeepLinkScreenType.fromIntentExtra("MANGA"))
+    }
+
+    @Test
+    fun `fromIntentExtra falls back instead of throwing for malformed values`() {
+        assertEquals(DeepLinkScreenType.ANIME, DeepLinkScreenType.fromIntentExtra("INVALID"))
+    }
+}

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/deeplink/SearchIntentManifestTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/deeplink/SearchIntentManifestTest.kt
@@ -1,0 +1,61 @@
+package eu.kanade.tachiyomi.ui.deeplink
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.w3c.dom.Element
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+
+class SearchIntentManifestTest {
+
+    @Test
+    fun `anime custom search action is only claimed by anime deep link activity`() {
+        val manifest = loadManifest()
+
+        val animeActivity = manifest.activity(".ui.deeplink.anime.DeepLinkAnimeActivity")
+        val mangaActivity = manifest.activity(".ui.deeplink.manga.DeepLinkMangaActivity")
+
+        assertTrue(animeActivity.claimsAction("eu.kanade.tachiyomi.ANIMESEARCH"))
+        assertFalse(mangaActivity.claimsAction("eu.kanade.tachiyomi.ANIMESEARCH"))
+    }
+
+    @Test
+    fun `manga custom search action is only claimed by manga deep link activity`() {
+        val manifest = loadManifest()
+
+        val animeActivity = manifest.activity(".ui.deeplink.anime.DeepLinkAnimeActivity")
+        val mangaActivity = manifest.activity(".ui.deeplink.manga.DeepLinkMangaActivity")
+
+        assertFalse(animeActivity.claimsAction("eu.kanade.tachiyomi.SEARCH"))
+        assertTrue(mangaActivity.claimsAction("eu.kanade.tachiyomi.SEARCH"))
+    }
+
+    private fun loadManifest(): Element {
+        val manifestFile = File("src/main/AndroidManifest.xml")
+        val document = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(manifestFile)
+        return document.documentElement
+    }
+
+    private fun Element.activity(name: String): Element {
+        val activities = getElementsByTagName("activity")
+        for (index in 0 until activities.length) {
+            val activity = activities.item(index) as Element
+            if (activity.getAttribute("android:name") == name) {
+                return activity
+            }
+        }
+        error("Activity $name not found in AndroidManifest.xml")
+    }
+
+    private fun Element.claimsAction(actionName: String): Boolean {
+        val actions = getElementsByTagName("action")
+        for (index in 0 until actions.length) {
+            val action = actions.item(index) as Element
+            if (action.getAttribute("android:name") == actionName) {
+                return true
+            }
+        }
+        return false
+    }
+}


### PR DESCRIPTION
## Objective
Guard exported search intents so malformed `INTENT_SEARCH_TYPE` extras cannot crash `MainActivity`, and ensure anime custom search actions are owned by the anime deep-link activity only.

## Scope
- Add `DeepLinkScreenType.fromIntentExtra` with the existing anime default for missing, blank, or malformed values.
- Route `MainActivity` search handling through the safe parser.
- Remove `eu.kanade.tachiyomi.ANIMESEARCH` from the manga deep-link activity intent filters.
- Add focused parser and manifest ownership tests.

## Verification
- `./gradlew :app:testStableDebugUnitTest --tests 'eu.kanade.tachiyomi.ui.deeplink.*'`
- `./gradlew spotlessCheck`
- `./gradlew :app:compileStableDebugKotlin`
- `git diff --check`
- Pre-push hook reran `./gradlew spotlessCheck` and `./gradlew :app:compileStableDebugKotlin`

## Risk
T1. Narrow defensive parsing and manifest routing fix.

## Rollback
Revert this PR to restore the previous intent parsing and manifest action mapping.

Closes #759
