### PR TITLE
fix: guard episode options missing state (R683)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 
 ### Fixed
 - Exported search intents now ignore malformed search type extras instead of crashing, and anime custom search no longer routes through the manga deep-link activity.
+- Episode options now shows a stable error state instead of crashing when episode, anime, source, hoster, or video state is unavailable.
 - Manual backup creation now stages and validates new backup data before replacing the selected file, preserving existing backups when generation, validation, or final writes fail.
 - Missing-extension sources now preserve readable stub source names from runtime and backup metadata (fallback to raw source ID only when metadata is unavailable), for both manga and anime source flows.
 - Reader initialization now guards chapter loading with a descriptive `checkNotNull` for `ChapterLoader`, replacing an unsafe null assertion crash path in `ReaderViewModel`.

--- a/app/src/main/java/eu/kanade/presentation/entries/anime/EpisodeOptionsDialogScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/entries/anime/EpisodeOptionsDialogScreen.kt
@@ -169,8 +169,22 @@ class EpisodeOptionsDialogScreenModel(
         val hasFoundPreferredVideo = AtomicBoolean(false)
 
         screenModelScope.launchIO {
-            val episode = Injekt.get<GetEpisode>().await(episodeId)!!
-            val anime = Injekt.get<GetAnime>().await(animeId)!!
+            val episode = Injekt.get<GetEpisode>().await(episodeId)
+            if (episode == null) {
+                _hosterState.update { _ ->
+                    Result.failure(IllegalStateException("Episode is no longer available"))
+                }
+                return@launchIO
+            }
+
+            val anime = Injekt.get<GetAnime>().await(animeId)
+            if (anime == null) {
+                _hosterState.update { _ ->
+                    Result.failure(IllegalStateException("Anime is no longer available"))
+                }
+                return@launchIO
+            }
+
             val source = sourceManager.getOrStub(sourceId)
 
             _episode.update { _ -> episode }
@@ -197,10 +211,10 @@ class EpisodeOptionsDialogScreenModel(
             }
 
             val initialHosterState = hosterList.map { hoster ->
-                if (hoster.videoList == null) {
+                val videoList = hoster.videoList
+                if (videoList == null) {
                     HosterState.Loading(hoster.hosterName)
                 } else {
-                    val videoList = hoster.videoList!!
                     HosterState.Ready(
                         hoster.hosterName,
                         videoList,
@@ -222,8 +236,11 @@ class EpisodeOptionsDialogScreenModel(
                             val prefIndex = hosterState.videoList.indexOfFirst { it.preferred }
                             if (prefIndex != -1) {
                                 if (hasFoundPreferredVideo.compareAndSet(false, true)) {
-                                    val success =
-                                        loadVideo(source, hosterState.videoList[prefIndex], hosterIdx, prefIndex)
+                                    val preferredVideo = EpisodeOptionsDialogStateGuard
+                                        .readyVideo(Result.success(listOf(hosterState)), 0, prefIndex)
+                                        ?.video
+                                    val success = preferredVideo != null &&
+                                        loadVideo(source, preferredVideo, hosterIdx, prefIndex)
                                     if (!success) {
                                         hasFoundPreferredVideo.set(false)
                                     }
@@ -234,7 +251,14 @@ class EpisodeOptionsDialogScreenModel(
                 }.awaitAll()
 
                 if (hasFoundPreferredVideo.compareAndSet(false, true)) {
-                    val hosterStateList = hosterState.value!!.getOrThrow()
+                    val hosterStateList = hosterState.value?.getOrNull()
+                    if (hosterStateList == null) {
+                        _hosterState.update { _ ->
+                            Result.failure(IllegalStateException("Hoster state is unavailable"))
+                        }
+                        return@launchIO
+                    }
+
                     val (hosterIdx, videoIdx) = HosterLoader.selectBestVideo(hosterStateList)
                     if (hosterIdx == -1) {
                         _hosterState.update { _ ->
@@ -243,7 +267,15 @@ class EpisodeOptionsDialogScreenModel(
                         return@launchIO
                     }
 
-                    val video = (hosterStateList[hosterIdx] as HosterState.Ready).videoList[videoIdx]
+                    val video = EpisodeOptionsDialogStateGuard
+                        .readyVideo(Result.success(hosterStateList), hosterIdx, videoIdx)
+                        ?.video
+                    if (video == null) {
+                        _hosterState.update { _ ->
+                            Result.failure(IllegalStateException("Selected video is unavailable"))
+                        }
+                        return@launchIO
+                    }
 
                     loadVideo(source, video, hosterIdx, videoIdx)
                 }
@@ -258,7 +290,11 @@ class EpisodeOptionsDialogScreenModel(
     }
 
     private suspend fun loadVideo(source: AnimeSource, video: Video, hosterIndex: Int, videoIndex: Int): Boolean {
-        val selectedHosterState = (_hosterState.value!!.getOrThrow()[hosterIndex] as? HosterState.Ready) ?: return false
+        val selectedHosterState = EpisodeOptionsDialogStateGuard
+            .readyVideo(_hosterState.value, hosterIndex, videoIndex)
+            ?.hosterState
+            ?: return false
+        val videoState = selectedHosterState.videoState.getOrNull(videoIndex) ?: return false
 
         val oldSelectedIndex = _selectedHosterVideoIndex.value
         _selectedHosterVideoIndex.update { _ -> Pair(hosterIndex, videoIndex) }
@@ -268,7 +304,7 @@ class EpisodeOptionsDialogScreenModel(
             selectedHosterState.getChangedAt(videoIndex, video, Video.State.LOAD_VIDEO),
         )
 
-        val resolvedVideo = if (selectedHosterState.videoState[videoIndex] != Video.State.READY) {
+        val resolvedVideo = if (videoState != Video.State.READY) {
             HosterLoader.getResolvedVideo(source, video)
         } else {
             video
@@ -291,7 +327,10 @@ class EpisodeOptionsDialogScreenModel(
                     return false
                 }
 
-                val newVideo = (hosterStateList[newHosterIdx] as HosterState.Ready).videoList[newVideoIdx]
+                val newVideo = EpisodeOptionsDialogStateGuard
+                    .readyVideo(Result.success(hosterStateList), newHosterIdx, newVideoIdx)
+                    ?.video
+                    ?: return false
 
                 return loadVideo(source, newVideo, newHosterIdx, newVideoIdx)
             } else {
@@ -318,7 +357,9 @@ class EpisodeOptionsDialogScreenModel(
             values?.getOrNull()?.let {
                 Result.success(
                     it.toMutableList().apply {
-                        this[index] = newValue
+                        if (index in indices) {
+                            this[index] = newValue
+                        }
                     },
                 )
             } ?: values
@@ -342,12 +383,19 @@ class EpisodeOptionsDialogScreenModel(
             }
             is HosterState.Error, is HosterState.Idle -> {
                 val hosterName = hosterState.name
+                val source = _source.value
+                val hoster = EpisodeOptionsDialogStateGuard.hosterAt(
+                    sourceAvailable = source != null,
+                    hosterList = _hosterList.value,
+                    hosterIndex = hosterIndex,
+                ) ?: return
+
                 _hosterState.updateAt(hosterIndex, HosterState.Loading(hosterName))
 
                 screenModelScope.launchIO {
                     val newHosterState = EpisodeLoader.loadHosterVideos(
-                        _source.value!!,
-                        _hosterList.value[hosterIndex],
+                        source ?: return@launchIO,
+                        hoster,
                     )
                     _hosterState.updateAt(hosterIndex, newHosterState)
                 }
@@ -357,13 +405,14 @@ class EpisodeOptionsDialogScreenModel(
     }
 
     fun onClickVideo(hosterIndex: Int, videoIndex: Int) {
-        val video = (_hosterState.value?.getOrNull()?.getOrNull(hosterIndex) as? HosterState.Ready)
-            ?.videoList
-            ?.getOrNull(videoIndex)
+        val video = EpisodeOptionsDialogStateGuard
+            .readyVideo(_hosterState.value, hosterIndex, videoIndex)
+            ?.video
             ?: return
+        val source = _source.value ?: return
 
         screenModelScope.launchIO {
-            val success = loadVideo(_source.value!!, video, hosterIndex, videoIndex)
+            val success = loadVideo(source, video, hosterIndex, videoIndex)
             if (success) {
                 _showAllQualities.update { _ -> false }
             }
@@ -373,11 +422,12 @@ class EpisodeOptionsDialogScreenModel(
     fun getHosterList(): List<Hoster>? {
         val hosterStateList = hosterState.value?.getOrNull() ?: return null
         return _hosterList.value.mapIndexed { index, h ->
-            if (hosterStateList[index] is HosterState.Ready) {
+            val state = hosterStateList.getOrNull(index)
+            if (state is HosterState.Ready) {
                 Hoster(
                     hosterName = h.hosterName,
                     hosterUrl = h.hosterUrl,
-                    videoList = (hosterStateList[index] as HosterState.Ready).videoList,
+                    videoList = state.videoList,
                 )
             } else {
                 Hoster(
@@ -387,6 +437,37 @@ class EpisodeOptionsDialogScreenModel(
                 )
             }
         }
+    }
+}
+
+internal object EpisodeOptionsDialogStateGuard {
+
+    data class ReadyVideo(
+        val hosterState: HosterState.Ready,
+        val video: Video,
+    )
+
+    fun readyVideo(
+        hosterState: Result<List<HosterState>>?,
+        hosterIndex: Int,
+        videoIndex: Int,
+    ): ReadyVideo? {
+        val readyHoster = hosterState
+            ?.getOrNull()
+            ?.getOrNull(hosterIndex) as? HosterState.Ready
+            ?: return null
+        val video = readyHoster.videoList.getOrNull(videoIndex) ?: return null
+        readyHoster.videoState.getOrNull(videoIndex) ?: return null
+        return ReadyVideo(readyHoster, video)
+    }
+
+    fun hosterAt(
+        sourceAvailable: Boolean,
+        hosterList: List<Hoster>,
+        hosterIndex: Int,
+    ): Hoster? {
+        if (!sourceAvailable) return null
+        return hosterList.getOrNull(hosterIndex)
     }
 }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/components/sheets/QualitySheet.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/components/sheets/QualitySheet.kt
@@ -171,7 +171,7 @@ fun QualitySheetVideoContent(
         itemsIndexed(videoList) { videoIdx, video ->
             VideoTrack(
                 video = video,
-                videoState = videoState[videoIdx],
+                videoState = videoState.getOrNull(videoIdx) ?: Video.State.LOAD_VIDEO,
                 selected = selectedVideoIndex == videoIdx,
                 onClick = { onClickVideo(0, videoIdx) },
                 noHoster = true,
@@ -263,7 +263,7 @@ internal fun LazyListScope.hosterContent(
                         it.videoList.forEachIndexed { videoIdx, video ->
                             VideoTrack(
                                 video = video,
-                                videoState = hoster.videoState[videoIdx],
+                                videoState = hoster.videoState.getOrNull(videoIdx) ?: Video.State.LOAD_VIDEO,
                                 selected = selectedVideoIndex == Pair(hosterIdx, videoIdx),
                                 onClick = { onClickVideo(hosterIdx, videoIdx) },
                                 noHoster = false,

--- a/app/src/test/java/eu/kanade/presentation/entries/anime/EpisodeOptionsDialogStateGuardTest.kt
+++ b/app/src/test/java/eu/kanade/presentation/entries/anime/EpisodeOptionsDialogStateGuardTest.kt
@@ -1,0 +1,89 @@
+package eu.kanade.presentation.entries.anime
+
+import eu.kanade.tachiyomi.animesource.model.Hoster
+import eu.kanade.tachiyomi.animesource.model.Video
+import eu.kanade.tachiyomi.ui.player.controls.components.sheets.HosterState
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class EpisodeOptionsDialogStateGuardTest {
+
+    @Test
+    fun `readyVideo returns null when hoster state is missing or indexes are stale`() {
+        val state = Result.success(
+            listOf(
+                HosterState.Ready(
+                    name = "hoster",
+                    videoList = listOf(video("720p")),
+                    videoState = listOf(Video.State.LOAD_VIDEO),
+                ),
+            ),
+        )
+
+        assertNull(EpisodeOptionsDialogStateGuard.readyVideo(null, 0, 0))
+        assertNull(EpisodeOptionsDialogStateGuard.readyVideo(state, -1, 0))
+        assertNull(EpisodeOptionsDialogStateGuard.readyVideo(state, 1, 0))
+        assertNull(EpisodeOptionsDialogStateGuard.readyVideo(state, 0, -1))
+        assertNull(EpisodeOptionsDialogStateGuard.readyVideo(state, 0, 1))
+    }
+
+    @Test
+    fun `readyVideo returns null when video state is missing for selected video`() {
+        val state = Result.success(
+            listOf(
+                HosterState.Ready(
+                    name = "hoster",
+                    videoList = listOf(video("720p")),
+                    videoState = emptyList(),
+                ),
+            ),
+        )
+
+        assertNull(EpisodeOptionsDialogStateGuard.readyVideo(state, 0, 0))
+    }
+
+    @Test
+    fun `readyVideo returns selected ready hoster and video for valid indexes`() {
+        val selectedVideo = video("720p")
+        val state = Result.success(
+            listOf(
+                HosterState.Ready(
+                    name = "hoster",
+                    videoList = listOf(selectedVideo),
+                    videoState = listOf(Video.State.LOAD_VIDEO),
+                ),
+            ),
+        )
+
+        val selection = EpisodeOptionsDialogStateGuard.readyVideo(state, 0, 0)
+
+        assertEquals(selectedVideo, selection?.video)
+        assertEquals("hoster", selection?.hosterState?.name)
+    }
+
+    @Test
+    fun `hosterAt returns null when source or hoster index is unavailable`() {
+        assertNull(EpisodeOptionsDialogStateGuard.hosterAt(sourceAvailable = false, hosterList = listOf(hoster()), 0))
+        assertNull(EpisodeOptionsDialogStateGuard.hosterAt(sourceAvailable = true, hosterList = emptyList(), 0))
+        assertNull(EpisodeOptionsDialogStateGuard.hosterAt(sourceAvailable = true, hosterList = listOf(hoster()), 1))
+    }
+
+    @Test
+    fun `hosterAt returns hoster when source and index are available`() {
+        val hoster = hoster()
+
+        assertEquals(
+            hoster,
+            EpisodeOptionsDialogStateGuard.hosterAt(sourceAvailable = true, hosterList = listOf(hoster), 0),
+        )
+    }
+
+    private fun video(title: String): Video {
+        return Video(videoUrl = "https://example.invalid/$title", videoTitle = title)
+    }
+
+    private fun hoster(): Hoster {
+        return Hoster(hosterName = "hoster")
+    }
+}


### PR DESCRIPTION
## Ticket
- ID: R683
- Priority: P2
- Risk Tier: T1
- GitHub Issue: Closes #764

## Objective
- Prevent episode options from crashing when episode, anime, source, hoster, or video state is missing or stale during async dialog setup and interaction.

## Scope
- Replace episode/anime force unwraps with explicit failure state.
- Guard preferred-video, best-video, hoster click, video click, and hoster-list access with safe state/index checks.
- Harden quality sheet rendering against mismatched video/video-state lists.
- Add focused unit coverage for the extracted state guard.
- Add changelog entry for the user-visible crash hardening.

## Non-goals
- No broad anime/manga workflow refactor.
- No global hoster loading rewrite.
- No player quality sheet redesign.

## Files Changed
- `EpisodeOptionsDialogScreen.kt`: missing-state and stale-index guards.
- `QualitySheet.kt`: safe render-time video state lookup.
- `EpisodeOptionsDialogStateGuardTest.kt`: focused state guard regression coverage.
- `CHANGELOG.md`: fixed entry.

## Verification
- Commands run:
  - `./gradlew :app:testStableDebugUnitTest --tests eu.kanade.presentation.entries.anime.EpisodeOptionsDialogStateGuardTest`
  - `git diff --check`
  - `./gradlew spotlessCheck`
  - `./gradlew :app:compileStableDebugKotlin`
  - Push hook reran `./gradlew spotlessCheck`
  - Push hook reran `./gradlew :app:compileStableDebugKotlin`
- Results:
  - All passed.
- Not tested:
  - Manual episode-options smoke was not run; this change is covered by focused guard tests plus stable debug compile.

## Risk
- Low. The change turns missing/stale state into failure/no-op/loading paths instead of throwing. The quality sheet fallback can temporarily show a loading state for malformed video-state rows rather than crashing.

## SLO Impact
- Improves crash-free behavior for episode options dialog interactions. No expected latency or throughput impact.

## Rollback
- Revert this PR to restore the prior dialog and quality-sheet behavior.

## Release Notes
- Episode options now shows stable loading/error behavior instead of crashing when required state is unavailable.

## Checklist
- [x] Naming conventions followed (use "Rayniyomi" in user-facing text; see [branding guardrail](../docs/branding-guardrail.md))
- [x] Branch rebased on latest main and verification re-run
- [x] New coroutine scopes have documented owner and cancellation path
- [x] No new `runBlocking` on UI/main thread paths

## Definition of Done (DoD)
- [x] Acceptance criteria met and non-goals respected
- [x] Verification matrix completed (Risk Tier: T1)
- [x] Self-review completed
- [x] Rebased on latest `main` and revalidated (mandatory for merge)
- [ ] Sprint board updated (branch, commit, checks, PR link)
- [x] Release notes drafted (if applicable)

## Fork Compliance Checklist (for new forks only)
Not applicable; this is not a new fork setup.