### PR TITLE
fix: validate tracker oauth callback state (R685)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 
 ### Fixed
 - Invalid extension trust-revoked dialogs now show the failure reason, package, version, signature prefix, debug detail, and recovery guidance.
+- Tracker OAuth callbacks now require a matching one-time state token before accepting provider login results.
 - Exported search intents now ignore malformed search type extras instead of crashing, and anime custom search no longer routes through the manga deep-link activity.
 - Episode options now shows a stable error state instead of crashing when episode, anime, source, hoster, or video state is unavailable.
 - Player quality selection now ignores stale hoster/video taps instead of crashing when hoster state changes asynchronously.

--- a/app/src/androidTest/java/eu/kanade/tachiyomi/ui/setting/track/TrackerOAuthCallbackAndroidTest.kt
+++ b/app/src/androidTest/java/eu/kanade/tachiyomi/ui/setting/track/TrackerOAuthCallbackAndroidTest.kt
@@ -1,0 +1,166 @@
+package eu.kanade.tachiyomi.ui.setting.track
+
+import android.net.Uri
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import eu.kanade.domain.track.service.TrackPreferences
+import eu.kanade.domain.track.service.TrackerOAuthStateStore
+import eu.kanade.tachiyomi.data.track.anilist.AnilistApi
+import eu.kanade.tachiyomi.data.track.bangumi.BangumiApi
+import eu.kanade.tachiyomi.data.track.myanimelist.MyAnimeListApi
+import eu.kanade.tachiyomi.data.track.shikimori.ShikimoriApi
+import eu.kanade.tachiyomi.data.track.simkl.SimklApi
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Test
+import org.junit.runner.RunWith
+import tachiyomi.core.common.preference.Preference
+import tachiyomi.core.common.preference.PreferenceStore
+
+@RunWith(AndroidJUnit4::class)
+class TrackerOAuthCallbackAndroidTest {
+
+    @Test
+    fun auth_urls_include_state_on_android_uri() {
+        assertEquals("state-value", AnilistApi.authUrl("state-value").getQueryParameter("state"))
+        assertEquals("state-value", MyAnimeListApi.authUrl("state-value").getQueryParameter("state"))
+        assertFalse(MyAnimeListApi.authUrl("state-value").getQueryParameter("code_challenge").isNullOrBlank())
+        assertEquals("state-value", BangumiApi.authUrl("state-value").getQueryParameter("state"))
+        assertEquals("state-value", ShikimoriApi.authUrl("state-value").getQueryParameter("state"))
+        assertEquals("state-value", SimklApi.authUrl("state-value").getQueryParameter("state"))
+    }
+
+    @Test
+    fun android_uri_callback_requires_matching_one_time_state() {
+        val stateStore = TrackerOAuthStateStore(
+            preferences = TrackPreferences(MutablePreferenceStore()),
+            generateState = { "expected-state" },
+        )
+        val state = stateStore.begin(TrackerOAuthCallback.MyAnimeList.HOST)
+        val callback = callbackFrom(
+            Uri.parse("aniyomi://myanimelist-auth?code=auth-code&state=$state"),
+        )
+
+        assertEquals(
+            TrackerOAuthCallbackResult.Login(
+                host = TrackerOAuthCallback.MyAnimeList.HOST,
+                credential = "auth-code",
+            ),
+            callback.validated(stateStore::consume),
+        )
+        assertEquals(TrackerOAuthCallbackResult.InvalidState, callback.validated(stateStore::consume))
+    }
+
+    @Test
+    fun android_uri_invalid_state_returns_before_provider_denial() {
+        val stateStore = TrackerOAuthStateStore(
+            preferences = TrackPreferences(MutablePreferenceStore()),
+            generateState = { "expected-state" },
+        )
+        stateStore.begin(TrackerOAuthCallback.Simkl.HOST)
+        val callback = callbackFrom(
+            Uri.parse("aniyomi://simkl-auth?state=wrong-state"),
+        )
+
+        assertEquals(TrackerOAuthCallbackResult.InvalidState, callback.validated(stateStore::consume))
+    }
+
+    @Test
+    fun android_uri_anilist_fragment_state_is_validated() {
+        val stateStore = TrackerOAuthStateStore(
+            preferences = TrackPreferences(MutablePreferenceStore()),
+            generateState = { "expected-state" },
+        )
+        val state = stateStore.begin(TrackerOAuthCallback.Anilist.HOST)
+        val callback = callbackFrom(
+            Uri.parse("aniyomi://anilist-auth#access_token=token-value&token_type=Bearer&state=$state"),
+        )
+
+        assertEquals(
+            TrackerOAuthCallbackResult.Login(
+                host = TrackerOAuthCallback.Anilist.HOST,
+                credential = "token-value",
+            ),
+            callback.validated(stateStore::consume),
+        )
+    }
+
+    private fun callbackFrom(uri: Uri): TrackerOAuthCallback? {
+        return TrackerOAuthCallback.from(
+            host = uri.host,
+            queryParameters = uri.queryParameterNames.associateWith(uri::getQueryParameter),
+            fragment = uri.fragment,
+        )
+    }
+
+    private class MutablePreferenceStore(initialValues: Map<String, Any?> = emptyMap()) : PreferenceStore {
+        private val data = initialValues.toMutableMap()
+
+        override fun getString(key: String, defaultValue: String): Preference<String> = MutablePreference(
+            key,
+            defaultValue,
+        )
+
+        override fun getLong(key: String, defaultValue: Long): Preference<Long> = MutablePreference(key, defaultValue)
+
+        override fun getInt(key: String, defaultValue: Int): Preference<Int> = MutablePreference(key, defaultValue)
+
+        override fun getFloat(key: String, defaultValue: Float): Preference<Float> = MutablePreference(
+            key,
+            defaultValue,
+        )
+
+        override fun getBoolean(key: String, defaultValue: Boolean): Preference<Boolean> = MutablePreference(
+            key,
+            defaultValue,
+        )
+
+        override fun getStringSet(key: String, defaultValue: Set<String>): Preference<Set<String>> =
+            MutablePreference(key, defaultValue)
+
+        override fun <T> getObject(
+            key: String,
+            defaultValue: T,
+            serializer: (T) -> String,
+            deserializer: (String) -> T,
+        ): Preference<T> = MutablePreference(key, defaultValue)
+
+        override fun getAll(): Map<String, *> = data
+
+        private inner class MutablePreference<T>(
+            private val key: String,
+            private val defaultValue: T,
+        ) : Preference<T> {
+            private val state = MutableStateFlow(get())
+
+            override fun key(): String = key
+
+            override fun get(): T {
+                @Suppress("UNCHECKED_CAST")
+                return (data[key] as T?) ?: defaultValue
+            }
+
+            override fun set(value: T) {
+                data[key] = value
+                state.value = value
+            }
+
+            override fun isSet(): Boolean = data.containsKey(key)
+
+            override fun delete() {
+                data.remove(key)
+                state.value = defaultValue
+            }
+
+            override fun defaultValue(): T = defaultValue
+
+            override fun changes(): Flow<T> = state.asStateFlow()
+
+            override fun stateIn(scope: CoroutineScope): StateFlow<T> = state.asStateFlow()
+        }
+    }
+}

--- a/app/src/main/java/eu/kanade/domain/track/service/TrackPreferences.kt
+++ b/app/src/main/java/eu/kanade/domain/track/service/TrackPreferences.kt
@@ -34,6 +34,11 @@ class TrackPreferences(
 
     fun trackToken(tracker: Tracker) = preferenceStore.getString(Preference.privateKey("track_token_${tracker.id}"), "")
 
+    fun trackOAuthState(callbackHost: String) = preferenceStore.getString(
+        Preference.appStateKey("track_oauth_state_$callbackHost"),
+        "",
+    )
+
     fun anilistScoreType() = preferenceStore.getString("anilist_score_type", Anilist.POINT_10)
 
     fun autoUpdateTrack() = preferenceStore.getBoolean("pref_auto_update_manga_sync_key", true)

--- a/app/src/main/java/eu/kanade/domain/track/service/TrackerOAuthStateStore.kt
+++ b/app/src/main/java/eu/kanade/domain/track/service/TrackerOAuthStateStore.kt
@@ -1,0 +1,28 @@
+package eu.kanade.domain.track.service
+
+import eu.kanade.tachiyomi.util.PkceUtil
+
+class TrackerOAuthStateStore(
+    private val preferences: TrackPreferences,
+    private val generateState: () -> String = PkceUtil::generateCodeVerifier,
+) {
+
+    fun begin(callbackHost: String): String {
+        val state = generateState()
+        preferences.trackOAuthState(callbackHost).set(state)
+        return state
+    }
+
+    fun consume(callbackHost: String, returnedState: String?): Boolean {
+        if (returnedState.isNullOrBlank()) return false
+
+        val pendingState = preferences.trackOAuthState(callbackHost)
+        val expectedState = pendingState.get()
+        if (expectedState.isBlank() || expectedState != returnedState) {
+            return false
+        }
+
+        pendingState.delete()
+        return true
+    }
+}

--- a/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsTrackingScreen.kt
+++ b/app/src/main/java/eu/kanade/presentation/more/settings/screen/SettingsTrackingScreen.kt
@@ -47,6 +47,7 @@ import dev.icerock.moko.resources.StringResource
 import eu.kanade.domain.track.model.AutoTrackState
 import eu.kanade.domain.track.service.PeriodicTrackerSyncJob
 import eu.kanade.domain.track.service.TrackPreferences
+import eu.kanade.domain.track.service.TrackerOAuthStateStore
 import eu.kanade.domain.track.service.TrackerSyncCoordinator
 import eu.kanade.domain.track.service.TrackerSyncResult
 import eu.kanade.domain.track.service.TrackerSyncTrigger
@@ -60,6 +61,7 @@ import eu.kanade.tachiyomi.data.track.bangumi.BangumiApi
 import eu.kanade.tachiyomi.data.track.myanimelist.MyAnimeListApi
 import eu.kanade.tachiyomi.data.track.shikimori.ShikimoriApi
 import eu.kanade.tachiyomi.data.track.simkl.SimklApi
+import eu.kanade.tachiyomi.ui.setting.track.TrackerOAuthCallback
 import eu.kanade.tachiyomi.util.system.openInBrowser
 import eu.kanade.tachiyomi.util.system.toast
 import kotlinx.collections.immutable.persistentListOf
@@ -101,6 +103,7 @@ object SettingsTrackingScreen : SearchableSettings {
     override fun getPreferences(): List<Preference> {
         val context = LocalContext.current
         val trackPreferences = remember { Injekt.get<TrackPreferences>() }
+        val oauthStateStore = remember { TrackerOAuthStateStore(trackPreferences) }
         val trackerManager = remember { Injekt.get<TrackerManager>() }
         val mangaSourceManager = remember { Injekt.get<MangaSourceManager>() }
         val animeSourceManager = remember { Injekt.get<AnimeSourceManager>() }
@@ -240,7 +243,9 @@ object SettingsTrackingScreen : SearchableSettings {
                         tracker = trackerManager.myAnimeList,
                         login = {
                             context.openInBrowser(
-                                MyAnimeListApi.authUrl(),
+                                MyAnimeListApi.authUrl(
+                                    oauthStateStore.begin(TrackerOAuthCallback.MyAnimeList.HOST),
+                                ),
                                 forceDefaultBrowser = true,
                             )
                         },
@@ -250,7 +255,9 @@ object SettingsTrackingScreen : SearchableSettings {
                         tracker = trackerManager.aniList,
                         login = {
                             context.openInBrowser(
-                                AnilistApi.authUrl(),
+                                AnilistApi.authUrl(
+                                    oauthStateStore.begin(TrackerOAuthCallback.Anilist.HOST),
+                                ),
                                 forceDefaultBrowser = true,
                             )
                         },
@@ -270,7 +277,9 @@ object SettingsTrackingScreen : SearchableSettings {
                         tracker = trackerManager.shikimori,
                         login = {
                             context.openInBrowser(
-                                ShikimoriApi.authUrl(),
+                                ShikimoriApi.authUrl(
+                                    oauthStateStore.begin(TrackerOAuthCallback.Shikimori.HOST),
+                                ),
                                 forceDefaultBrowser = true,
                             )
                         },
@@ -280,7 +289,9 @@ object SettingsTrackingScreen : SearchableSettings {
                         tracker = trackerManager.simkl,
                         login = {
                             context.openInBrowser(
-                                SimklApi.authUrl(),
+                                SimklApi.authUrl(
+                                    oauthStateStore.begin(TrackerOAuthCallback.Simkl.HOST),
+                                ),
                                 forceDefaultBrowser = true,
                             )
                         },
@@ -290,7 +301,9 @@ object SettingsTrackingScreen : SearchableSettings {
                         tracker = trackerManager.bangumi,
                         login = {
                             context.openInBrowser(
-                                BangumiApi.authUrl(),
+                                BangumiApi.authUrl(
+                                    oauthStateStore.begin(TrackerOAuthCallback.Bangumi.HOST),
+                                ),
                                 forceDefaultBrowser = true,
                             )
                         },

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/anilist/AnilistApi.kt
@@ -24,6 +24,7 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonObject
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
@@ -585,9 +586,18 @@ class AnilistApi(val client: OkHttpClient, interceptor: AnilistInterceptor) {
             return BASE_ANIME_URL + mediaId
         }
 
-        fun authUrl(): Uri = "${BASE_URL}oauth/authorize".toUri().buildUpon()
-            .appendQueryParameter("client_id", CLIENT_ID)
-            .appendQueryParameter("response_type", "token")
-            .build()
+        fun authUrl(state: String? = null): Uri = authUrlString(state).toUri()
+
+        internal fun authUrlString(state: String? = null): String =
+            "${BASE_URL}oauth/authorize".toHttpUrl().newBuilder()
+                .addQueryParameter("client_id", CLIENT_ID)
+                .addQueryParameter("response_type", "token")
+                .apply {
+                    if (state != null) {
+                        addQueryParameter("state", state)
+                    }
+                }
+                .build()
+                .toString()
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/bangumi/BangumiApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/bangumi/BangumiApi.kt
@@ -24,6 +24,7 @@ import kotlinx.serialization.json.putJsonObject
 import okhttp3.CacheControl
 import okhttp3.FormBody
 import okhttp3.Headers.Companion.headersOf
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
@@ -276,12 +277,20 @@ class BangumiApi(
 
         private const val APP_JSON = "application/json"
 
-        fun authUrl(): Uri =
-            LOGIN_URL.toUri().buildUpon()
-                .appendQueryParameter("client_id", CLIENT_ID)
-                .appendQueryParameter("response_type", "code")
-                .appendQueryParameter("redirect_uri", REDIRECT_URL)
+        fun authUrl(state: String? = null): Uri = authUrlString(state).toUri()
+
+        internal fun authUrlString(state: String? = null): String =
+            LOGIN_URL.toHttpUrl().newBuilder()
+                .addQueryParameter("client_id", CLIENT_ID)
+                .addQueryParameter("response_type", "code")
+                .addQueryParameter("redirect_uri", REDIRECT_URL)
+                .apply {
+                    if (state != null) {
+                        addQueryParameter("state", state)
+                    }
+                }
                 .build()
+                .toString()
 
         fun refreshTokenRequest(token: String) = POST(
             OAUTH_URL,

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeListApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/myanimelist/MyAnimeListApi.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.serialization.json.Json
 import okhttp3.FormBody
 import okhttp3.Headers
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody
@@ -395,11 +396,20 @@ class MyAnimeListApi(
 
         private var codeVerifier: String = ""
 
-        fun authUrl(): Uri = "$BASE_OAUTH_URL/authorize".toUri().buildUpon()
-            .appendQueryParameter("client_id", CLIENT_ID)
-            .appendQueryParameter("code_challenge", getPkceChallengeCode())
-            .appendQueryParameter("response_type", "code")
-            .build()
+        fun authUrl(state: String? = null): Uri = authUrlString(state).toUri()
+
+        internal fun authUrlString(state: String? = null): String =
+            "$BASE_OAUTH_URL/authorize".toHttpUrl().newBuilder()
+                .addQueryParameter("client_id", CLIENT_ID)
+                .addQueryParameter("code_challenge", getPkceChallengeCode())
+                .addQueryParameter("response_type", "code")
+                .apply {
+                    if (state != null) {
+                        addQueryParameter("state", state)
+                    }
+                }
+                .build()
+                .toString()
 
         fun mangaUrl(id: Long): Uri = "$BASE_API_URL/manga".toUri().buildUpon()
             .appendPath(id.toString())

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/shikimori/ShikimoriApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/shikimori/ShikimoriApi.kt
@@ -250,15 +250,21 @@ class ShikimoriApi(
         private const val CLIENT_ID = "SmkA50jJviGntLvJLsEwEVetogb0RnS35OgvFCQttpM"
         private const val CLIENT_SECRET = "lOFK6rLfV8Eu7cO0V9pMLIoC8X2f3BL11HVn-MRitvQ"
 
-        fun authUrl(): Uri = authUrlString().toUri()
+        fun authUrl(state: String? = null): Uri = authUrlString(state).toUri()
 
         @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-        internal fun authUrlString(): String = LOGIN_URL.toHttpUrl().newBuilder()
-            .addQueryParameter("client_id", CLIENT_ID)
-            .addQueryParameter("redirect_uri", REDIRECT_URL)
-            .addQueryParameter("response_type", "code")
-            .build()
-            .toString()
+        internal fun authUrlString(state: String? = null): String =
+            LOGIN_URL.toHttpUrl().newBuilder()
+                .addQueryParameter("client_id", CLIENT_ID)
+                .addQueryParameter("redirect_uri", REDIRECT_URL)
+                .addQueryParameter("response_type", "code")
+                .apply {
+                    if (state != null) {
+                        addQueryParameter("state", state)
+                    }
+                }
+                .build()
+                .toString()
 
         @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
         internal fun accessTokenRequest(code: String) = POST(

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/simkl/SimklApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/simkl/SimklApi.kt
@@ -21,6 +21,7 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
 import kotlinx.serialization.json.putJsonObject
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.RequestBody.Companion.toRequestBody
 import tachiyomi.core.common.util.lang.withIOContext
@@ -244,11 +245,19 @@ class SimklApi(private val client: OkHttpClient, interceptor: SimklInterceptor) 
 
         private const val REDIRECT_URL = "aniyomi://simkl-auth"
 
-        fun authUrl(): Uri =
-            LOGIN_URL.toUri().buildUpon()
-                .appendQueryParameter("response_type", "code")
-                .appendQueryParameter("client_id", CLIENT_ID)
-                .appendQueryParameter("redirect_uri", REDIRECT_URL)
+        fun authUrl(state: String? = null): Uri = authUrlString(state).toUri()
+
+        internal fun authUrlString(state: String? = null): String =
+            LOGIN_URL.toHttpUrl().newBuilder()
+                .addQueryParameter("response_type", "code")
+                .addQueryParameter("client_id", CLIENT_ID)
+                .addQueryParameter("redirect_uri", REDIRECT_URL)
+                .apply {
+                    if (state != null) {
+                        addQueryParameter("state", state)
+                    }
+                }
                 .build()
+                .toString()
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/track/TrackLoginActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/track/TrackLoginActivity.kt
@@ -2,83 +2,56 @@ package eu.kanade.tachiyomi.ui.setting.track
 
 import android.net.Uri
 import androidx.lifecycle.lifecycleScope
+import eu.kanade.domain.track.service.TrackPreferences
+import eu.kanade.domain.track.service.TrackerOAuthStateStore
 import tachiyomi.core.common.util.lang.launchIO
+import uy.kohesive.injekt.injectLazy
 
 class TrackLoginActivity : BaseOAuthLoginActivity() {
 
+    private val trackPreferences: TrackPreferences by injectLazy()
+    private val oauthStateStore by lazy { TrackerOAuthStateStore(trackPreferences) }
+
     override fun handleResult(data: Uri?) {
-        when (data?.host) {
-            "anilist-auth" -> handleAnilist(data)
-            "bangumi-auth" -> handleBangumi(data)
-            "myanimelist-auth" -> handleMyAnimeList(data)
-            "shikimori-auth" -> handleShikimori(data)
-            "simkl-auth" -> handleSimkl(data)
+        val callback = TrackerOAuthCallback.from(
+            host = data?.host,
+            queryParameters = data.queryParameters(),
+            fragment = data?.fragment,
+        )
+        when (val result = callback.validated(oauthStateStore::consume)) {
+            TrackerOAuthCallbackResult.InvalidState -> returnToSettings()
+            TrackerOAuthCallbackResult.ProviderDenied -> handleDenied(callback)
+            is TrackerOAuthCallbackResult.Login -> handleLogin(result)
         }
     }
 
-    private fun handleAnilist(data: Uri) {
-        val regex = "(?:access_token=)(.*?)(?:&)".toRegex()
-        val matchResult = regex.find(data.fragment.toString())
-        if (matchResult?.groups?.get(1) != null) {
-            lifecycleScope.launchIO {
-                trackerManager.aniList.login(matchResult.groups[1]!!.value)
-                returnToSettings()
+    private fun handleLogin(result: TrackerOAuthCallbackResult.Login) {
+        lifecycleScope.launchIO {
+            when (result.host) {
+                TrackerOAuthCallback.Anilist.HOST -> trackerManager.aniList.login(result.credential)
+                TrackerOAuthCallback.Bangumi.HOST -> trackerManager.bangumi.login(result.credential)
+                TrackerOAuthCallback.MyAnimeList.HOST -> trackerManager.myAnimeList.login(result.credential)
+                TrackerOAuthCallback.Shikimori.HOST -> trackerManager.shikimori.login(result.credential)
+                TrackerOAuthCallback.Simkl.HOST -> trackerManager.simkl.login(result.credential)
             }
-        } else {
-            trackerManager.aniList.logout()
             returnToSettings()
         }
     }
 
-    private fun handleBangumi(data: Uri) {
-        val code = data.getQueryParameter("code")
-        if (code != null) {
-            lifecycleScope.launchIO {
-                trackerManager.bangumi.login(code)
-                returnToSettings()
-            }
-        } else {
-            trackerManager.bangumi.logout()
-            returnToSettings()
+    private fun handleDenied(callback: TrackerOAuthCallback?) {
+        when (callback?.host) {
+            TrackerOAuthCallback.Anilist.HOST -> trackerManager.aniList.logout()
+            TrackerOAuthCallback.Bangumi.HOST -> trackerManager.bangumi.logout()
+            TrackerOAuthCallback.MyAnimeList.HOST -> trackerManager.myAnimeList.logout()
+            TrackerOAuthCallback.Shikimori.HOST -> trackerManager.shikimori.logout()
+            TrackerOAuthCallback.Simkl.HOST -> trackerManager.simkl.logout()
         }
+        returnToSettings()
     }
 
-    private fun handleMyAnimeList(data: Uri) {
-        val code = data.getQueryParameter("code")
-        if (code != null) {
-            lifecycleScope.launchIO {
-                trackerManager.myAnimeList.login(code)
-                returnToSettings()
-            }
-        } else {
-            trackerManager.myAnimeList.logout()
-            returnToSettings()
-        }
-    }
-
-    private fun handleShikimori(data: Uri) {
-        val code = data.getQueryParameter("code")
-        if (code != null) {
-            lifecycleScope.launchIO {
-                trackerManager.shikimori.login(code)
-                returnToSettings()
-            }
-        } else {
-            trackerManager.shikimori.logout()
-            returnToSettings()
-        }
-    }
-
-    private fun handleSimkl(data: Uri?) {
-        val code = data?.getQueryParameter("code")
-        if (code != null) {
-            lifecycleScope.launchIO {
-                trackerManager.simkl.login(code)
-                returnToSettings()
-            }
-        } else {
-            trackerManager.simkl.logout()
-            returnToSettings()
-        }
+    private fun Uri?.queryParameters(): Map<String, String?> {
+        return this?.queryParameterNames
+            ?.associateWith(::getQueryParameter)
+            ?: emptyMap()
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/track/TrackerOAuthCallback.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/track/TrackerOAuthCallback.kt
@@ -1,0 +1,165 @@
+package eu.kanade.tachiyomi.ui.setting.track
+
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
+
+sealed interface TrackerOAuthCallback {
+    val host: String
+    val credential: String?
+    val state: String?
+
+    data class Anilist(
+        val accessToken: String?,
+        override val state: String?,
+    ) : TrackerOAuthCallback {
+        override val credential: String?
+            get() = accessToken
+
+        override val host: String = HOST
+
+        companion object {
+            const val HOST = "anilist-auth"
+        }
+    }
+
+    data class Bangumi(
+        val code: String?,
+        override val state: String?,
+    ) : TrackerOAuthCallback {
+        override val credential: String?
+            get() = code
+
+        override val host: String = HOST
+
+        companion object {
+            const val HOST = "bangumi-auth"
+        }
+    }
+
+    data class MyAnimeList(
+        val code: String?,
+        override val state: String?,
+    ) : TrackerOAuthCallback {
+        override val credential: String?
+            get() = code
+
+        override val host: String = HOST
+
+        companion object {
+            const val HOST = "myanimelist-auth"
+        }
+    }
+
+    data class Shikimori(
+        val code: String?,
+        override val state: String?,
+    ) : TrackerOAuthCallback {
+        override val credential: String?
+            get() = code
+
+        override val host: String = HOST
+
+        companion object {
+            const val HOST = "shikimori-auth"
+        }
+    }
+
+    data class Simkl(
+        val code: String?,
+        override val state: String?,
+    ) : TrackerOAuthCallback {
+        override val credential: String?
+            get() = code
+
+        override val host: String = HOST
+
+        companion object {
+            const val HOST = "simkl-auth"
+        }
+    }
+
+    companion object {
+        fun from(
+            host: String?,
+            queryParameters: Map<String, String?>,
+            fragment: String?,
+        ): TrackerOAuthCallback? {
+            val fragmentParameters = fragmentParameters(fragment)
+            return when (host) {
+                Anilist.HOST -> Anilist(
+                    accessToken = fragmentParameters["access_token"],
+                    state = fragmentParameters["state"],
+                )
+                Bangumi.HOST -> Bangumi(
+                    code = queryParameters["code"],
+                    state = queryParameters["state"],
+                )
+                MyAnimeList.HOST -> MyAnimeList(
+                    code = queryParameters["code"],
+                    state = queryParameters["state"],
+                )
+                Shikimori.HOST -> Shikimori(
+                    code = queryParameters["code"],
+                    state = queryParameters["state"],
+                )
+                Simkl.HOST -> Simkl(
+                    code = queryParameters["code"],
+                    state = queryParameters["state"],
+                )
+                else -> null
+            }
+        }
+
+        private fun fragmentParameters(fragment: String?): Map<String, String> {
+            if (fragment.isNullOrBlank()) return emptyMap()
+
+            return fragment.split("&")
+                .mapNotNull { parameter ->
+                    val separator = parameter.indexOf("=")
+                    if (separator <= 0) return@mapNotNull null
+
+                    val key = parameter.substring(0, separator).decodeUrlParameter()
+                    val value = parameter.substring(separator + 1).decodeUrlParameter()
+                    key to value
+                }
+                .toMap()
+        }
+
+        private fun String.decodeUrlParameter(): String {
+            return URLDecoder.decode(this, StandardCharsets.UTF_8.name())
+        }
+    }
+}
+
+sealed interface TrackerOAuthCallbackResult {
+    data class Login(
+        val host: String,
+        val credential: String,
+    ) : TrackerOAuthCallbackResult
+
+    data object ProviderDenied : TrackerOAuthCallbackResult
+
+    data object InvalidState : TrackerOAuthCallbackResult
+}
+
+fun TrackerOAuthCallback?.validated(
+    consumeState: (host: String, state: String?) -> Boolean,
+): TrackerOAuthCallbackResult {
+    val callback = this ?: return TrackerOAuthCallbackResult.InvalidState
+    if (callback.state.isNullOrBlank()) {
+        return TrackerOAuthCallbackResult.InvalidState
+    }
+    if (!consumeState(callback.host, callback.state)) {
+        return TrackerOAuthCallbackResult.InvalidState
+    }
+
+    val credential = callback.credential
+    return if (credential.isNullOrBlank()) {
+        TrackerOAuthCallbackResult.ProviderDenied
+    } else {
+        TrackerOAuthCallbackResult.Login(
+            host = callback.host,
+            credential = credential,
+        )
+    }
+}

--- a/app/src/test/java/eu/kanade/domain/track/service/TrackerOAuthStateStoreTest.kt
+++ b/app/src/test/java/eu/kanade/domain/track/service/TrackerOAuthStateStoreTest.kt
@@ -1,0 +1,123 @@
+package eu.kanade.domain.track.service
+
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import org.junit.jupiter.api.Test
+import tachiyomi.core.common.preference.Preference
+import tachiyomi.core.common.preference.PreferenceStore
+
+class TrackerOAuthStateStoreTest {
+
+    @Test
+    fun `begin stores generated state by callback host`() {
+        val preferences = TrackPreferences(MutablePreferenceStore())
+        val store = TrackerOAuthStateStore(preferences) { "generated-state" }
+
+        store.begin("anilist-auth") shouldBe "generated-state"
+
+        preferences.trackOAuthState("anilist-auth").get() shouldBe "generated-state"
+    }
+
+    @Test
+    fun `consume accepts matching state once`() {
+        val preferences = TrackPreferences(MutablePreferenceStore())
+        val store = TrackerOAuthStateStore(preferences) { "generated-state" }
+        val state = store.begin("myanimelist-auth")
+
+        store.consume("myanimelist-auth", state).shouldBeTrue()
+        store.consume("myanimelist-auth", state).shouldBeFalse()
+    }
+
+    @Test
+    fun `consume rejects missing blank and mismatched state without clearing pending state`() {
+        val preferences = TrackPreferences(MutablePreferenceStore())
+        val store = TrackerOAuthStateStore(preferences) { "expected-state" }
+        store.begin("shikimori-auth")
+
+        store.consume("shikimori-auth", null).shouldBeFalse()
+        store.consume("shikimori-auth", "").shouldBeFalse()
+        store.consume("shikimori-auth", "wrong-state").shouldBeFalse()
+
+        preferences.trackOAuthState("shikimori-auth").get() shouldBe "expected-state"
+    }
+
+    @Test
+    fun `trackOAuthState uses app state key`() {
+        val preferences = TrackPreferences(MutablePreferenceStore())
+
+        preferences.trackOAuthState("simkl-auth").key() shouldBe "__APP_STATE_track_oauth_state_simkl-auth"
+    }
+
+    private class MutablePreferenceStore(initialValues: Map<String, Any?> = emptyMap()) : PreferenceStore {
+        private val data = initialValues.toMutableMap()
+
+        override fun getString(key: String, defaultValue: String): Preference<String> = MutablePreference(
+            key,
+            defaultValue,
+        )
+
+        override fun getLong(key: String, defaultValue: Long): Preference<Long> = MutablePreference(key, defaultValue)
+
+        override fun getInt(key: String, defaultValue: Int): Preference<Int> = MutablePreference(key, defaultValue)
+
+        override fun getFloat(key: String, defaultValue: Float): Preference<Float> = MutablePreference(
+            key,
+            defaultValue,
+        )
+
+        override fun getBoolean(key: String, defaultValue: Boolean): Preference<Boolean> = MutablePreference(
+            key,
+            defaultValue,
+        )
+
+        override fun getStringSet(key: String, defaultValue: Set<String>): Preference<Set<String>> =
+            MutablePreference(key, defaultValue)
+
+        override fun <T> getObject(
+            key: String,
+            defaultValue: T,
+            serializer: (T) -> String,
+            deserializer: (String) -> T,
+        ): Preference<T> = MutablePreference(key, defaultValue)
+
+        override fun getAll(): Map<String, *> = data
+
+        private inner class MutablePreference<T>(
+            private val key: String,
+            private val defaultValue: T,
+        ) : Preference<T> {
+            private val state = MutableStateFlow(get())
+
+            override fun key(): String = key
+
+            override fun get(): T {
+                @Suppress("UNCHECKED_CAST")
+                return (data[key] as T?) ?: defaultValue
+            }
+
+            override fun set(value: T) {
+                data[key] = value
+                state.value = value
+            }
+
+            override fun isSet(): Boolean = data.containsKey(key)
+
+            override fun delete() {
+                data.remove(key)
+                state.value = defaultValue
+            }
+
+            override fun defaultValue(): T = defaultValue
+
+            override fun changes(): Flow<T> = state.asStateFlow()
+
+            override fun stateIn(scope: CoroutineScope): StateFlow<T> = state.asStateFlow()
+        }
+    }
+}

--- a/app/src/test/java/eu/kanade/tachiyomi/data/track/TrackerOAuthAuthUrlTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/data/track/TrackerOAuthAuthUrlTest.kt
@@ -1,0 +1,49 @@
+package eu.kanade.tachiyomi.data.track
+
+import eu.kanade.tachiyomi.data.track.anilist.AnilistApi
+import eu.kanade.tachiyomi.data.track.bangumi.BangumiApi
+import eu.kanade.tachiyomi.data.track.myanimelist.MyAnimeListApi
+import eu.kanade.tachiyomi.data.track.shikimori.ShikimoriApi
+import eu.kanade.tachiyomi.data.track.simkl.SimklApi
+import io.kotest.matchers.shouldBe
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import org.junit.jupiter.api.Test
+
+class TrackerOAuthAuthUrlTest {
+
+    @Test
+    fun `anilist auth url includes state`() {
+        val url = AnilistApi.authUrlString("state-value").toHttpUrl()
+
+        url.queryParameter("state") shouldBe "state-value"
+    }
+
+    @Test
+    fun `myanimelist auth url includes state and preserves pkce`() {
+        val url = MyAnimeListApi.authUrlString("state-value").toHttpUrl()
+
+        url.queryParameter("state") shouldBe "state-value"
+        url.queryParameter("code_challenge").isNullOrBlank() shouldBe false
+    }
+
+    @Test
+    fun `bangumi auth url includes state`() {
+        val url = BangumiApi.authUrlString("state-value").toHttpUrl()
+
+        url.queryParameter("state") shouldBe "state-value"
+    }
+
+    @Test
+    fun `shikimori auth url includes state`() {
+        val url = ShikimoriApi.authUrlString("state-value").toHttpUrl()
+
+        url.queryParameter("state") shouldBe "state-value"
+    }
+
+    @Test
+    fun `simkl auth url includes state`() {
+        val url = SimklApi.authUrlString("state-value").toHttpUrl()
+
+        url.queryParameter("state") shouldBe "state-value"
+    }
+}

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/setting/track/TrackerOAuthCallbackTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/setting/track/TrackerOAuthCallbackTest.kt
@@ -1,0 +1,82 @@
+package eu.kanade.tachiyomi.ui.setting.track
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class TrackerOAuthCallbackTest {
+
+    @Test
+    fun `anilist callback reads token and state from fragment`() {
+        val callback = TrackerOAuthCallback.from(
+            host = "anilist-auth",
+            queryParameters = emptyMap(),
+            fragment = "access_token=token-value&token_type=Bearer&state=state-value",
+        )
+
+        callback shouldBe TrackerOAuthCallback.Anilist(
+            accessToken = "token-value",
+            state = "state-value",
+        )
+    }
+
+    @Test
+    fun `code callback reads code and state from query`() {
+        val callback = TrackerOAuthCallback.from(
+            host = "myanimelist-auth",
+            queryParameters = mapOf("code" to "auth-code", "state" to "state-value"),
+            fragment = null,
+        )
+
+        callback shouldBe TrackerOAuthCallback.MyAnimeList(
+            code = "auth-code",
+            state = "state-value",
+        )
+    }
+
+    @Test
+    fun `valid state with missing code is provider denial`() {
+        val result = TrackerOAuthCallback.from(
+            host = "bangumi-auth",
+            queryParameters = mapOf("state" to "state-value"),
+            fragment = null,
+        ).validated { host, state ->
+            host shouldBe "bangumi-auth"
+            state shouldBe "state-value"
+            true
+        }
+
+        result shouldBe TrackerOAuthCallbackResult.ProviderDenied
+    }
+
+    @Test
+    fun `missing or mismatched state is invalid before provider action`() {
+        val missingState = TrackerOAuthCallback.from(
+            host = "simkl-auth",
+            queryParameters = mapOf("code" to "auth-code"),
+            fragment = null,
+        ).validated { _, _ -> true }
+
+        val mismatchedState = TrackerOAuthCallback.from(
+            host = "shikimori-auth",
+            queryParameters = mapOf("code" to "auth-code", "state" to "wrong-state"),
+            fragment = null,
+        ).validated { _, _ -> false }
+
+        missingState shouldBe TrackerOAuthCallbackResult.InvalidState
+        mismatchedState shouldBe TrackerOAuthCallbackResult.InvalidState
+    }
+
+    @Test
+    fun `valid state with credential is login`() {
+        val result = TrackerOAuthCallback.from(
+            host = "shikimori-auth",
+            queryParameters = mapOf("code" to "auth-code", "state" to "state-value"),
+            fragment = null,
+        ).validated { _, _ -> true }
+
+        result shouldBe TrackerOAuthCallbackResult.Login(
+            host = "shikimori-auth",
+            credential = "auth-code",
+        )
+    }
+}


### PR DESCRIPTION
## Ticket
- ID: R685
- Priority: P1
- Risk Tier: T2
- GitHub Issue: Closes #767

## Objective
- Prevent exported tracker OAuth callbacks from accepting login results that are not tied to an app-started OAuth attempt.

## Scope
- Add a tracker OAuth state store with one-time consume semantics.
- Attach generated `state` values to AniList, Bangumi, MyAnimeList, Shikimori, and Simkl auth URLs.
- Validate callback `state` before provider login/logout handling.
- Preserve existing provider token/code exchange behavior, including MyAnimeList PKCE.

## Non-goals
- No tracker credential, redirect URI, or provider API migration changes.
- No real-provider browser OAuth login round trip.

## Files Changed
- Tracker OAuth URL builders and settings launch wiring.
- `TrackLoginActivity` callback validation path.
- Tracker preferences/state storage helpers.
- Focused unit tests, Android `Uri` instrumentation coverage, and changelog entry.

## Verification
- Commands run:
  - `./gradlew :app:testStableDebugUnitTest --tests 'eu.kanade.domain.track.service.TrackerOAuthStateStoreTest' --tests 'eu.kanade.tachiyomi.ui.setting.track.TrackerOAuthCallbackTest' --tests 'eu.kanade.tachiyomi.data.track.TrackerOAuthAuthUrlTest' --tests 'eu.kanade.tachiyomi.data.track.shikimori.ShikimoriApiTest'`\n  - `./gradlew :app:connectedStableDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=eu.kanade.tachiyomi.ui.setting.track.TrackerOAuthCallbackAndroidTest`\n  - `./gradlew spotlessCheck`\n  - `./gradlew :app:compileStableDebugKotlin`\n  - `git diff --check`\n  - Independent agent review\n- Results:\n  - Focused unit tests passed.\n  - Android emulator test passed: 4 tests on `R645_API36_PlayStore(AVD) - 16`.\n  - Spotless and stable debug Kotlin compile passed.\n  - Independent review found no issues.\n- Not tested:\n  - Real provider OAuth round trip in a browser with live provider credentials/account state.\n\n## Risk\n- Risk: tracker login could fail if a provider drops or rewrites `state`. Mitigation: all supported OAuth providers receive a standard query parameter and callbacks reject only when the returned state does not match the stored app-started attempt.\n- Risk: existing sessions could be cleared by invalid callbacks. Mitigation: invalid/missing/replayed state returns to settings before provider logout handling.\n\n## SLO Impact\n- No runtime SLO impact expected. State generation and preference reads/writes happen only during tracker OAuth login.\n\n## Rollback\n- Revert this PR to restore prior tracker OAuth callback behavior. Existing tracker tokens/sessions are not migrated by this change.\n\n## Release Notes\n- Tracker OAuth callbacks now require a matching one-time state token before accepting provider login results.\n\n## Checklist\n- [x] Naming conventions followed (use "Rayniyomi" in user-facing text; see [branding guardrail](../docs/branding-guardrail.md))\n- [x] Branch rebased on latest main and verification re-run\n- [x] New coroutine scopes have documented owner and cancellation path\n- [x] No new `runBlocking` on UI/main thread paths\n\n## Definition of Done (DoD)\n- [x] Acceptance criteria met and non-goals respected\n- [x] Verification matrix completed (Risk Tier: T2)\n- [x] Self-review completed\n- [x] Rebased on latest `main` and revalidated (mandatory for merge)\n- [ ] Sprint board updated (branch, commit, checks, PR link)\n- [x] Release notes drafted (if applicable)\n\n## Fork Compliance Checklist (for new forks only)\nIf you are creating a new fork of this project, ensure the following:\n- [ ] **App Identity**: Changed app name from "Aniyomi" to your fork name\n- [ ] **App Icon**: Replaced launcher icon assets with fork-specific icons\n- [ ] **Application ID**: Changed `applicationId` in `app/build.gradle.kts` from `xyz.rayniyomi` to your unique ID\n- [ ] **Update Checker**: Configured `AppUpdateChecker.kt` to point to your fork's repository\n- [ ] **Analytics**: Either disabled Firebase Analytics or configured with your own `google-services.json`\n- [ ] **Crash Reporting**: Either disabled ACRA crash reporting or configured with your own endpoint credentials\n\nSee [CONTRIBUTING.md](../CONTRIBUTING.md) Forks section for details.