### PR TITLE
fix: cancel stale reader config collectors (R676)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 - Discover and entry-enrichment Compose screen state now uses explicit stability annotations, and discover feed items are stored as immutable collections at the UI-state boundary to reduce avoidable recompositions.
 
 ### Fixed
+- Reader config reinitialization now cancels stale preference collectors before replacing the active manager.
 - Reader and player gesture UI now use lifecycle-aware flow collection so inactive screens stop collecting targeted state updates.
 - Translation provider API keys now migrate from plaintext preferences into encrypted secure preferences while preserving existing empty-key behavior.
 - Invalid extension trust-revoked dialogs now show the failure reason, package, version, signature prefix, debug detail, and recovery guidance.

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderConfigManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderConfigManager.kt
@@ -12,6 +12,8 @@ import eu.kanade.tachiyomi.data.coil.TachiyomiImageDecoder
 import eu.kanade.tachiyomi.ui.reader.setting.ReaderPreferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -35,9 +37,13 @@ import logcat.logcat
 class ReaderConfigManager(
     private val readerPreferences: ReaderPreferences,
     private val basePreferences: BasePreferences,
-    private val scope: CoroutineScope,
+    scope: CoroutineScope,
     private val isNightMode: Boolean,
+    private val displayProfileLoader: suspend (String) -> ByteArray? = ::loadDisplayProfile,
 ) {
+    private val managerJob = SupervisorJob(scope.coroutineContext[Job])
+    private val managerScope = CoroutineScope(scope.coroutineContext + managerJob)
+
     private val _backgroundColor = MutableStateFlow(Color.BLACK)
     val backgroundColor: StateFlow<Int> = _backgroundColor.asStateFlow()
 
@@ -110,7 +116,7 @@ class ReaderConfigManager(
                     }
                 }
             }
-            .launchIn(scope)
+            .launchIn(managerScope)
     }
 
     private fun getGrayBackgroundColor(): Int {
@@ -122,7 +128,7 @@ class ReaderConfigManager(
             .onStart { emit(basePreferences.displayProfile().get()) }
             .onEach { path ->
                 val profile = withContext(Dispatchers.IO) {
-                    loadDisplayProfile(path)
+                    displayProfileLoader(path)
                 }
                 _displayProfile.update { profile }
                 profile?.let {
@@ -130,7 +136,7 @@ class ReaderConfigManager(
                     TachiyomiImageDecoder.displayProfile = it
                 }
             }
-            .launchIn(scope)
+            .launchIn(managerScope)
     }
 
     private fun observeCutoutShort() {
@@ -139,7 +145,7 @@ class ReaderConfigManager(
             .onEach { enabled ->
                 _cutoutShort.update { enabled }
             }
-            .launchIn(scope)
+            .launchIn(managerScope)
     }
 
     private fun observeKeepScreenOn() {
@@ -148,7 +154,7 @@ class ReaderConfigManager(
             .onEach { enabled ->
                 _keepScreenOn.update { enabled }
             }
-            .launchIn(scope)
+            .launchIn(managerScope)
     }
 
     private fun observeCustomBrightness() {
@@ -160,7 +166,7 @@ class ReaderConfigManager(
                     _customBrightnessValue.update { 0 }
                 }
             }
-            .launchIn(scope)
+            .launchIn(managerScope)
 
         readerPreferences.customBrightnessValue().changes()
             .onStart { emit(readerPreferences.customBrightnessValue().get()) }
@@ -169,7 +175,7 @@ class ReaderConfigManager(
                     _customBrightnessValue.update { value }
                 }
             }
-            .launchIn(scope)
+            .launchIn(managerScope)
     }
 
     private fun observeColorFilters() {
@@ -188,7 +194,7 @@ class ReaderConfigManager(
                     }
                 }
             }
-            .launchIn(scope)
+            .launchIn(managerScope)
     }
 
     private fun observeFullscreen() {
@@ -197,7 +203,7 @@ class ReaderConfigManager(
             .onEach { enabled ->
                 _fullscreen.update { enabled }
             }
-            .launchIn(scope)
+            .launchIn(managerScope)
     }
 
     private fun automaticBackgroundColor(): Int {
@@ -208,16 +214,8 @@ class ReaderConfigManager(
         }
     }
 
-    private fun loadDisplayProfile(path: String): ByteArray? {
-        val file = UniFile.fromUri(null, path.toUri()) ?: return null
-        if (!file.exists()) return null
-
-        return try {
-            file.openInputStream().use { it.readBytes() }
-        } catch (e: Exception) {
-            logcat(LogPriority.ERROR) { "Failed to load display profile from $path: ${e.message}" }
-            null
-        }
+    fun close() {
+        managerJob.cancel()
     }
 
     private fun getCombinedPaint(grayscale: Boolean, invertedColors: Boolean): Paint {
@@ -249,4 +247,16 @@ class ReaderConfigManager(
      * Delegates to companion object for testability.
      */
     fun calculateReaderBrightness(value: Int): Float = calculateBrightness(value)
+}
+
+private fun loadDisplayProfile(path: String): ByteArray? {
+    val file = UniFile.fromUri(null, path.toUri()) ?: return null
+    if (!file.exists()) return null
+
+    return try {
+        file.openInputStream().use { it.readBytes() }
+    } catch (e: Exception) {
+        logcat("ReaderConfigManager", LogPriority.ERROR) { "Failed to load display profile from $path: ${e.message}" }
+        null
+    }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderViewModel.kt
@@ -194,6 +194,7 @@ class ReaderViewModel @JvmOverloads constructor(
      * Safe to call multiple times (e.g., on configuration changes).
      */
     fun initReaderConfig(isNightMode: Boolean) {
+        _readerConfig?.close()
         _readerConfig = ReaderConfigManager(
             readerPreferences = readerPreferences,
             basePreferences = basePreferences,
@@ -203,6 +204,9 @@ class ReaderViewModel @JvmOverloads constructor(
     }
 
     override fun onCleared() {
+        _readerConfig?.close()
+        _readerConfig = null
+
         val currentChapters = state.value.viewerChapters
         if (currentChapters != null) {
             currentChapters.unref()

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/reader/ReaderConfigManagerTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/reader/ReaderConfigManagerTest.kt
@@ -1,7 +1,18 @@
 package eu.kanade.tachiyomi.ui.reader
 
+import eu.kanade.domain.base.BasePreferences
+import eu.kanade.tachiyomi.ui.reader.setting.ReaderPreferences
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import tachiyomi.core.common.preference.Preference
 
 /**
  * Tests for ReaderConfigManager that don't require Android framework.
@@ -10,6 +21,37 @@ import org.junit.jupiter.api.Test
  * WindowManager, Uri). Only pure calculation logic can be tested here.
  */
 class ReaderConfigManagerTest {
+
+    @Test
+    fun `close stops preference collectors without cancelling parent scope`() = runTest {
+        val readerPreferences = mockk<ReaderPreferences>()
+        val basePreferences = mockk<BasePreferences>()
+        val keepScreenOnPreference = FakePreference(true)
+
+        stubReaderConfigPreferences(
+            readerPreferences = readerPreferences,
+            basePreferences = basePreferences,
+            keepScreenOnPreference = keepScreenOnPreference,
+        )
+
+        val manager = ReaderConfigManager(
+            readerPreferences = readerPreferences,
+            basePreferences = basePreferences,
+            scope = this,
+            isNightMode = false,
+            displayProfileLoader = { null },
+        )
+        advanceUntilIdle()
+
+        assertEquals(true, manager.keepScreenOn.value)
+
+        manager.close()
+        keepScreenOnPreference.set(false)
+        advanceUntilIdle()
+
+        assertEquals(true, manager.keepScreenOn.value)
+        assertEquals(true, coroutineContext[kotlinx.coroutines.Job]?.isActive)
+    }
 
     @Test
     fun `calculateBrightness returns percentage for positive values`() {
@@ -41,5 +83,45 @@ class ReaderConfigManagerTest {
         assertEquals(1.0f, ReaderConfigManager.calculateBrightness(100))
         // Below minimum (still returns minimum)
         assertEquals(0.01f, ReaderConfigManager.calculateBrightness(-100))
+    }
+
+    private fun stubReaderConfigPreferences(
+        readerPreferences: ReaderPreferences,
+        basePreferences: BasePreferences,
+        keepScreenOnPreference: Preference<Boolean> = FakePreference(true),
+    ) {
+        every { readerPreferences.readerTheme() } returns FakePreference(1)
+        every { basePreferences.displayProfile() } returns FakePreference("")
+        every { readerPreferences.cutoutShort() } returns FakePreference(true)
+        every { readerPreferences.keepScreenOn() } returns keepScreenOnPreference
+        every { readerPreferences.customBrightness() } returns FakePreference(false)
+        every { readerPreferences.customBrightnessValue() } returns FakePreference(0)
+        every { readerPreferences.grayscale() } returns FakePreference(false)
+        every { readerPreferences.invertedColors() } returns FakePreference(false)
+        every { readerPreferences.fullscreen() } returns FakePreference(true)
+    }
+
+    private class FakePreference<T>(
+        initialValue: T,
+    ) : Preference<T> {
+        private val state = MutableStateFlow(initialValue)
+
+        override fun key(): String = "fake"
+
+        override fun get(): T = state.value
+
+        override fun set(value: T) {
+            state.value = value
+        }
+
+        override fun isSet(): Boolean = true
+
+        override fun delete() = error("Not needed for this test")
+
+        override fun defaultValue(): T = state.value
+
+        override fun changes(): Flow<T> = state.asStateFlow()
+
+        override fun stateIn(scope: kotlinx.coroutines.CoroutineScope): StateFlow<T> = state
     }
 }


### PR DESCRIPTION
## Ticket
- ID: R676
- Priority: P2
- Risk Tier: T2
- GitHub Issue: Closes #757

## Objective
- Stop repeated reader config initialization from leaving old preference collectors alive in `viewModelScope`.

## Scope
- Give `ReaderConfigManager` its own child `SupervisorJob` and manager-owned coroutine scope.
- Route reader config preference collectors through that manager-owned scope.
- Close the existing manager before `ReaderViewModel.initReaderConfig()` replaces it, and close it from `onCleared()`.
- Add focused coroutine coverage proving `close()` stops a preference collector without cancelling the parent scope.
- Add a changelog entry for the reader reliability fix.

## Non-goals
- No changes to reader UI behavior, preference semantics, source loading, or chapter loading.
- No broad reader lifecycle refactors.

## Files Changed
- `ReaderConfigManager.kt`: manager-owned collector scope and `close()` lifecycle API.
- `ReaderViewModel.kt`: closes old config manager on reinit and cleanup.
- `ReaderConfigManagerTest.kt`: coroutine lifecycle regression coverage.
- `CHANGELOG.md`: fixed entry.

## Verification
- Commands run:
  - `git diff --check`
  - `./gradlew :app:testStableDebugUnitTest --tests 'eu.kanade.tachiyomi.ui.reader.ReaderConfigManagerTest'`
  - `./gradlew :app:testStableDebugUnitTest --tests 'eu.kanade.tachiyomi.ui.reader.*'`
  - `./gradlew spotlessCheck`
  - `./gradlew :app:compileStableDebugKotlin`
  - Post-rebase: `./gradlew :app:testStableDebugUnitTest --tests 'eu.kanade.tachiyomi.ui.reader.*'`
  - Post-rebase: `./gradlew spotlessCheck && ./gradlew :app:compileStableDebugKotlin`
  - Pre-push hook reran `spotlessCheck` and `:app:compileStableDebugKotlin` successfully.
- Results:
  - All commands passed.
  - Independent review: PASS, no blocking findings.
- Not tested:
  - No emulator/manual reader session; this change is covered at the coroutine collector lifecycle boundary.

## Risk
- Risk: closing the manager could accidentally cancel `viewModelScope`.
- Mitigation: `ReaderConfigManager` uses a child `SupervisorJob`; the new test proves parent scope remains active after `close()`.
- Risk: first initialization behavior could change.
- Mitigation: first init still no-ops the nullable close and builds the manager with the same parent `viewModelScope`.

## SLO Impact
- Expected positive reliability impact: avoids duplicate stale reader preference collectors after repeated config initialization.
- No expected startup, sync, or network SLO impact.

## Rollback
- Revert this PR to restore the previous direct `viewModelScope` collector behavior.

## Release Notes
- Reader config reinitialization now cancels stale preference collectors before replacing the active manager.

## Checklist
- [x] Naming conventions followed (use "Rayniyomi" in user-facing text; see [branding guardrail](../docs/branding-guardrail.md))
- [x] Branch rebased on latest main and verification re-run
- [x] New coroutine scopes have documented owner and cancellation path
- [x] No new `runBlocking` on UI/main thread paths

## Definition of Done (DoD)
- [x] Acceptance criteria met and non-goals respected
- [x] Verification matrix completed (Risk Tier: T2)
- [x] Self-review completed
- [x] Rebased on latest `main` and revalidated (mandatory for merge)
- [ ] Sprint board updated (branch, commit, checks, PR link)
- [x] Release notes drafted (if applicable)

## Fork Compliance Checklist (for new forks only)
N/A - not a new fork.