### PR TITLE
fix: route player startup errors locally (R679)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is a modified version of [Keep a Changelog](https://keepachangelog.co
 
 ### Fixed
 - Reader config reinitialization now cancels stale preference collectors before replacing the active manager.
+- Player startup errors now use the local player failure path instead of replacing process-wide crash handling while the player screen is open.
 - Reader and player gesture UI now use lifecycle-aware flow collection so inactive screens stop collecting targeted state updates.
 - Translation provider API keys now migrate from plaintext preferences into encrypted secure preferences while preserving existing empty-key behavior.
 - Invalid extension trust-revoked dialogs now show the failure reason, package, version, signature prefix, debug detail, and recovery guidance.

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt
@@ -78,6 +78,7 @@ import eu.kanade.tachiyomi.util.system.powerManager
 import eu.kanade.tachiyomi.util.system.toShareIntent
 import eu.kanade.tachiyomi.util.system.toast
 import `is`.xyz.mpv.MPVLib
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
@@ -105,7 +106,6 @@ class PlayerActivity : BaseActivity() {
     val windowInsetsController by lazy { WindowCompat.getInsetsController(window, window.decorView) }
     val audioManager by lazy { getSystemService(Context.AUDIO_SERVICE) as AudioManager }
 
-    private var previousUncaughtExceptionHandler: Thread.UncaughtExceptionHandler? = null
     private var mediaSession: MediaSession? = null
     private val gesturePreferences: GesturePreferences by lazy { viewModel.gesturePreferences }
     private val playerPreferences: PlayerPreferences by lazy { viewModel.playerPreferences }
@@ -297,15 +297,6 @@ class PlayerActivity : BaseActivity() {
             }
         }
 
-        previousUncaughtExceptionHandler = Thread.getDefaultUncaughtExceptionHandler()
-        Thread.setDefaultUncaughtExceptionHandler { _, throwable ->
-            runOnUiThread {
-                toast(throwable.message)
-            }
-            logcat(LogPriority.ERROR, throwable)
-            finish()
-        }
-
         viewModel.eventFlow
             .onEach { event ->
                 when (event) {
@@ -326,12 +317,6 @@ class PlayerActivity : BaseActivity() {
     }
 
     override fun onDestroy() {
-        // Restore global handler FIRST to prevent leak if cleanup throws
-        previousUncaughtExceptionHandler?.let {
-            Thread.setDefaultUncaughtExceptionHandler(it)
-        }
-        previousUncaughtExceptionHandler = null
-
         player.isExiting = true
 
         audioFocusRequest?.let {
@@ -446,23 +431,31 @@ class PlayerActivity : BaseActivity() {
         val logLevel = if (networkPreferences.verboseLogging().get()) "info" else "warn"
 
         lifecycleScope.launchIO {
-            val configDir = mpvInitializer.initialize(
-                mpvConf = advancedPlayerPreferences.mpvConf().get(),
-                mpvInput = advancedPlayerPreferences.mpvInput().get(),
-                mpvUserFilesEnabled = advancedPlayerPreferences.mpvUserFiles().get(),
-            )
-
-            withUIContext {
-                MPVLib.setOptionString("sub-ass-force-margins", "yes")
-                MPVLib.setOptionString("sub-use-margins", "yes")
-
-                player.initialize(
-                    configDir = configDir,
-                    cacheDir = applicationContext.cacheDir.path,
-                    logLvl = logLevel,
+            try {
+                val configDir = mpvInitializer.initialize(
+                    mpvConf = advancedPlayerPreferences.mpvConf().get(),
+                    mpvInput = advancedPlayerPreferences.mpvInput().get(),
+                    mpvUserFilesEnabled = advancedPlayerPreferences.mpvUserFiles().get(),
                 )
-                MPVLib.addLogObserver(playerObserver)
-                MPVLib.addObserver(playerObserver)
+
+                withUIContext {
+                    MPVLib.setOptionString("sub-ass-force-margins", "yes")
+                    MPVLib.setOptionString("sub-use-margins", "yes")
+
+                    player.initialize(
+                        configDir = configDir,
+                        cacheDir = applicationContext.cacheDir.path,
+                        logLvl = logLevel,
+                    )
+                    MPVLib.addLogObserver(playerObserver)
+                    MPVLib.addObserver(playerObserver)
+                }
+            } catch (error: CancellationException) {
+                throw error
+            } catch (error: Exception) {
+                withUIContext {
+                    setInitialEpisodeError(error)
+                }
             }
         }
     }

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/player/PlayerActivityHostInitOrderTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/player/PlayerActivityHostInitOrderTest.kt
@@ -41,6 +41,32 @@ class PlayerActivityHostInitOrderTest {
         )
     }
 
+    @Test
+    fun `player activity does not replace the process uncaught exception handler`() {
+        val source = loadPlayerActivitySource()
+
+        assertTrue(
+            !source.contains("Thread.setDefaultUncaughtExceptionHandler"),
+            "PlayerActivity must not replace process-wide crash handling",
+        )
+        assertTrue(
+            !source.contains("Thread.getDefaultUncaughtExceptionHandler"),
+            "PlayerActivity must not read process-wide crash handling",
+        )
+    }
+
+    @Test
+    fun `mpv setup failures route through the local initial episode error path`() {
+        val source = loadPlayerActivitySource()
+        val setupMpvIdx = source.indexOf("private fun setupPlayerMPV()")
+        val catchIdx = source.indexOf("catch (error: Exception)", startIndex = setupMpvIdx)
+        val errorPathIdx = source.indexOf("setInitialEpisodeError(error)", startIndex = catchIdx)
+
+        assertTrue(setupMpvIdx >= 0, "Expected setupPlayerMPV to exist")
+        assertTrue(catchIdx > setupMpvIdx, "Expected setupPlayerMPV to catch startup failures locally")
+        assertTrue(errorPathIdx > catchIdx, "Expected MPV startup failures to use setInitialEpisodeError")
+    }
+
     private fun loadPlayerActivitySource(): String {
         val moduleRelative = Paths.get(
             "src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt",


### PR DESCRIPTION
## Objective
Route player startup failures through PlayerActivity's local error UI instead of replacing the process-wide uncaught exception handler while the player screen is open.

Closes #760

## Scope
- Removed PlayerActivity's default uncaught exception handler replacement and restore logic.
- Wrapped MPV startup initialization in the existing local player failure path.
- Preserved coroutine cancellation by rethrowing CancellationException.
- Preserved fatal Error propagation by catching Exception rather than Throwable.
- Added focused regression coverage for the removed global handler and local startup error routing.
- Added an Unreleased > Fixed changelog entry.

Out of scope: PlayerViewModel, repositories, UI redesign, light novel/plugin code, and unrelated player behavior.

## Verification
- ./gradlew :app:testStableDebugUnitTest --tests "eu.kanade.tachiyomi.ui.player.PlayerActivityHostInitOrderTest"
- ./gradlew :app:testStableDebugUnitTest --tests "eu.kanade.tachiyomi.ui.player.*" --tests "eu.kanade.tachiyomi.ui.player.cast.*" --tests "eu.kanade.tachiyomi.ui.player.loader.*" --tests "eu.kanade.tachiyomi.ui.player.controls.*" --tests "eu.kanade.tachiyomi.ui.player.settings.*" --tests "eu.kanade.tachiyomi.ui.player.utils.*"
- ./gradlew spotlessCheck
- ./gradlew :app:compileStableDebugKotlin
- git diff --check
- rg -n "catch \\(error: Throwable\\)|setDefaultUncaughtExceptionHandler|getDefaultUncaughtExceptionHandler|previousUncaughtExceptionHandler" app/src/main/java/eu/kanade/tachiyomi/ui/player/PlayerActivity.kt app/src/test/java/eu/kanade/tachiyomi/ui/player/PlayerActivityHostInitOrderTest.kt

Manual emulator smoke was not run; this was covered with focused unit/source regression checks and compile gates.

## Risk
Risk Tier: T2. This changes Android player startup error handling, but keeps the change localized to PlayerActivity startup wiring. The main regression risk is startup exceptions no longer reaching the local player error UI; the focused regression test checks that MPV setup failures still route to setInitialEpisodeError. Normal process crash reporting is lower risk because the process-wide handler replacement is removed and fatal Error subclasses are not caught by the new local handler.

## Review
Independent agent review was saved locally at .local/review-notes/r679-independent-review.md before findings were addressed. No blocking findings; the non-blocking catch-width concern was addressed by catching Exception instead of Throwable.