### PR TITLE
fix: harden player hoster state indexing (R686)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 ### Fixed
 - Exported search intents now ignore malformed search type extras instead of crashing, and anime custom search no longer routes through the manga deep-link activity.
 - Episode options now shows a stable error state instead of crashing when episode, anime, source, hoster, or video state is unavailable.
+- Player quality selection now ignores stale hoster/video taps instead of crashing when hoster state changes asynchronously.
 - Manual backup creation now stages and validates new backup data before replacing the selected file, preserving existing backups when generation, validation, or final writes fail.
 - Missing-extension sources now preserve readable stub source names from runtime and backup metadata (fallback to raw source ID only when metadata is unavailable), for both manga and anime source flows.
 - Reader initialization now guards chapter loading with a descriptive `checkNotNull` for `ChapterLoader`, replacing an unsafe null assertion crash path in `ReaderViewModel`.

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/loader/HosterOrchestrator.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/loader/HosterOrchestrator.kt
@@ -85,15 +85,14 @@ class HosterOrchestrator(
                 hosterList.map { hoster ->
                     if (hoster.lazy) {
                         HosterState.Idle(hoster.hosterName)
-                    } else if (hoster.videoList == null) {
-                        HosterState.Loading(hoster.hosterName)
                     } else {
-                        val videoList = hoster.videoList!!
-                        HosterState.Ready(
-                            hoster.hosterName,
-                            videoList,
-                            List(videoList.size) { Video.State.QUEUE },
-                        )
+                        hoster.videoList?.let { videoList ->
+                            HosterState.Ready(
+                                hoster.hosterName,
+                                videoList,
+                                List(videoList.size) { Video.State.QUEUE },
+                            )
+                        } ?: HosterState.Loading(hoster.hosterName)
                     }
                 }
             }
@@ -121,13 +120,16 @@ class HosterOrchestrator(
                                 if (prefIndex != -1 && hosterIndex == -1) {
                                     if (hasFoundPreferredVideo.compareAndSet(false, true)) {
                                         if (selectedHosterVideoIndex.value == Pair(-1, -1)) {
-                                            val success =
-                                                loadVideo(
-                                                    source,
-                                                    hosterState.videoList[prefIndex],
-                                                    hosterIdx,
-                                                    prefIndex,
-                                                )
+                                            val success = hosterState.videoList.getOrNull(prefIndex)
+                                                ?.let { preferredVideo ->
+                                                    loadVideo(
+                                                        source,
+                                                        preferredVideo,
+                                                        hosterIdx,
+                                                        prefIndex,
+                                                    )
+                                                }
+                                                ?: false
                                             if (!success) {
                                                 hasFoundPreferredVideo.set(false)
                                             }
@@ -144,9 +146,9 @@ class HosterOrchestrator(
                             throw Exception("No available videos")
                         }
 
-                        val video = (hosterState.value[hosterIdx] as HosterState.Ready).videoList[videoIdx]
-
-                        loadVideo(source, video, hosterIdx, videoIdx)
+                        readyVideoAt(hosterIdx, videoIdx)?.let { video ->
+                            loadVideo(source, video, hosterIdx, videoIdx)
+                        }
                     }
                 }
             } catch (e: CancellationException) {
@@ -171,6 +173,10 @@ class HosterOrchestrator(
             val selectedHosterState =
                 (_hosterState.value.getOrNull(currentHosterIndex) as? HosterState.Ready)
                     ?: return false
+            val videoState = selectedHosterState.videoState.getOrNull(currentVideoIndex)
+            if (videoState == null) {
+                return false
+            }
 
             _selectedHosterVideoIndex.update { Pair(currentHosterIndex, currentVideoIndex) }
             _hosterState.updateAt(
@@ -180,7 +186,7 @@ class HosterOrchestrator(
 
             onPauseRequested?.invoke()
 
-            val resolvedVideo = if (selectedHosterState.videoState[currentVideoIndex] != Video.State.READY) {
+            val resolvedVideo = if (videoState != Video.State.READY) {
                 HosterLoader.getResolvedVideo(source, currentVideo)
             } else {
                 currentVideo
@@ -203,7 +209,10 @@ class HosterOrchestrator(
                         }
                     }
 
-                    val newVideo = (hosterState.value[newHosterIdx] as HosterState.Ready).videoList[newVideoIdx]
+                    val newVideo = readyVideoAt(newHosterIdx, newVideoIdx)
+                    if (newVideo == null) {
+                        return false
+                    }
                     currentHosterIndex = newHosterIdx
                     currentVideoIndex = newVideoIdx
                     currentVideo = newVideo
@@ -237,7 +246,7 @@ class HosterOrchestrator(
         onSuccess: () -> Unit,
         onFailure: () -> Unit,
     ) {
-        val hosterState = _hosterState.value[hosterIndex] as? HosterState.Ready
+        val hosterState = _hosterState.value.getOrNull(hosterIndex) as? HosterState.Ready
         val video = hosterState?.videoList
             ?.getOrNull(videoIndex)
             ?: return
@@ -261,18 +270,21 @@ class HosterOrchestrator(
     }
 
     fun onHosterClicked(index: Int, currentSource: AnimeSource?) {
-        when (hosterState.value[index]) {
+        when (hosterState.value.getOrNull(index) ?: return) {
             is HosterState.Ready -> {
-                _hosterExpandedList.updateAt(index, !_hosterExpandedList.value[index])
+                val isExpanded = _hosterExpandedList.value.getOrNull(index) ?: return
+                _hosterExpandedList.updateAt(index, !isExpanded)
             }
             is HosterState.Idle -> {
-                val hosterName = hosterList.value[index].hosterName
+                val source = currentSource ?: return
+                val hoster = hosterList.value.getOrNull(index) ?: return
+                val hosterName = hoster.hosterName
                 _hosterState.updateAt(index, HosterState.Loading(hosterName))
 
                 scope.launch(hosterLoadDispatcher) {
                     val hosterState = EpisodeLoader.loadHosterVideos(
-                        source = currentSource!!,
-                        hoster = hosterList.value[index],
+                        source = source,
+                        hoster = hoster,
                         force = true,
                     )
                     _hosterState.updateAt(index, hosterState)
@@ -282,10 +294,18 @@ class HosterOrchestrator(
         }
     }
 
+    private fun readyVideoAt(hosterIndex: Int, videoIndex: Int): Video? {
+        return (_hosterState.value.getOrNull(hosterIndex) as? HosterState.Ready)
+            ?.videoList
+            ?.getOrNull(videoIndex)
+    }
+
     private fun <T> MutableStateFlow<List<T>>.updateAt(index: Int, newValue: T) {
         this.update { values ->
             values.toMutableList().apply {
-                this[index] = newValue
+                if (index in indices) {
+                    this[index] = newValue
+                }
             }
         }
     }

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/player/loader/HosterOrchestratorTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/player/loader/HosterOrchestratorTest.kt
@@ -1,15 +1,21 @@
 package eu.kanade.tachiyomi.ui.player.loader
 
 import eu.kanade.tachiyomi.animesource.model.Hoster
+import eu.kanade.tachiyomi.animesource.model.Video
 import eu.kanade.tachiyomi.ui.player.controls.components.sheets.HosterState
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class HosterOrchestratorTest {
@@ -58,5 +64,133 @@ class HosterOrchestratorTest {
     @Test
     fun `cancelHosterVideoLinksJob does not throw`() {
         orchestrator.cancelHosterVideoLinksJob()
+    }
+
+    @Test
+    fun `onVideoClicked ignores stale hoster index`() {
+        assertDoesNotThrow {
+            orchestrator.onVideoClicked(
+                hosterIndex = 0,
+                videoIndex = 0,
+                currentSource = null,
+                onSuccess = {},
+                onFailure = {},
+            )
+        }
+    }
+
+    @Test
+    fun `onHosterClicked ignores stale hoster index`() {
+        assertDoesNotThrow {
+            orchestrator.onHosterClicked(index = 0, currentSource = null)
+        }
+    }
+
+    @Test
+    fun `onHosterClicked toggles valid ready hoster expansion`() {
+        orchestrator.setHosterStateForTest(
+            listOf(
+                HosterState.Ready(
+                    name = "hoster",
+                    videoList = listOf(Video(videoUrl = "https://example.invalid/video", videoTitle = "720p")),
+                    videoState = listOf(Video.State.READY),
+                ),
+            ),
+        )
+        orchestrator.setHosterExpandedListForTest(listOf(false))
+
+        orchestrator.onHosterClicked(index = 0, currentSource = null)
+
+        assertEquals(listOf(true), orchestrator.hosterExpandedList.value)
+    }
+
+    @Test
+    fun `onHosterClicked ignores idle hoster when source is missing`() = runTest {
+        orchestrator.setHosterListForTest(listOf(Hoster(hosterName = "lazy", lazy = true)))
+        orchestrator.setHosterStateForTest(listOf(HosterState.Idle("lazy")))
+        orchestrator.setHosterExpandedListForTest(listOf(false))
+
+        assertDoesNotThrow {
+            orchestrator.onHosterClicked(index = 0, currentSource = null)
+        }
+        advanceUntilIdle()
+
+        assertEquals(listOf(HosterState.Idle("lazy")), orchestrator.hosterState.value)
+    }
+
+    @Test
+    fun `onVideoClicked ignores ready hoster with mismatched video state`() = runTest {
+        orchestrator.setHosterStateForTest(
+            listOf(
+                HosterState.Ready(
+                    name = "hoster",
+                    videoList = listOf(Video(videoUrl = "https://example.invalid/video", videoTitle = "720p")),
+                    videoState = emptyList(),
+                ),
+            ),
+        )
+
+        assertDoesNotThrow {
+            orchestrator.onVideoClicked(
+                hosterIndex = 0,
+                videoIndex = 0,
+                currentSource = null,
+                onSuccess = {},
+                onFailure = {},
+            )
+        }
+        advanceUntilIdle()
+
+        assertEquals(Pair(-1, -1), orchestrator.selectedHosterVideoIndex.value)
+    }
+
+    @Test
+    fun `onVideoClicked loads valid ready video and calls success`() {
+        val video = Video(videoUrl = "https://example.invalid/video", videoTitle = "720p")
+        val successLatch = CountDownLatch(1)
+        var readyVideo: Video? = null
+        orchestrator.onVideoReady = { readyVideo = it }
+        orchestrator.setHosterStateForTest(
+            listOf(
+                HosterState.Ready(
+                    name = "hoster",
+                    videoList = listOf(video),
+                    videoState = listOf(Video.State.READY),
+                ),
+            ),
+        )
+
+        orchestrator.onVideoClicked(
+            hosterIndex = 0,
+            videoIndex = 0,
+            currentSource = null,
+            onSuccess = { successLatch.countDown() },
+            onFailure = {},
+        )
+
+        assertEquals(true, successLatch.await(5, TimeUnit.SECONDS))
+        assertEquals(video, readyVideo)
+        assertEquals(Pair(0, 0), orchestrator.selectedHosterVideoIndex.value)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun HosterOrchestrator.setHosterListForTest(value: List<Hoster>) {
+        val field = HosterOrchestrator::class.java.getDeclaredField("_hosterList")
+        field.isAccessible = true
+        (field.get(this) as MutableStateFlow<List<Hoster>>).value = value
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun HosterOrchestrator.setHosterStateForTest(value: List<HosterState>) {
+        val field = HosterOrchestrator::class.java.getDeclaredField("_hosterState")
+        field.isAccessible = true
+        (field.get(this) as MutableStateFlow<List<HosterState>>).value = value
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun HosterOrchestrator.setHosterExpandedListForTest(value: List<Boolean>) {
+        val field = HosterOrchestrator::class.java.getDeclaredField("_hosterExpandedList")
+        field.isAccessible = true
+        (field.get(this) as MutableStateFlow<List<Boolean>>).value = value
     }
 }


### PR DESCRIPTION
## Ticket
- ID: R686
- Priority: P2
- Risk Tier: T2
- GitHub Issue: Closes #770

## Objective
Prevent player quality/hoster UI actions from crashing when async hoster state changes leave the UI with stale hoster or video indexes.

## Scope
- Replaces direct hoster/video list indexing in `HosterOrchestrator` with guarded lookups on stale async state paths.
- Removes the lazy hoster `currentSource!!` crash path by ignoring expansion when the source is unavailable.
- Makes `updateAt` ignore stale indexes instead of throwing after backing state changes.
- Adds focused regression tests for stale hoster indexes, null source lazy hoster expansion, and mismatched ready video state.
- Adds a changelog entry for the player crash hardening.

## Non-goals
- No broader player loader refactor.
- No changes to hoster selection ranking or source loading behavior.
- No UI redesign or player screen behavior changes beyond ignoring stale taps safely.

## Files Changed
- `app/src/main/java/eu/kanade/tachiyomi/ui/player/loader/HosterOrchestrator.kt`
- `app/src/test/java/eu/kanade/tachiyomi/ui/player/loader/HosterOrchestratorTest.kt`
- `CHANGELOG.md`

## Verification
- Commands run:
  - `./gradlew :app:testStableDebugUnitTest --tests 'eu.kanade.tachiyomi.ui.player.loader.HosterOrchestratorTest'`
  - `./gradlew spotlessCheck`
  - `./gradlew :app:compileStableDebugKotlin`
  - independent agent review for correctness, validity, and architecture
- Results:
  - Focused HosterOrchestrator unit tests passed.
  - Spotless passed.
  - Stable debug Kotlin compile passed with existing warnings.
  - Independent review found no blocking issues.
- Not tested:
  - Full app instrumentation/player playback on device was not run for this narrow state-guard change.

## Risk
Low-medium. This touches player hoster selection logic, but changes are limited to stale/null guards around async state. Valid indexes continue down the same existing paths; stale indexes now return without mutating state or throwing. Focused regression tests cover the crash paths.

## SLO Impact
Expected positive stability impact for player quality selection. No expected performance or startup impact.

## Rollback
Revert `R686: harden player hoster state indexing` to restore prior hoster indexing behavior if regressions appear.

## Release Notes
Player quality selection now ignores stale hoster/video taps instead of crashing when hoster state changes asynchronously.

## Checklist
- [x] Naming conventions followed (use "Rayniyomi" in user-facing text; see [branding guardrail](../docs/branding-guardrail.md))
- [x] Branch rebased on latest main and verification re-run
- [x] New coroutine scopes have documented owner and cancellation path
- [x] No new `runBlocking` on UI/main thread paths

## Definition of Done (DoD)
- [x] Acceptance criteria met and non-goals respected
- [x] Verification matrix completed (Risk Tier: T2)
- [x] Self-review completed
- [x] Rebased on latest `main` and revalidated (mandatory for merge)
- [ ] Sprint board updated (branch, commit, checks, PR link)
- [x] Release notes drafted (if applicable)

## Fork Compliance Checklist (for new forks only)
If you are creating a new fork of this project, ensure the following:
- [ ] **App Identity**: Changed app name from "Aniyomi" to your fork name
- [ ] **App Icon**: Replaced launcher icon assets with fork-specific icons
- [ ] **Application ID**: Changed `applicationId` in `app/build.gradle.kts` from `xyz.rayniyomi` to your unique ID
- [ ] **Update Checker**: Configured `AppUpdateChecker.kt` to point to your fork's repository
- [ ] **Analytics**: Either disabled Firebase Analytics or configured with your own `google-services.json`
- [ ] **Crash Reporting**: Either disabled ACRA crash reporting or configured with your own endpoint credentials

See [CONTRIBUTING.md](../CONTRIBUTING.md) Forks section for details.
