### PR TITLE
fix: secure translation API key storage (R684)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Discover and entry-enrichment Compose screen state now uses explicit stability annotations, and discover feed items are stored as immutable collections at the UI-state boundary to reduce avoidable recompositions.
 
 ### Fixed
+- Translation provider API keys now migrate from plaintext preferences into encrypted secure preferences while preserving existing empty-key behavior.
 - Invalid extension trust-revoked dialogs now show the failure reason, package, version, signature prefix, debug detail, and recovery guidance.
 - Tracker OAuth callbacks now require a matching one-time state token before accepting provider login results.
 - Library display mode persistence now uses stable keys with a safe fallback for stale values, keeping display mode global while avoiding library render crashes.

--- a/app/src/main/java/eu/kanade/tachiyomi/App.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/App.kt
@@ -55,6 +55,7 @@ import eu.kanade.tachiyomi.network.NetworkPreferences
 import eu.kanade.tachiyomi.security.PinHashMigration
 import eu.kanade.tachiyomi.security.RayniyomiSecurePrefs
 import eu.kanade.tachiyomi.security.TrackerTokenMigration
+import eu.kanade.tachiyomi.security.TranslationApiKeyMigration
 import eu.kanade.tachiyomi.ui.base.delegate.SecureActivityDelegate
 import eu.kanade.tachiyomi.util.system.DeviceUtil
 import eu.kanade.tachiyomi.util.system.GLUtil
@@ -146,6 +147,7 @@ class App : Application(), DefaultLifecycleObserver, SingletonImageLoader.Factor
         val defaultPrefs = PreferenceManager.getDefaultSharedPreferences(this)
         PinHashMigration.migrate(defaultPrefs)
         TrackerTokenMigration.migrate(defaultPrefs)
+        TranslationApiKeyMigration.migrate(defaultPrefs)
 
         patchInjekt()
 

--- a/app/src/main/java/eu/kanade/tachiyomi/di/PreferenceModule.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/di/PreferenceModule.kt
@@ -93,7 +93,7 @@ class PreferenceModule(val app: Application) : InjektModule {
             BasePreferences(app, get())
         }
         addSingletonFactory {
-            TranslationPreferences(get())
+            TranslationPreferences(SecurePreferenceStore(get()))
         }
         addSingletonFactory {
             NovelFeaturePreferences(get())

--- a/app/src/main/java/eu/kanade/tachiyomi/security/RayniyomiSecurePrefs.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/security/RayniyomiSecurePrefs.kt
@@ -5,7 +5,8 @@ import androidx.annotation.VisibleForTesting
 
 /**
  * Singleton for managing sensitive data in encrypted storage.
- * Stores PIN hash/salt and rayniyomi-specific tracker API tokens using
+ * Stores PIN hash/salt, rayniyomi-specific tracker API tokens, and translation
+ * provider API keys using
  * Android Keystore AES-256-GCM encryption via [KeystoreSecureStorage].
  *
  * Usage:
@@ -17,6 +18,7 @@ object RayniyomiSecurePrefs {
     private const val PIN_HASH_KEY = "pin_hash"
     private const val PIN_SALT_KEY = "pin_salt"
     private const val TRACKER_TOKEN_PREFIX = "track_token_"
+    private const val TRANSLATION_API_KEY = "translation_api_key"
 
     private lateinit var storage: SecureStorage
 
@@ -54,4 +56,9 @@ object RayniyomiSecurePrefs {
     /** Store or update a tracker API token. Pass null to clear. */
     fun setTrackerToken(trackerId: Long, token: String?) =
         storage.putString("$TRACKER_TOKEN_PREFIX$trackerId", token)
+
+    /** Translation provider API key. Returns null if not set. */
+    var translationApiKey: String?
+        get() = storage.getString(TRANSLATION_API_KEY)
+        set(value) = storage.putString(TRANSLATION_API_KEY, value)
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/security/SecurePreferenceStore.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/security/SecurePreferenceStore.kt
@@ -11,9 +11,11 @@ import tachiyomi.core.common.preference.PreferenceStore
  * Secure keys handled:
  * - `pin_hash` / `pin_salt` — PIN lock credentials
  * - `__PRIVATE_track_token_<id>` — rayniyomi tracker API tokens
+ * - `translation_api_key` — translation provider API key
  *
- * Used by [eu.kanade.tachiyomi.di.PreferenceModule] to construct [SecurityPreferences]
- * and [eu.kanade.domain.track.service.TrackPreferences] with encrypted backing.
+ * Used by [eu.kanade.tachiyomi.di.PreferenceModule] to construct [SecurityPreferences],
+ * [eu.kanade.domain.track.service.TrackPreferences], and
+ * [eu.kanade.tachiyomi.data.translation.TranslationPreferences] with encrypted backing.
  */
 class SecurePreferenceStore(
     private val delegate: PreferenceStore,
@@ -29,6 +31,11 @@ class SecurePreferenceStore(
             key = key,
             getter = { RayniyomiSecurePrefs.pinSalt },
             setter = { RayniyomiSecurePrefs.pinSalt = it },
+        )
+        key == TRANSLATION_API_KEY -> SecureStringPreference(
+            key = key,
+            getter = { RayniyomiSecurePrefs.translationApiKey },
+            setter = { RayniyomiSecurePrefs.translationApiKey = it },
         )
         key.startsWith(TRACKER_TOKEN_PREFIX) -> {
             val trackerId = key.removePrefix(TRACKER_TOKEN_PREFIX).toLongOrNull()
@@ -47,5 +54,6 @@ class SecurePreferenceStore(
 
     private companion object {
         const val TRACKER_TOKEN_PREFIX = "__PRIVATE_track_token_"
+        const val TRANSLATION_API_KEY = "translation_api_key"
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/security/TranslationApiKeyMigration.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/security/TranslationApiKeyMigration.kt
@@ -1,0 +1,29 @@
+package eu.kanade.tachiyomi.security
+
+import android.content.SharedPreferences
+
+/**
+ * Migrates the translation provider API key from plaintext SharedPreferences to
+ * [RayniyomiSecurePrefs].
+ *
+ * Idempotent: safe to call multiple times. If the secure store already has the
+ * key, it is not overwritten. The old plaintext key is deleted after migration.
+ */
+object TranslationApiKeyMigration {
+
+    private const val TRANSLATION_API_KEY = "translation_api_key"
+
+    fun migrate(plainPrefs: SharedPreferences) {
+        val plainApiKey = plainPrefs.getString(TRANSLATION_API_KEY, null)
+
+        if (plainApiKey.isNullOrEmpty()) return
+
+        if (RayniyomiSecurePrefs.translationApiKey.isNullOrEmpty()) {
+            RayniyomiSecurePrefs.translationApiKey = plainApiKey
+        }
+
+        plainPrefs.edit()
+            .remove(TRANSLATION_API_KEY)
+            .apply()
+    }
+}

--- a/app/src/test/java/eu/kanade/tachiyomi/data/translation/TranslationPreferencesIntegrationTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/data/translation/TranslationPreferencesIntegrationTest.kt
@@ -1,0 +1,66 @@
+package eu.kanade.tachiyomi.data.translation
+
+import eu.kanade.tachiyomi.security.InMemorySecureStorage
+import eu.kanade.tachiyomi.security.RayniyomiSecurePrefs
+import eu.kanade.tachiyomi.security.SecurePreferenceStore
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import tachiyomi.core.common.preference.InMemoryPreferenceStore
+
+class TranslationPreferencesIntegrationTest {
+
+    private lateinit var delegate: InMemoryPreferenceStore
+    private lateinit var translationPreferences: TranslationPreferences
+
+    @BeforeEach
+    fun setup() {
+        RayniyomiSecurePrefs.initForTesting(InMemorySecureStorage())
+
+        delegate = InMemoryPreferenceStore()
+        translationPreferences = TranslationPreferences(SecurePreferenceStore(delegate))
+    }
+
+    @Test
+    fun `translationApiKey get returns empty string when not set`() {
+        translationPreferences.translationApiKey().get() shouldBe ""
+    }
+
+    @Test
+    fun `translationApiKey set stores value in RayniyomiSecurePrefs`() {
+        translationPreferences.translationApiKey().set("provider-key")
+
+        RayniyomiSecurePrefs.translationApiKey shouldBe "provider-key"
+    }
+
+    @Test
+    fun `translationApiKey get reads from RayniyomiSecurePrefs`() {
+        RayniyomiSecurePrefs.translationApiKey = "stored-provider-key"
+
+        translationPreferences.translationApiKey().get() shouldBe "stored-provider-key"
+    }
+
+    @Test
+    fun `translationApiKey delete clears from RayniyomiSecurePrefs`() {
+        RayniyomiSecurePrefs.translationApiKey = "existing-provider-key"
+
+        translationPreferences.translationApiKey().delete()
+
+        RayniyomiSecurePrefs.translationApiKey shouldBe null
+    }
+
+    @Test
+    fun `translationApiKey key returns translation_api_key`() {
+        translationPreferences.translationApiKey().key() shouldBe "translation_api_key"
+    }
+
+    @Test
+    fun `targetLanguage still uses delegate store`() {
+        val targetLanguage = translationPreferences.targetLanguage()
+
+        targetLanguage.set("ja")
+
+        targetLanguage.get() shouldBe "ja"
+        RayniyomiSecurePrefs.translationApiKey shouldBe null
+    }
+}

--- a/app/src/test/java/eu/kanade/tachiyomi/security/RayniyomiSecurePrefsTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/security/RayniyomiSecurePrefsTest.kt
@@ -191,6 +191,29 @@ class RayniyomiSecurePrefsTest {
         RayniyomiSecurePrefs.getTrackerToken(3L).shouldBeNull()
     }
 
+    // Translation API key tests
+
+    @Test
+    fun `stores and retrieves translation api key successfully`() {
+        RayniyomiSecurePrefs.translationApiKey = "translation-provider-key"
+
+        RayniyomiSecurePrefs.translationApiKey shouldBe "translation-provider-key"
+    }
+
+    @Test
+    fun `returns null translation api key when not set`() {
+        RayniyomiSecurePrefs.translationApiKey.shouldBeNull()
+    }
+
+    @Test
+    fun `clears translation api key when set to null`() {
+        RayniyomiSecurePrefs.translationApiKey = "translation-provider-key"
+
+        RayniyomiSecurePrefs.translationApiKey = null
+
+        RayniyomiSecurePrefs.translationApiKey.shouldBeNull()
+    }
+
     // Storage isolation (key name verification)
 
     @Test
@@ -209,6 +232,12 @@ class RayniyomiSecurePrefsTest {
     fun `tracker tokens use prefixed keys in storage`() {
         RayniyomiSecurePrefs.setTrackerToken(99L, "tokenValue")
         storage.getString("track_token_99") shouldBe "tokenValue"
+    }
+
+    @Test
+    fun `translation api key uses correct key in storage`() {
+        RayniyomiSecurePrefs.translationApiKey = "translation-provider-key"
+        storage.getString("translation_api_key") shouldBe "translation-provider-key"
     }
 
     @Test

--- a/app/src/test/java/eu/kanade/tachiyomi/security/TranslationApiKeyMigrationTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/security/TranslationApiKeyMigrationTest.kt
@@ -1,0 +1,107 @@
+package eu.kanade.tachiyomi.security
+
+import android.content.SharedPreferences
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class TranslationApiKeyMigrationTest {
+
+    private lateinit var mockEditor: SharedPreferences.Editor
+    private lateinit var mockPrefs: SharedPreferences
+
+    @BeforeEach
+    fun setup() {
+        RayniyomiSecurePrefs.initForTesting(InMemorySecureStorage())
+
+        mockEditor = mockk(relaxed = true)
+        every { mockEditor.remove(any()) } returns mockEditor
+        mockPrefs = mockk()
+        every { mockPrefs.edit() } returns mockEditor
+    }
+
+    @Test
+    fun `migrates translation api key from plaintext to secure store`() {
+        every { mockPrefs.getString("translation_api_key", null) } returns "plain-provider-key"
+
+        TranslationApiKeyMigration.migrate(mockPrefs)
+
+        RayniyomiSecurePrefs.translationApiKey shouldBe "plain-provider-key"
+    }
+
+    @Test
+    fun `deletes old plaintext key after migration`() {
+        every { mockPrefs.getString("translation_api_key", null) } returns "plain-provider-key"
+
+        TranslationApiKeyMigration.migrate(mockPrefs)
+
+        verify { mockEditor.remove("translation_api_key") }
+        verify { mockEditor.apply() }
+    }
+
+    @Test
+    fun `skips migration when no plaintext api key exists`() {
+        every { mockPrefs.getString("translation_api_key", null) } returns null
+
+        TranslationApiKeyMigration.migrate(mockPrefs)
+
+        RayniyomiSecurePrefs.translationApiKey.shouldBeNull()
+        verify(exactly = 0) { mockEditor.apply() }
+    }
+
+    @Test
+    fun `skips migration when plaintext api key is empty string`() {
+        every { mockPrefs.getString("translation_api_key", null) } returns ""
+
+        TranslationApiKeyMigration.migrate(mockPrefs)
+
+        RayniyomiSecurePrefs.translationApiKey.shouldBeNull()
+        verify(exactly = 0) { mockEditor.apply() }
+    }
+
+    @Test
+    fun `does not overwrite secure store when already migrated`() {
+        RayniyomiSecurePrefs.translationApiKey = "already-secure-key"
+        every { mockPrefs.getString("translation_api_key", null) } returns "old-plain-key"
+
+        TranslationApiKeyMigration.migrate(mockPrefs)
+
+        RayniyomiSecurePrefs.translationApiKey shouldBe "already-secure-key"
+    }
+
+    @Test
+    fun `overwrites empty secure store with plaintext api key`() {
+        RayniyomiSecurePrefs.translationApiKey = ""
+        every { mockPrefs.getString("translation_api_key", null) } returns "plain-provider-key"
+
+        TranslationApiKeyMigration.migrate(mockPrefs)
+
+        RayniyomiSecurePrefs.translationApiKey shouldBe "plain-provider-key"
+    }
+
+    @Test
+    fun `cleans up plaintext key even when secure store already has value`() {
+        RayniyomiSecurePrefs.translationApiKey = "already-secure-key"
+        every { mockPrefs.getString("translation_api_key", null) } returns "old-plain-key"
+
+        TranslationApiKeyMigration.migrate(mockPrefs)
+
+        verify { mockEditor.remove("translation_api_key") }
+        verify { mockEditor.apply() }
+    }
+
+    @Test
+    fun `safe to call multiple times without data loss`() {
+        every { mockPrefs.getString("translation_api_key", null) } returns "plain-provider-key"
+
+        TranslationApiKeyMigration.migrate(mockPrefs)
+        every { mockPrefs.getString("translation_api_key", null) } returns null
+        TranslationApiKeyMigration.migrate(mockPrefs)
+
+        RayniyomiSecurePrefs.translationApiKey shouldBe "plain-provider-key"
+    }
+}


### PR DESCRIPTION
## Ticket
- ID: R684
- Priority: P1
- Risk Tier: T1
- GitHub Issue: Closes #765

## Objective
- Move the translation provider API key out of plaintext preferences and into the existing encrypted secure preferences path.

## Scope
- Route `translation_api_key` through `SecurePreferenceStore`.
- Add a `RayniyomiSecurePrefs.translationApiKey` secure accessor.
- Migrate existing non-empty plaintext API keys into secure storage during app startup.
- Remove the old plaintext key after a successful migration.
- Keep provider/model/target-language translation prefs in the normal preference store.
- Add focused tests for secure set/get/delete behavior and migration behavior.

## Non-goals
- No translation engine rewrite.
- No provider/model/target-language storage changes.
- No broader AI/privacy settings redesign.

## Files Changed
- `TranslationPreferences` DI wiring now uses `SecurePreferenceStore`.
- Secure prefs now know the `translation_api_key` key.
- App startup now runs `TranslationApiKeyMigration`.
- Focused tests cover translation preference routing, secure storage accessors, and plaintext migration.
- Changelog documents the security-visible storage migration.

## Verification
- Commands run:
  - `./gradlew :app:testStableDebugUnitTest --tests 'eu.kanade.tachiyomi.data.translation.TranslationPreferencesIntegrationTest' --tests 'eu.kanade.tachiyomi.security.TranslationApiKeyMigrationTest' --tests 'eu.kanade.tachiyomi.security.RayniyomiSecurePrefsTest'`
  - `./gradlew spotlessCheck`
  - `./gradlew :app:compileStableDebugKotlin`
  - `git diff --check`
- Results:
  - All passed locally.
- Not tested:
  - Full app manual translation-provider login/request flow; this ticket only changes persisted key storage and migration.

## Risk
- Low. The public `Preference<String>` contract remains the same for callers.
- Migration only copies non-empty plaintext keys and does not overwrite an existing non-empty secure key.
- Plaintext cleanup runs after secure migration/write path.

## SLO Impact
- No expected runtime SLO impact. Startup adds one small idempotent preference migration check.

## Rollback
- Revert this PR to restore plaintext preference storage and remove the startup migration.

## Release Notes
- Translation provider API keys now migrate from plaintext preferences into encrypted secure preferences while preserving existing empty-key behavior.

## Checklist
- [x] Naming conventions followed (use "Rayniyomi" in user-facing text; see [branding guardrail](../docs/branding-guardrail.md))
- [x] Branch rebased on latest main and verification re-run
- [x] New coroutine scopes have documented owner and cancellation path
- [x] No new `runBlocking` on UI/main thread paths

## Definition of Done (DoD)
- [x] Acceptance criteria met and non-goals respected
- [x] Verification matrix completed (Risk Tier: T1)
- [x] Self-review completed
- [ ] Rebased on latest `main` and revalidated (mandatory for merge)
- [ ] Sprint board updated (branch, commit, checks, PR link)
- [x] Release notes drafted (if applicable)

## Fork Compliance Checklist (for new forks only)
If you are creating a new fork of this project, ensure the following:
- [ ] **App Identity**: Changed app name from "Aniyomi" to your fork name
- [ ] **App Icon**: Replaced launcher icon assets with fork-specific icons
- [ ] **Application ID**: Changed `applicationId` in `app/build.gradle.kts` from `xyz.rayniyomi` to your unique ID
- [ ] **Update Checker**: Configured `AppUpdateChecker.kt` to point to your fork's repository
- [ ] **Analytics**: Either disabled Firebase Analytics or configured with your own `google-services.json`
- [ ] **Crash Reporting**: Either disabled ACRA crash reporting or configured with your own endpoint credentials

See [CONTRIBUTING.md](../CONTRIBUTING.md) Forks section for details.
