### PR TITLE
fix: use lifecycle-aware reader player collection (R677)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Discover and entry-enrichment Compose screen state now uses explicit stability annotations, and discover feed items are stored as immutable collections at the UI-state boundary to reduce avoidable recompositions.
 
 ### Fixed
+- Reader and player gesture UI now use lifecycle-aware flow collection so inactive screens stop collecting targeted state updates.
 - Translation provider API keys now migrate from plaintext preferences into encrypted secure preferences while preserving existing empty-key behavior.
 - Invalid extension trust-revoked dialogs now show the failure reason, package, version, signature prefix, debug detail, and recovery guidance.
 - Tracker OAuth callbacks now require a matching one-time state token before accepting provider login results.

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/GestureHandler.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/GestureHandler.kt
@@ -40,7 +40,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -54,6 +53,7 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import eu.kanade.presentation.player.components.LeftSideOvalShape
 import eu.kanade.presentation.player.components.RightSideOvalShape
 import eu.kanade.presentation.theme.playerRippleConfiguration
@@ -69,7 +69,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.update
 import tachiyomi.i18n.aniyomi.AYMR
 import tachiyomi.presentation.core.i18n.pluralStringResource
-import tachiyomi.presentation.core.util.collectAsState
+import tachiyomi.presentation.core.util.collectAsStateWithLifecycle
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import kotlin.math.roundToInt
@@ -86,14 +86,14 @@ fun GestureHandler(
     val gesturePreferences = remember { Injekt.get<GesturePreferences>() }
     val audioPreferences = remember { Injekt.get<AudioPreferences>() }
 
-    val panelShown by viewModel.panelShown.collectAsState()
-    val allowGesturesInPanels by playerPreferences.allowGestures().collectAsState()
-    val duration by viewModel.duration.collectAsState()
-    val position by viewModel.pos.collectAsState()
-    val controlsShown by viewModel.controlsShown.collectAsState()
-    val areControlsLocked by viewModel.areControlsLocked.collectAsState()
-    val seekAmount by viewModel.doubleTapSeekAmount.collectAsState()
-    val isSeekingForwards by viewModel.isSeekingForwards.collectAsState()
+    val panelShown by viewModel.panelShown.collectAsStateWithLifecycle()
+    val allowGesturesInPanels by playerPreferences.allowGestures().collectAsStateWithLifecycle()
+    val duration by viewModel.duration.collectAsStateWithLifecycle()
+    val position by viewModel.pos.collectAsStateWithLifecycle()
+    val controlsShown by viewModel.controlsShown.collectAsStateWithLifecycle()
+    val areControlsLocked by viewModel.areControlsLocked.collectAsStateWithLifecycle()
+    val seekAmount by viewModel.doubleTapSeekAmount.collectAsStateWithLifecycle()
+    val isSeekingForwards by viewModel.isSeekingForwards.collectAsStateWithLifecycle()
     var isDoubleTapSeeking by remember { mutableStateOf(false) }
 
     LaunchedEffect(seekAmount) {
@@ -106,10 +106,10 @@ fun GestureHandler(
     }
 
     val gestureVolumeBrightness = gesturePreferences.gestureVolumeBrightness().get()
-    val swapVolumeBrightness by gesturePreferences.swapVolumeBrightness().collectAsState()
-    val seekGesture by gesturePreferences.gestureHorizontalSeek().collectAsState()
-    val preciseSeeking by gesturePreferences.playerSmoothSeek().collectAsState()
-    val showSeekbar by gesturePreferences.showSeekBar().collectAsState()
+    val swapVolumeBrightness by gesturePreferences.swapVolumeBrightness().collectAsStateWithLifecycle()
+    val seekGesture by gesturePreferences.gestureHorizontalSeek().collectAsStateWithLifecycle()
+    val preciseSeeking by gesturePreferences.playerSmoothSeek().collectAsStateWithLifecycle()
+    val showSeekbar by gesturePreferences.showSeekBar().collectAsStateWithLifecycle()
     var isLongPressing by remember { mutableStateOf(false) }
     var speedBeforeBoost by remember { mutableStateOf(1.0f) }
 
@@ -121,9 +121,9 @@ fun GestureHandler(
             }
         }
     }
-    val currentVolume by viewModel.currentVolume.collectAsState()
-    val currentMPVVolume by viewModel.currentMPVVolume.collectAsState()
-    val currentBrightness by viewModel.currentBrightness.collectAsState()
+    val currentVolume by viewModel.currentVolume.collectAsStateWithLifecycle()
+    val currentMPVVolume by viewModel.currentMPVVolume.collectAsStateWithLifecycle()
+    val currentBrightness by viewModel.currentBrightness.collectAsStateWithLifecycle()
     val volumeBoostingCap = audioPreferences.volumeBoostCap().get()
     val haptics = LocalHapticFeedback.current
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -22,7 +22,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Text
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -38,6 +37,7 @@ import androidx.core.transition.doOnEnd
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import com.google.android.material.elevation.SurfaceColors
 import com.google.android.material.transition.platform.MaterialContainerTransform
@@ -96,7 +96,7 @@ import tachiyomi.core.common.util.lang.launchNonCancellable
 import tachiyomi.core.common.util.lang.withUIContext
 import tachiyomi.core.common.util.system.logcat
 import tachiyomi.i18n.MR
-import tachiyomi.presentation.core.util.collectAsState
+import tachiyomi.presentation.core.util.collectAsStateWithLifecycle
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 
@@ -370,8 +370,8 @@ class ReaderActivity : BaseActivity() {
      */
     private fun initializeMenu() {
         pageNumber.setComposeContent {
-            val state by viewModel.state.collectAsState()
-            val showPageNumber by viewModel.readerPreferences.showPageNumber().collectAsState()
+            val state by viewModel.state.collectAsStateWithLifecycle()
+            val showPageNumber by viewModel.readerPreferences.showPageNumber().collectAsStateWithLifecycle()
 
             if (!state.menuVisible && showPageNumber) {
                 PageIndicatorText(
@@ -382,7 +382,7 @@ class ReaderActivity : BaseActivity() {
         }
 
         dialogRoot.setComposeContent {
-            val state by viewModel.state.collectAsState()
+            val state by viewModel.state.collectAsStateWithLifecycle()
             val settingsScreenModel = remember {
                 ReaderSettingsScreenModel(
                     readerState = viewModel.state,
@@ -397,18 +397,18 @@ class ReaderActivity : BaseActivity() {
             }
 
             val isHttpSource = viewModel.getSource() is HttpSource
-            val isFullscreen by readerPreferences.fullscreen().collectAsState()
-            val flashOnPageChange by readerPreferences.flashOnPageChange().collectAsState()
+            val isFullscreen by readerPreferences.fullscreen().collectAsStateWithLifecycle()
+            val flashOnPageChange by readerPreferences.flashOnPageChange().collectAsStateWithLifecycle()
 
-            val colorOverlayEnabled by readerPreferences.colorFilter().collectAsState()
-            val colorOverlay by readerPreferences.colorFilterValue().collectAsState()
-            val colorOverlayMode by readerPreferences.colorFilterMode().collectAsState()
+            val colorOverlayEnabled by readerPreferences.colorFilter().collectAsStateWithLifecycle()
+            val colorOverlay by readerPreferences.colorFilterValue().collectAsStateWithLifecycle()
+            val colorOverlayMode by readerPreferences.colorFilterMode().collectAsStateWithLifecycle()
             val colorOverlayBlendMode = remember(colorOverlayMode) {
                 ReaderPreferences.ColorFilterMode.getOrNull(colorOverlayMode)?.second
             }
 
-            val cropBorderPaged by readerPreferences.cropBorders().collectAsState()
-            val cropBorderWebtoon by readerPreferences.cropBordersWebtoon().collectAsState()
+            val cropBorderPaged by readerPreferences.cropBorders().collectAsStateWithLifecycle()
+            val cropBorderWebtoon by readerPreferences.cropBordersWebtoon().collectAsStateWithLifecycle()
             val isPagerType = ReadingMode.isPagerType(viewModel.getMangaReadingMode())
             val cropEnabled = if (isPagerType) cropBorderPaged else cropBorderWebtoon
 

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/lifecycle/ScopedUiStateCollectionGuardrailTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/lifecycle/ScopedUiStateCollectionGuardrailTest.kt
@@ -123,6 +123,8 @@ class ScopedUiStateCollectionGuardrailTest {
         val TRIPLE_QUOTED_STRING = Regex(""""\"\"\"[\s\S]*?\"\"\""""")
         val EXPLICIT_SCOPED_TARGETS = setOf(
             "app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/PlayerControls.kt",
+            "app/src/main/java/eu/kanade/tachiyomi/ui/player/controls/GestureHandler.kt",
+            "app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt",
         )
     }
 }


### PR DESCRIPTION
## Ticket
- ID: R677
- Priority: P2
- Risk Tier: T1
- GitHub Issue: Closes #758

## Objective
- Make targeted reader/player UI state collection lifecycle-aware so flow-backed collection stops when the screen lifecycle is inactive.

## Scope
- Updated `ReaderActivity.kt` flow/preference-backed Compose state collection to `collectAsStateWithLifecycle()`.
- Updated `GestureHandler.kt` flow/preference-backed Compose state collection to `collectAsStateWithLifecycle()`.
- Added both target files to `ScopedUiStateCollectionGuardrailTest`.
- Added a changelog entry.

## Non-goals
- No whole-app collection migration.
- No player/reader behavior refactor.
- No changes to plain Compose `State<T>` usage.

## Files Changed
- `ReaderActivity.kt`
- `GestureHandler.kt`
- `ScopedUiStateCollectionGuardrailTest.kt`
- `CHANGELOG.md`

## Verification
- Commands run:
  - `./gradlew :app:testStableDebugUnitTest --tests 'eu.kanade.tachiyomi.ui.lifecycle.ScopedUiStateCollectionGuardrailTest'`
  - `./gradlew spotlessCheck`
  - `./gradlew :app:compileStableDebugKotlin`
  - `git diff --check`
- Results:
  - Guardrail test failed before the lifecycle migration when the target files were added.
  - All listed checks pass after the migration.
- Not tested:
  - Manual reader/player UI smoke testing; this ticket only changes collection lifecycle behavior and compile/test coverage passed.

## Risk
- Low. State sources and rendered values are unchanged; only collection is lifecycle-scoped.
- The guardrail now covers the targeted reader/player files against raw flow-backed `collectAsState()` regressions.

## SLO Impact
- Expected slight reduction in unnecessary UI collection work while reader/player screens are inactive.

## Rollback
- Revert this PR to restore raw Compose collection in the targeted files and remove the added guardrail targets.

## Release Notes
- Reader and player gesture UI now use lifecycle-aware flow collection so inactive screens stop collecting targeted state updates.

## Checklist
- [x] Naming conventions followed (use "Rayniyomi" in user-facing text; see [branding guardrail](../docs/branding-guardrail.md))
- [x] Branch rebased on latest main and verification re-run
- [x] New coroutine scopes have documented owner and cancellation path
- [x] No new `runBlocking` on UI/main thread paths

## Definition of Done (DoD)
- [x] Acceptance criteria met and non-goals respected
- [x] Verification matrix completed (Risk Tier: T1)
- [x] Self-review completed
- [ ] Rebased on latest `main` and revalidated (mandatory for merge)
- [ ] Sprint board updated (branch, commit, checks, PR link)
- [x] Release notes drafted (if applicable)

## Fork Compliance Checklist (for new forks only)
If you are creating a new fork of this project, ensure the following:
- [ ] **App Identity**: Changed app name from "Aniyomi" to your fork name
- [ ] **App Icon**: Replaced launcher icon assets with fork-specific icons
- [ ] **Application ID**: Changed `applicationId` in `app/build.gradle.kts` from `xyz.rayniyomi` to your unique ID
- [ ] **Update Checker**: Configured `AppUpdateChecker.kt` to point to your fork's repository
- [ ] **Analytics**: Either disabled Firebase Analytics or configured with your own `google-services.json`
- [ ] **Crash Reporting**: Either disabled ACRA crash reporting or configured with your own endpoint credentials

See [CONTRIBUTING.md](../CONTRIBUTING.md) Forks section for details.
