### PR TITLE
test: add extension loader parity coverage (R682)

### DIFF
--- a/app/src/test/java/eu/kanade/tachiyomi/extension/anime/util/AnimeExtensionLoaderTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/extension/anime/util/AnimeExtensionLoaderTest.kt
@@ -54,7 +54,7 @@ class AnimeExtensionLoaderTest {
     }
 
     @Test
-    fun `findInvalidSource returns null when all source ids are readable`() {
+    fun `findInvalidSource returns null when all source metadata is readable`() {
         val good = mockk<AnimeSource>()
 
         every { good.id } returns 1L
@@ -62,5 +62,25 @@ class AnimeExtensionLoaderTest {
         every { good.name } returns "good"
 
         AnimeExtensionLoader.findInvalidSource(listOf(good)) shouldBe null
+    }
+
+    @Test
+    fun `findInvalidSource returns null for an empty source list`() {
+        AnimeExtensionLoader.findInvalidSource(emptyList()) shouldBe null
+    }
+
+    @Test
+    fun `findInvalidSource returns first invalid source when multiple sources are invalid`() {
+        val first = mockk<AnimeSource>()
+        val second = mockk<AnimeSource>()
+
+        every { first.id } throws IllegalStateException("first")
+        every { first.lang } returns "en"
+        every { first.name } returns "first"
+        every { second.id } throws IllegalStateException("second")
+        every { second.lang } returns "en"
+        every { second.name } returns "second"
+
+        AnimeExtensionLoader.findInvalidSource(listOf(first, second)) shouldBe first
     }
 }

--- a/app/src/test/java/eu/kanade/tachiyomi/extension/manga/util/MangaExtensionLoaderTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/extension/manga/util/MangaExtensionLoaderTest.kt
@@ -54,7 +54,7 @@ class MangaExtensionLoaderTest {
     }
 
     @Test
-    fun `findInvalidSource returns null when all source ids are readable`() {
+    fun `findInvalidSource returns null when all source metadata is readable`() {
         val good = mockk<MangaSource>()
 
         every { good.id } returns 1L
@@ -62,5 +62,25 @@ class MangaExtensionLoaderTest {
         every { good.name } returns "good"
 
         MangaExtensionLoader.findInvalidSource(listOf(good)) shouldBe null
+    }
+
+    @Test
+    fun `findInvalidSource returns null for an empty source list`() {
+        MangaExtensionLoader.findInvalidSource(emptyList()) shouldBe null
+    }
+
+    @Test
+    fun `findInvalidSource returns first invalid source when multiple sources are invalid`() {
+        val first = mockk<MangaSource>()
+        val second = mockk<MangaSource>()
+
+        every { first.id } throws IllegalStateException("first")
+        every { first.lang } returns "en"
+        every { first.name } returns "first"
+        every { second.id } throws IllegalStateException("second")
+        every { second.lang } returns "en"
+        every { second.name } returns "second"
+
+        MangaExtensionLoader.findInvalidSource(listOf(first, second)) shouldBe first
     }
 }


### PR DESCRIPTION
## Ticket
- ID: R682
- Priority: P2
- Risk Tier: T1
- GitHub Issue: Closes #763

## Objective
- Add conservative parity coverage for anime and manga extension loader invalid-source handling without changing production loader behavior.

## Scope
- Adds mirrored behavior tests for `AnimeExtensionLoader.findInvalidSource` and `MangaExtensionLoader.findInvalidSource`.
- Covers empty source lists and returning the first invalid source when multiple sources fail metadata access.
- Keeps the ticket scoped to loader-policy tests only.

## Non-goals
- No shared loader refactor.
- No installer flow matrix.
- No Android DownloadManager coverage.
- No light novel plugin changes.
- No production behavior changes.

## Files Changed
- `app/src/test/java/eu/kanade/tachiyomi/extension/anime/util/AnimeExtensionLoaderTest.kt`
- `app/src/test/java/eu/kanade/tachiyomi/extension/manga/util/MangaExtensionLoaderTest.kt`

## Verification
- Commands run:
  - `./gradlew :app:testStableDebugUnitTest --tests "eu.kanade.tachiyomi.extension.anime.util.AnimeExtensionLoaderTest" --tests "eu.kanade.tachiyomi.extension.manga.util.MangaExtensionLoaderTest"`
  - `git diff --check`
  - `./gradlew spotlessCheck`
  - `./gradlew :app:compileStableDebugKotlin`
- Results:
  - Focused anime/manga extension loader tests passed.
  - Whitespace diff check passed.
  - Spotless passed.
  - Stable debug Kotlin compile passed.
  - Pre-push hook reran `spotlessCheck` and `:app:compileStableDebugKotlin`; both passed.
- Not tested:
  - `:app:compileDebugKotlin` was not run because this repo treats it as ambiguous; `:app:compileStableDebugKotlin` is the compile gate.

## Risk
- Low risk. This is test-only and does not change runtime code.
- Regression mitigation is the mirrored coverage keeping anime and manga loader policy expectations explicit.

## SLO Impact
- None. No runtime code changed.

## Rollback
- Revert the test-only commit if the narrowed coverage needs to be replaced.

## Release Notes
- No changelog entry. This is test-only and has no user-facing, CI/process-visible, or requested release-note impact.

## Checklist
- [x] Naming conventions followed (use "Rayniyomi" in user-facing text; see [branding guardrail](../docs/branding-guardrail.md))
- [x] Branch rebased on latest main and verification re-run
- [x] New coroutine scopes have documented owner and cancellation path
- [x] No new `runBlocking` on UI/main thread paths

## Definition of Done (DoD)
- [x] Acceptance criteria met and non-goals respected
- [x] Verification matrix completed (Risk Tier: T1)
- [x] Self-review completed
- [x] Rebased on latest `main` and revalidated (mandatory for merge)
- [ ] Sprint board updated (branch, commit, checks, PR link)
- [x] Release notes drafted (if applicable)

## Fork Compliance Checklist (for new forks only)
If you are creating a new fork of this project, ensure the following:
- [ ] **App Identity**: Changed app name from "Aniyomi" to your fork name
- [ ] **App Icon**: Replaced launcher icon assets with fork-specific icons
- [ ] **Application ID**: Changed `applicationId` in `app/build.gradle.kts` from `xyz.rayniyomi` to your unique ID
- [ ] **Update Checker**: Configured `AppUpdateChecker.kt` to point to your fork's repository
- [ ] **Analytics**: Either disabled Firebase Analytics or configured with your own `google-services.json`
- [ ] **Crash Reporting**: Either configured ACRA crash reporting or configured with your own endpoint credentials
