### PR TITLE
fix: improve invalid extension diagnostics (R774)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Discover and entry-enrichment Compose screen state now uses explicit stability annotations, and discover feed items are stored as immutable collections at the UI-state boundary to reduce avoidable recompositions.
 
 ### Fixed
+- Invalid extension trust-revoked dialogs now show the failure reason, package, version, signature prefix, debug detail, and recovery guidance.
 - Exported search intents now ignore malformed search type extras instead of crashing, and anime custom search no longer routes through the manga deep-link activity.
 - Episode options now shows a stable error state instead of crashing when episode, anime, source, hoster, or video state is unavailable.
 - Player quality selection now ignores stale hoster/video taps instead of crashing when hoster state changes asynchronously.

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/anime/extension/AnimeExtensionsTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/anime/extension/AnimeExtensionsTab.kt
@@ -19,7 +19,10 @@ import eu.kanade.presentation.components.TabContent
 import eu.kanade.presentation.more.settings.screen.browse.AnimeExtensionReposScreen
 import eu.kanade.tachiyomi.extension.anime.model.AnimeExtension
 import eu.kanade.tachiyomi.extension.anime.model.AnimeLoadResult
+import eu.kanade.tachiyomi.extension.anime.model.InvalidReason
 import eu.kanade.tachiyomi.ui.browse.anime.extension.details.AnimeExtensionDetailsScreen
+import eu.kanade.tachiyomi.ui.browse.extension.InvalidExtensionDiagnostics
+import eu.kanade.tachiyomi.ui.browse.extension.InvalidExtensionDialogContent
 import eu.kanade.tachiyomi.ui.webview.WebViewScreen
 import eu.kanade.tachiyomi.util.system.isPackageInstalled
 import kotlinx.collections.immutable.persistentListOf
@@ -125,7 +128,7 @@ fun animeExtensionsTab(
 
             invalidExtensionToUninstall?.let { invalidExtension ->
                 AnimeInvalidExtensionConfirmation(
-                    extensionName = invalidExtension.name,
+                    extension = invalidExtension,
                     onClickConfirm = {
                         extensionsScreenModel.uninstallExtension(invalidExtension.pkgName)
                     },
@@ -172,16 +175,27 @@ private fun AnimeExtensionUninstallConfirmation(
 
 @Composable
 private fun AnimeInvalidExtensionConfirmation(
-    extensionName: String,
+    extension: AnimeLoadResult.Invalid,
     onClickConfirm: () -> Unit,
     onDismissRequest: () -> Unit,
 ) {
+    val diagnostics = InvalidExtensionDiagnostics.from(
+        pkgName = extension.pkgName,
+        versionName = extension.versionName,
+        versionCode = extension.versionCode,
+        signatureHash = extension.signatureHash,
+        debugDetail = extension.debugDetail,
+    )
     AlertDialog(
         title = {
             Text(text = stringResource(MR.strings.ext_invalid_extension_title))
         },
         text = {
-            Text(text = stringResource(MR.strings.ext_invalid_extension_message, extensionName))
+            InvalidExtensionDialogContent(
+                extensionName = extension.name,
+                reason = stringResource(extension.reason.labelRes),
+                diagnostics = diagnostics,
+            )
         },
         confirmButton = {
             TextButton(
@@ -201,3 +215,11 @@ private fun AnimeInvalidExtensionConfirmation(
         onDismissRequest = onDismissRequest,
     )
 }
+
+private val InvalidReason.labelRes
+    get() = when (this) {
+        InvalidReason.DENYLISTED -> MR.strings.ext_invalid_extension_reason_denylisted
+        InvalidReason.METADATA_INVALID -> MR.strings.ext_invalid_extension_reason_metadata
+        InvalidReason.SOURCE_FACTORY_THROW -> MR.strings.ext_invalid_extension_reason_source_factory
+        InvalidReason.SOURCE_ID_THROW -> MR.strings.ext_invalid_extension_reason_source_id
+    }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/InvalidExtensionDiagnostics.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/InvalidExtensionDiagnostics.kt
@@ -1,0 +1,35 @@
+package eu.kanade.tachiyomi.ui.browse.extension
+
+internal data class InvalidExtensionDiagnostics(
+    val pkgName: String,
+    val version: String,
+    val signatureHashDisplay: String,
+    val debugDetail: String?,
+) {
+    companion object {
+        private const val SIGNATURE_HASH_PREFIX_LENGTH = 12
+
+        fun from(
+            pkgName: String,
+            versionName: String,
+            versionCode: Long,
+            signatureHash: String,
+            debugDetail: String?,
+        ): InvalidExtensionDiagnostics {
+            return InvalidExtensionDiagnostics(
+                pkgName = pkgName,
+                version = "$versionName ($versionCode)",
+                signatureHashDisplay = signatureHash.toDisplayHash(),
+                debugDetail = debugDetail?.trim()?.takeIf { it.isNotEmpty() },
+            )
+        }
+
+        private fun String.toDisplayHash(): String {
+            return if (length > SIGNATURE_HASH_PREFIX_LENGTH) {
+                "${take(SIGNATURE_HASH_PREFIX_LENGTH)}..."
+            } else {
+                this
+            }
+        }
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/InvalidExtensionDialogContent.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/InvalidExtensionDialogContent.kt
@@ -1,0 +1,55 @@
+package eu.kanade.tachiyomi.ui.browse.extension
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import tachiyomi.i18n.MR
+import tachiyomi.presentation.core.i18n.stringResource
+
+@Composable
+internal fun InvalidExtensionDialogContent(
+    extensionName: String,
+    reason: String,
+    diagnostics: InvalidExtensionDiagnostics,
+) {
+    Column(
+        modifier = Modifier.verticalScroll(rememberScrollState()),
+    ) {
+        Text(text = stringResource(MR.strings.ext_invalid_extension_message, extensionName))
+        Spacer(modifier = Modifier.height(12.dp))
+        Text(
+            text = stringResource(MR.strings.ext_invalid_extension_reason, reason),
+            style = MaterialTheme.typography.bodyMedium,
+        )
+        Text(
+            text = stringResource(MR.strings.ext_invalid_extension_package, diagnostics.pkgName),
+            style = MaterialTheme.typography.bodyMedium,
+        )
+        Text(
+            text = stringResource(MR.strings.ext_invalid_extension_version, diagnostics.version),
+            style = MaterialTheme.typography.bodyMedium,
+        )
+        Text(
+            text = stringResource(
+                MR.strings.ext_invalid_extension_signature,
+                diagnostics.signatureHashDisplay,
+            ),
+            style = MaterialTheme.typography.bodyMedium,
+        )
+        diagnostics.debugDetail?.let {
+            Text(
+                text = stringResource(MR.strings.ext_invalid_extension_detail, it),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        }
+        Spacer(modifier = Modifier.height(12.dp))
+        Text(text = stringResource(MR.strings.ext_invalid_extension_recovery_hint))
+    }
+}

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/browse/manga/extension/MangaExtensionsTab.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/browse/manga/extension/MangaExtensionsTab.kt
@@ -17,8 +17,11 @@ import eu.kanade.presentation.browse.manga.MangaExtensionScreen
 import eu.kanade.presentation.components.AppBar
 import eu.kanade.presentation.components.TabContent
 import eu.kanade.presentation.more.settings.screen.browse.MangaExtensionReposScreen
+import eu.kanade.tachiyomi.extension.manga.model.InvalidReason
 import eu.kanade.tachiyomi.extension.manga.model.MangaExtension
 import eu.kanade.tachiyomi.extension.manga.model.MangaLoadResult
+import eu.kanade.tachiyomi.ui.browse.extension.InvalidExtensionDiagnostics
+import eu.kanade.tachiyomi.ui.browse.extension.InvalidExtensionDialogContent
 import eu.kanade.tachiyomi.ui.browse.manga.extension.details.MangaExtensionDetailsScreen
 import eu.kanade.tachiyomi.ui.webview.WebViewScreen
 import eu.kanade.tachiyomi.util.system.isPackageInstalled
@@ -116,7 +119,7 @@ fun mangaExtensionsTab(
 
             invalidExtensionToUninstall?.let { invalidExtension ->
                 MangaInvalidExtensionConfirmation(
-                    extensionName = invalidExtension.name,
+                    extension = invalidExtension,
                     onClickConfirm = {
                         extensionsScreenModel.uninstallExtension(invalidExtension.pkgName)
                     },
@@ -163,16 +166,27 @@ private fun MangaExtensionUninstallConfirmation(
 
 @Composable
 private fun MangaInvalidExtensionConfirmation(
-    extensionName: String,
+    extension: MangaLoadResult.Invalid,
     onClickConfirm: () -> Unit,
     onDismissRequest: () -> Unit,
 ) {
+    val diagnostics = InvalidExtensionDiagnostics.from(
+        pkgName = extension.pkgName,
+        versionName = extension.versionName,
+        versionCode = extension.versionCode,
+        signatureHash = extension.signatureHash,
+        debugDetail = extension.debugDetail,
+    )
     AlertDialog(
         title = {
             Text(text = stringResource(MR.strings.ext_invalid_extension_title))
         },
         text = {
-            Text(text = stringResource(MR.strings.ext_invalid_extension_message, extensionName))
+            InvalidExtensionDialogContent(
+                extensionName = extension.name,
+                reason = stringResource(extension.reason.labelRes),
+                diagnostics = diagnostics,
+            )
         },
         confirmButton = {
             TextButton(
@@ -192,3 +206,11 @@ private fun MangaInvalidExtensionConfirmation(
         onDismissRequest = onDismissRequest,
     )
 }
+
+private val InvalidReason.labelRes
+    get() = when (this) {
+        InvalidReason.DENYLISTED -> MR.strings.ext_invalid_extension_reason_denylisted
+        InvalidReason.METADATA_INVALID -> MR.strings.ext_invalid_extension_reason_metadata
+        InvalidReason.SOURCE_FACTORY_THROW -> MR.strings.ext_invalid_extension_reason_source_factory
+        InvalidReason.SOURCE_ID_THROW -> MR.strings.ext_invalid_extension_reason_source_id
+    }

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/browse/extension/InvalidExtensionDiagnosticsTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/browse/extension/InvalidExtensionDiagnosticsTest.kt
@@ -1,0 +1,42 @@
+package eu.kanade.tachiyomi.ui.browse.extension
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class InvalidExtensionDiagnosticsTest {
+
+    @Test
+    fun `diagnostics keep package version and truncate long signature hash`() {
+        val diagnostics = InvalidExtensionDiagnostics.from(
+            pkgName = "eu.kanade.tachiyomi.animeextension.en.allanime",
+            versionName = "14.55",
+            versionCode = 55L,
+            signatureHash = "cbec121aa82ebb02aaa73806992e0368a97d47b5451ed6524816d03084c45905",
+            debugDetail = "eu.kanade.tachiyomi.animeextension.en.allanime.AllAnime",
+        )
+
+        assertEquals("eu.kanade.tachiyomi.animeextension.en.allanime", diagnostics.pkgName)
+        assertEquals("14.55 (55)", diagnostics.version)
+        assertEquals("cbec121aa82e...", diagnostics.signatureHashDisplay)
+        assertEquals(
+            "eu.kanade.tachiyomi.animeextension.en.allanime.AllAnime",
+            diagnostics.debugDetail,
+        )
+    }
+
+    @Test
+    fun `diagnostics omit blank debug detail and keep short signature hash without ellipsis`() {
+        val diagnostics = InvalidExtensionDiagnostics.from(
+            pkgName = "com.example.bad",
+            versionName = "1.0",
+            versionCode = 1L,
+            signatureHash = "hash-z",
+            debugDetail = "  ",
+        )
+
+        assertEquals("1.0 (1)", diagnostics.version)
+        assertEquals("hash-z", diagnostics.signatureHashDisplay)
+        assertNull(diagnostics.debugDetail)
+    }
+}

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -391,6 +391,16 @@
     <string name="ext_confirm_remove">Remove Extension?</string>
     <string name="ext_invalid_extension_title">Invalid extension</string>
     <string name="ext_invalid_extension_message">"%1$s" was loaded with invalid source data. Trust was revoked to prevent crashes. You can remove it now.</string>
+    <string name="ext_invalid_extension_reason">Reason: %1$s</string>
+    <string name="ext_invalid_extension_reason_denylisted">Previously marked invalid</string>
+    <string name="ext_invalid_extension_reason_metadata">Missing or invalid source metadata</string>
+    <string name="ext_invalid_extension_reason_source_factory">Source factory failed to load</string>
+    <string name="ext_invalid_extension_reason_source_id">Source identity failed to load</string>
+    <string name="ext_invalid_extension_package">Package: %1$s</string>
+    <string name="ext_invalid_extension_version">Version: %1$s</string>
+    <string name="ext_invalid_extension_signature">Signature: %1$s</string>
+    <string name="ext_invalid_extension_detail">Detail: %1$s</string>
+    <string name="ext_invalid_extension_recovery_hint">Uninstalling clears the invalid trust entry. If this keeps happening, remove stale or duplicate extension repos before reinstalling.</string>
     <string name="ext_app_info">App info</string>
     <string name="untrusted_extension">Untrusted extension</string>
     <string name="untrusted_extension_message">Malicious extensions can read any stored login credentials or execute arbitrary code.\n\nBy trusting this extension, you accept these risks.</string>


### PR DESCRIPTION
## Ticket
- ID: R774
- Priority: P1
- Risk Tier: T2
- GitHub Issue: Closes #774

## Objective
- Make invalid extension trust-revoked dialogs actionable without requiring adb/logcat by showing the loader's existing failure metadata.

## Scope
- Show invalid extension reason, package name, version code/name, signature display value, optional debug detail, and recovery guidance in anime and manga invalid-extension dialogs.
- Add a shared diagnostic formatter and shared Compose dialog body for the invalid-extension detail block.
- Keep the loader trust/revoke behavior unchanged.
- Add focused unit coverage for diagnostic formatting, including long and short signature values.
- Add a changelog entry for the user-facing diagnostic improvement.

## Non-goals
- Does not change extension installation, source loading, trust, or denylist semantics.
- Does not validate extension repo reachability or alter duplicate repo candidate selection.
- Does not add screenshot/UI instrumentation coverage for the dialog.

## Files Changed
- `app/src/main/java/eu/kanade/tachiyomi/ui/browse/anime/extension/AnimeExtensionsTab.kt`
- `app/src/main/java/eu/kanade/tachiyomi/ui/browse/manga/extension/MangaExtensionsTab.kt`
- `app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/InvalidExtensionDiagnostics.kt`
- `app/src/main/java/eu/kanade/tachiyomi/ui/browse/extension/InvalidExtensionDialogContent.kt`
- `app/src/test/java/eu/kanade/tachiyomi/ui/browse/extension/InvalidExtensionDiagnosticsTest.kt`
- `i18n/src/commonMain/moko-resources/base/strings.xml`
- `CHANGELOG.md`

## Verification
- Commands run:
  - `./gradlew :app:testStableDebugUnitTest --tests "eu.kanade.tachiyomi.ui.browse.extension.InvalidExtensionDiagnosticsTest"` initially failed before implementation with unresolved `InvalidExtensionDiagnostics`.
  - `./gradlew :app:testStableDebugUnitTest --tests "eu.kanade.tachiyomi.ui.browse.extension.InvalidExtensionDiagnosticsTest"` failed before the signature-display fix with unresolved `signatureHashDisplay`.
  - `./gradlew :app:testStableDebugUnitTest --tests "eu.kanade.tachiyomi.ui.browse.anime.extension.AnimeExtensionsScreenModelTest" --tests "eu.kanade.tachiyomi.ui.browse.manga.extension.MangaExtensionsScreenModelTest" --tests "eu.kanade.tachiyomi.ui.browse.extension.InvalidExtensionDiagnosticsTest"`
  - `git diff --check`
  - `./gradlew spotlessCheck`
  - `./gradlew :app:compileStableDebugKotlin`
  - `git push -u origin codex/r774-invalid-extension-diagnostics` pre-push hook reran `spotlessCheck` and `:app:compileStableDebugKotlin` successfully.
- Results:
  - Focused tests passed.
  - Whitespace check passed.
  - Spotless passed.
  - Stable debug Kotlin compile passed.
  - Independent review completed and saved under `.local/review-notes/r774-invalid-extension-diagnostics.md`.
- Not tested:
  - No emulator screenshot/UI assertion for long package/debug-detail dialog text.

## Risk
- Dialog now contains more text, so small screens could be cramped. Mitigation: the shared dialog content is vertically scrollable.
- Diagnostic strings expose package/signature/debug metadata already available in loader state. Signature display is truncated for normal hashes and does not add a fake ellipsis for short/nonstandard values.
- Loader trust/revoke behavior is unchanged, limiting behavioral risk to presentation.

## SLO Impact
- No runtime SLO impact expected. This only changes UI text shown after an invalid extension load event.

## Rollback
- Revert this PR to restore the previous generic invalid-extension dialog. Existing trust/denylist data remains compatible because no storage or loader semantics changed.

## Release Notes
- Invalid extension trust-revoked dialogs now show the failure reason, package, version, signature display value, optional debug detail, and recovery guidance.

## Checklist
- [x] Naming conventions followed (use "Rayniyomi" in user-facing text; see [branding guardrail](../docs/branding-guardrail.md))
- [x] Branch rebased on latest main and verification re-run
- [x] New coroutine scopes have documented owner and cancellation path
- [x] No new `runBlocking` on UI/main thread paths

## Definition of Done (DoD)
- [x] Acceptance criteria met and non-goals respected
- [x] Verification matrix completed (Risk Tier: T2)
- [x] Self-review completed
- [x] Rebased on latest `main` and revalidated (mandatory for merge)
- [x] Sprint board updated (branch, commit, checks, PR link)
- [x] Release notes drafted (if applicable)

## Fork Compliance Checklist (for new forks only)
If you are creating a new fork of this project, ensure the following:
- [ ] **App Identity**: Changed app name from "Aniyomi" to your fork name
- [ ] **App Icon**: Replaced launcher icon assets with fork-specific icons
- [ ] **Application ID**: Changed `applicationId` in `app/build.gradle.kts` from `xyz.rayniyomi` to your unique ID
- [ ] **Update Checker**: Configured `AppUpdateChecker.kt` to point to your fork's repository
- [ ] **Analytics**: Either disabled Firebase Analytics or configured with your own `google-services.json`
- [ ] **Crash Reporting**: Either disabled ACRA crash reporting or configured with your own endpoint credentials

See [CONTRIBUTING.md](../CONTRIBUTING.md) Forks section for details.

